### PR TITLE
fix cpu/xpu backend selection

### DIFF
--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os.path
+import torch
 from os.path import isdir, join
 from typing import Dict, List, Optional, Union
 
@@ -202,6 +203,10 @@ class GPTQModel:
     ) -> BaseGPTQModel:
         model_type = check_and_get_model_type(model_id_or_path, trust_remote_code)
         quant_func = MODEL_MAP[model_type].from_quantized
+
+        if backend == BACKEND.AUTO and not torch.cuda.is_available():
+            logger.warning("No cuda found, use IPEX backend")
+            backend = BACKEND.IPEX
 
         return quant_func(
             model_id_or_path=model_id_or_path,

--- a/gptqmodel/nn_modules/qlinear/qlinear_exllama.py
+++ b/gptqmodel/nn_modules/qlinear/qlinear_exllama.py
@@ -9,7 +9,12 @@ import torch.nn as nn
 import torch.nn.functional as F
 import transformers
 from gptqmodel.nn_modules.qlinear import BaseQuantLinear
-from gptqmodel_exllama_kernels import make_q4, q4_matmul
+
+exllama_import_exception = None
+try:
+    from gptqmodel_exllama_kernels import make_q4, q4_matmul
+except ImportError as e:
+    exllama_import_exception = e
 
 logger = getLogger(__name__)
 
@@ -42,6 +47,10 @@ class ExllamaQuantLinear(BaseQuantLinear):
     """Linear layer implementation with per-group 4-bit quantization of the weights"""
 
     def __init__(self, bits: int, group_size: int, desc_act: bool, sym: bool, infeatures: int, outfeatures: int, bias: bool,  **kwargs,):
+        if exllama_import_exception is not None:
+            raise ValueError(
+                f"Trying to use the exllama backend, but could not import the C++/CUDA dependencies with the following error: {exllama_import_exception}"
+            )
         self.group_size = group_size if group_size != -1 else infeatures
         # auto pad
         self.outfeatures = outfeatures + (-outfeatures % 32)


### PR DESCRIPTION
Still need this change to run `quantization/basic_usage.py` in a CPU-only device.