### PR TITLE
increase log precision in avg_loss and decrease for time taken

### DIFF
--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -480,8 +480,8 @@ class BaseGPTQModel(nn.Module):
                             static_groups=self.quantize_config.static_groups,
                         )
 
-                        stat = {"layer": i + 1, "module": name, "avg_loss": f"{avg_loss:.4f}",
-                                "time": f"{duration:.4f}"}
+                        stat = {"layer": i + 1, "module": name, "avg_loss": f"{avg_loss:.5f}",
+                                "time": f"{duration:.3f}"}
 
                         quant_log.append(stat)
                         logger.info(stat)


### PR DESCRIPTION
Need higher precision in avg_loss logs due to some modules showing `0.0000` during quants. Reduce the precison for time logs since humans don't need/care for sub-ms timings. 