### PR TITLE
[FIX] opt fc1/fc2 layer modules should not be quantized

### DIFF
--- a/gptqmodel/models/opt.py
+++ b/gptqmodel/models/opt.py
@@ -15,6 +15,6 @@ class OPTGPTQ(BaseGPTQModel):
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
         ["self_attn.out_proj"],
-        ["fc1"],
-        ["fc2"],
+        # ["fc1"], disabled: not a good candidate for quantization
+        # ["fc2"], disabled: not a good candidate for quantization
     ]


### PR DESCRIPTION
Resolves https://github.com/ModelCloud/GPTQModel/issues/117

For OPT model, the fc1/fc2 layer modules are horrible/in-compatible with current quant calibration resulting in massive losses for every single layer.  Solution is to disable/skip these 2 modules.