### PR TITLE
[Fix] Export TORCH_CUDA_ARCH_LIST in install.sh

### DIFF
--- a/gptqmodel/nn_modules/qlinear/bitblas_target_detector.py
+++ b/gptqmodel/nn_modules/qlinear/bitblas_target_detector.py
@@ -37,7 +37,7 @@ def get_gpu_model_from_nvidia_smi(gpu_id: int = 0):
 
     # for multiple cpus, CUDA_DEVICE_ORDER=PCI_BUS_ID must be set to match nvidia-smi or else gpu_id is
     # most likely incorrect and the wrong gpu
-    if len(gpus) > 0 and os.environ.get("CUDA_DEVICE_ORDER") != "PCI_BUS_ID":
+    if len(gpus) > 1 and os.environ.get("CUDA_DEVICE_ORDER") != "PCI_BUS_ID":
         raise EnvironmentError("Multi-gpu environment must set `CUDA_DEVICE_ORDER=PCI_BUS_ID`.")
 
     if gpu_id >= len(gpus) or gpu_id < 0:

--- a/gptqmodel/nn_modules/qlinear/qlinear_bitblas.py
+++ b/gptqmodel/nn_modules/qlinear/qlinear_bitblas.py
@@ -42,7 +42,7 @@ def import_bitblas():
 
         bitblas.auto_detect_nvidia_target = patched_auto_detect_nvidia_target
         BITBLAS_TARGET = bitblas.auto_detect_nvidia_target(int(os.environ.get("CUDA_VISIBLE_DEVICES", "0")))
-        logger.info("BITBLAS_TARGET", BITBLAS_TARGET)
+        logger.info(f"BITBLAS_TARGET {BITBLAS_TARGET}")
 
     if BITBLAS_DATABASE_PATH is None:
         from bitblas.cache import get_database_path

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0 7.5 8.0 8.6 8.9 9.0+PTX"
+export TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0 7.5 8.0 8.6 8.9 9.0"
 INSTALL_COMMAND="pip install -vvv --no-build-isolation ."
 
 check_uv_version() {

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+export TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0 7.5 8.0 8.6 8.9 9.0+PTX"
 INSTALL_COMMAND="pip install -vvv --no-build-isolation ."
 
 check_uv_version() {

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ threadpoolctl>=3.5.0
 packaging>=24.1
 ninja>=1.11.1.1
 bitblas>=0.0.1.dev12
-importlib>=1.0.4


### PR DESCRIPTION
This pull request includes a change to the `install.sh` script to export the `TORCH_CUDA_ARCH_LIST`  variables in install.sh scripts. Otherwise, the build pipeline of cuda backend will crash.

Also remove `importlib` from requirements.txt ref to #132 