### PR TITLE
fix check pkg bug

### DIFF
--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os.path
+import torch
 from os.path import isdir, join
 from typing import Dict, List, Optional, Union
 
@@ -203,6 +204,11 @@ class GPTQModel:
         verify_hash: Optional[Union[str, List[str]]] = None,
         **kwargs,
     ) -> BaseGPTQModel:
+
+        if backend == BACKEND.AUTO and not torch.cuda.is_available():
+            logger.warning("No cuda fuond, use ipex backend")
+            backend = BACKEND.IPEX
+
         model_type = check_and_get_model_type(model_id_or_path, trust_remote_code)
         quant_func = MODEL_MAP[model_type].from_quantized
 

--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -196,23 +196,23 @@ def ModelLoader(cls):
                 f"{model_id_or_path} requires trust_remote_code=True. Please set trust_remote_code=True to load this model."
             )
 
-        if cls.require_transformers_version:
+        if cls.require_pkgs_version:
             from transformers import __version__ as transformers_version
-            passed = check_requires_version(cls.require_transformers_version, current_version=transformers_version)
+            passed = check_requires_version(cls.require_pkgs_version, current_version=transformers_version)
             if passed is not None:
                 if not passed:
-                    raise ValueError(f"{model_id_or_path} requires transformers version {cls.require_transformers_version} current transformers version is {transformers_version} ")
+                    raise ValueError(f"{model_id_or_path} requires transformers version {cls.require_pkgs_version} current transformers version is {transformers_version} ")
             else:
-                raise ValueError(f"can not parse requires_transformers_version {cls.require_transformers_version}, need (>, <, ==, >=, <=)version")
+                raise ValueError(f"can not parse requires_transformers_version {cls.require_pkgs_version}, need (>, <, ==, >=, <=)version")
 
-        if cls.require_tokenizers_version:
+        if cls.require_pkgs_version:
             from tokenizers import __version__ as tokenizers_version
-            passed = check_requires_version(cls.require_tokenizers_version, current_version=tokenizers_version)
+            passed = check_requires_version(cls.require_pkgs_version, current_version=tokenizers_version)
             if passed is not None:
                 if not passed:
-                    raise ValueError(f"{model_id_or_path} requires tokenizers version {cls.require_tokenizers_version} current tokenizers version is {tokenizers_version} ")
+                    raise ValueError(f"{model_id_or_path} requires tokenizers version {cls.require_pkgs_version} current tokenizers version is {tokenizers_version} ")
             else:
-                raise ValueError(f"can not parse require_tokenizers_version {cls.require_tokenizers_version}, need (>, <, ==, >=, <=)version")
+                raise ValueError(f"can not parse require_pkgs_version {cls.require_pkgs_version}, need (>, <, ==, >=, <=)version")
 
         check_versions(model_id_or_path, cls.require_pkgs_version)
 


### PR DESCRIPTION
Refer to #693 , `require_transformers_version` and `require_tokenizers_version` have been deprecated. This PR fixed the functions in models/auto.py 

@Qubitium @ZX-ModelCloud 