### PR TITLE
revert prefix-less regex matching

### DIFF
--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -322,7 +322,6 @@ class BaseGPTQModel(nn.Module):
                 desc_act=self.quantize_config.desc_act,
                 force_layer_back_to_cpu=True,
                 format=self.quantize_config.format,
-                prefix=self.layers_node,
             )
 
             self.model = model
@@ -437,7 +436,7 @@ class BaseGPTQModel(nn.Module):
                 for name in subset:
                     bits = self.quantize_config.bits
                     if self.quantize_config.dynamic_bits is not None:
-                        key = f"{i}.{name}"
+                        key = f"{self.layers_node}.{i}.{name}"
                         for pattern, d_bits in self.quantize_config.dynamic_bits.items():
                             if re.match(pattern, key):
                                 bits = d_bits
@@ -561,7 +560,6 @@ class BaseGPTQModel(nn.Module):
             force_layer_back_to_cpu=force_layer_back_to_cpu,
             format=self.quantize_config.format,
             dynamic_bits=self.quantize_config.dynamic_bits,
-            prefix=self.layers_node,
         )
 
         if device_map:
@@ -829,7 +827,6 @@ class BaseGPTQModel(nn.Module):
                 format=quantize_config.format,
                 desc_act=quantize_config.desc_act,
                 pack=True,
-                prefix=self.layers_node,
             )
             model.tie_weights()
 
@@ -1183,7 +1180,6 @@ class BaseGPTQModel(nn.Module):
                 format=quantize_config.format,
                 desc_act=quantize_config.desc_act,
                 dynamic_bits=quantize_config.dynamic_bits,
-                prefix=cls.layers_node,
             )
             if preload_qlinear_kernel == QBitsQuantLinear:
                 quantize_config.runtime_format = FORMAT.QBITS

--- a/tests/test_quant_batch.py
+++ b/tests/test_quant_batch.py
@@ -48,7 +48,6 @@ class TestQuantBatch(unittest.TestCase):
         quantize_config = QuantizeConfig(
             bits=4,
             group_size=128,
-            format=FORMAT.GPTQ,
         )
 
         model = GPTQModel.from_pretrained(
@@ -67,7 +66,6 @@ class TestQuantBatch(unittest.TestCase):
 
             model = GPTQModel.from_quantized(
                 tmp_dir,
-                device_map="auto",
             )
 
             batch_size_1_ppl = self.calculate_avg_ppl(model, self.tokenizer)
@@ -77,8 +75,7 @@ class TestQuantBatch(unittest.TestCase):
             quantize_config=quantize_config,
         )
 
-        model.quantize(self.calibration_dataset, batch_size=256)
-
+        model.quantize(self.calibration_dataset, batch_size=4)
         with tempfile.TemporaryDirectory() as tmp_dir:
             model.save_quantized(
                 tmp_dir,
@@ -88,32 +85,32 @@ class TestQuantBatch(unittest.TestCase):
 
             model = GPTQModel.from_quantized(
                 tmp_dir,
-                device_map="auto",
             )
 
             batch_size_256_ppl = self.calculate_avg_ppl(model, self.tokenizer)
 
+            del model
+
         assert abs(batch_size_1_ppl - batch_size_256_ppl) < 0.1
 
     def test_dynamic_bits(self):
-        # layer starting point of 0
         dynamic_bits = {
-            r"^18\..*gate.*": 8,
-            r"^19\..*gate.*": 8,
-            r"^20\..*gate.*": 8,
-            r"^21\..*gate.*": 8,
+            # `.*\.` matches the layers_node prefix
+            r".*\.18\..*gate.*": 8, # match layer 18 (index start at 0) gate module
+            r".*\.19\..*gate.*": 8, # match layer 19 (index start at 0) gate module
+            r".*\.20\..*gate.*": 8, # match layer 21 (index start at 0) gate module
+            r".*\.21\..*gate.*": 8, # match layer 22 (index start at 0) gate module
         }
         quantize_config = QuantizeConfig(
             bits=4,
             dynamic_bits=dynamic_bits,
             group_size=128,
-            format=FORMAT.GPTQ,
         )
         model = GPTQModel.from_pretrained(
             self.NATIVE_MODEL_ID,
             quantize_config=quantize_config,
         )
-        model.quantize(self.calibration_dataset, batch_size=256)
+        model.quantize(self.calibration_dataset, batch_size=4)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             model.save_quantized(
@@ -124,9 +121,10 @@ class TestQuantBatch(unittest.TestCase):
 
             model = GPTQModel.from_quantized(
                 tmp_dir,
-                device_map="auto",
                 backend=BACKEND.TRITON,
             )
 
             dynamic_bits_ppl = self.calculate_avg_ppl(model, self.tokenizer)
+
+            del model
             assert dynamic_bits_ppl < 10


### PR DESCRIPTION
Prefix-less (without `layers_node` prefix) regex matching makes life easier for users but becomes a headache for vllm/sgalng. Remove for now.