### PR TITLE
Revert "fix opt fc1/fc2 layer modules should not be quantized (#118)"

### DIFF
--- a/gptqmodel/models/opt.py
+++ b/gptqmodel/models/opt.py
@@ -15,6 +15,6 @@ class OPTGPTQ(BaseGPTQModel):
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
         ["self_attn.out_proj"],
-        # ["fc1"], disabled: not a good candidate for quantization
-        # ["fc2"], disabled: not a good candidate for quantization
+        ["fc1"],
+        ["fc2"],
     ]


### PR DESCRIPTION
This reverts commit c9a0688809238543b221654c2f0f9385d0e521a7.

Even though PPL improved fc1/fc2 omission there were too many inference incompatibility to warrant this change. 