### PR TITLE
fix ppl test

### DIFF
--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -164,10 +164,6 @@ def ModelLoader(cls):
         # enforce some values despite user specified
         # non-quantized models are always loaded into cpu
         model_init_kwargs["device_map"] = cpu_device_map
-        # if flash_attn was installed and _attn_implementation_autoset was None, flash attention would be loaded
-        # but device map is cpu, it will trow non-supported device error
-        if Version(transformers.__version__) >= Version("4.46.0"):
-            model_init_kwargs["_attn_implementation_autoset"] = True
         model_init_kwargs["torch_dtype"] = torch_dtype
 
         if config.model_type not in SUPPORTED_MODELS:

--- a/tests/models/model_test.py
+++ b/tests/models/model_test.py
@@ -107,7 +107,7 @@ class ModelTest(unittest.TestCase):
         if expected_kernels:
             assert modules == expected_kernels, f"kernels are different with expected. found: {modules}. expected: {expected_kernels}"
 
-    def quantModel(self, model_or_path, trust_remote_code=False, torch_dtype="auto", need_eval=True, batch_size: int=4, **kwargs):
+    def quantModel(self, model_id_or_path, trust_remote_code=False, torch_dtype="auto", need_eval=True, batch_size: int=4, **kwargs):
         quantize_config = QuantizeConfig(
             bits=4,
             group_size=128,
@@ -115,20 +115,17 @@ class ModelTest(unittest.TestCase):
             desc_act=self.DESC_ACT,
             sym=self.SYM,
         )
-        if isinstance(model_or_path, str):
-            model = GPTQModel.load(
-                model_or_path,
-                quantize_config=quantize_config,
-                trust_remote_code=trust_remote_code,
-                torch_dtype=torch_dtype,
-                backend=self.LOAD_BACKEND,
-                device_map={"": "cpu"} if self.LOAD_BACKEND == BACKEND.IPEX else "auto",
-                **kwargs,
-            )
-            tokenizer = self.load_tokenizer(model_or_path, trust_remote_code=trust_remote_code)
-        else:
-            model = model_or_path
-            tokenizer = self.load_tokenizer(model.model_local_path, trust_remote_code=trust_remote_code)
+        model = GPTQModel.load(
+            model_id_or_path,
+            quantize_config=quantize_config,
+            trust_remote_code=trust_remote_code,
+            torch_dtype=torch_dtype,
+            backend=self.LOAD_BACKEND,
+            device_map={"": "cpu"} if self.LOAD_BACKEND == BACKEND.IPEX else "auto",
+            **kwargs,
+        )
+
+        tokenizer = self.load_tokenizer(model_id_or_path, trust_remote_code=trust_remote_code)
 
         is_image_to_text_model = MODALITY.IMAGE_TO_TEXT in model.modality
         calibration_dataset = get_calib_dataset(model) if is_image_to_text_model else self.load_dataset(tokenizer)

--- a/tests/models/test_minicpm.py
+++ b/tests/models/test_minicpm.py
@@ -18,6 +18,4 @@ class TestMiniCpm(ModelTest):
         if Version(transformers.__version__) >= Version("4.46.0"):
             args["_attn_implementation_autoset"] = True
 
-        model = self.loadQuantModel(self.NATIVE_MODEL_ID, trust_remote_code=self.TRUST_REMOTE_CODE, args=args)
-
-        self.quantModel(model)
+        self.quantModel(self.NATIVE_MODEL_ID, trust_remote_code=self.TRUST_REMOTE_CODE, **args)

--- a/tests/models/test_minicpm.py
+++ b/tests/models/test_minicpm.py
@@ -18,6 +18,6 @@ class TestMiniCpm(ModelTest):
         if Version(transformers.__version__) >= Version("4.46.0"):
             args["_attn_implementation_autoset"] = True
 
-        model = self.loadQuantModel(self.NATIVE_MODEL_ID, args=args)
+        model = self.loadQuantModel(self.NATIVE_MODEL_ID, trust_remote_code=self.TRUST_REMOTE_CODE, args=args)
 
         self.quantModel(model)

--- a/tests/models/test_minicpm.py
+++ b/tests/models/test_minicpm.py
@@ -1,12 +1,23 @@
 from model_test import ModelTest
 
+import transformers
+from packaging.version import Version
+
 
 class TestMiniCpm(ModelTest):
-    NATIVE_MODEL_ID = "/monster/data/model/MiniCPM-2B-128k" # "openbmb/MiniCPM-2B-128k"
+    NATIVE_MODEL_ID = "/monster/data/model/MiniCPM-2B-128k"  # "openbmb/MiniCPM-2B-128k"
     NATIVE_ARC_CHALLENGE_ACC = 0.3848
     NATIVE_ARC_CHALLENGE_ACC_NORM = 0.4164
     TRUST_REMOTE_CODE = True
     BATCH_SIZE = 4
 
     def test_minicpm(self):
-        self.quant_lm_eval()
+        args = {}
+        # if flash_attn was installed and _attn_implementation_autoset was None, flash attention would be loaded
+        # but device map is cpu, it will trow non-supported device error
+        if Version(transformers.__version__) >= Version("4.46.0"):
+            args["_attn_implementation_autoset"] = True
+
+        model = self.loadQuantModel(self.NATIVE_MODEL_ID, args=args)
+
+        self.quantModel(model)

--- a/tests/test_perplexity.py
+++ b/tests/test_perplexity.py
@@ -21,6 +21,9 @@ class TestPerplexity(unittest.TestCase):
     TINYLLAMA_MODEL_ID = "/monster/data/model/tinyllama-15M-stories" # "ModelCloud/tinyllama-15M-stories"
     OPT_MODEL_ID = "/monster/data/model/opt-125m" # "facebook/opt-125m"
 
+    tinyllama_native_ppl = 54.616613778642396
+    opt_125m_native_ppl = 30.3942897844937
+
     OPT_DATASET_PATH = "wikitext"
     OPT_DATASET_NAME = "wikitext-2-raw-v1"
     OPT_DATASET_SPLIT = "test"
@@ -80,15 +83,20 @@ class TestPerplexity(unittest.TestCase):
             device_map="auto",
         )
 
-        native_ppl = self.calculate_avg_ppl(
-            self,
-            dataset_path,
-            dataset_name,
-            dataset_split,
-            dataset_column,
-            model,
-            tokenizer,
-        )
+        if model_id == self.TINYLLAMA_MODEL_ID:
+            native_ppl = self.tinyllama_native_ppl
+        elif model_id == self.OPT_MODEL_ID:
+            native_ppl = self.opt_125m_native_ppl
+        else:
+            native_ppl = self.calculate_avg_ppl(
+                self,
+                dataset_path,
+                dataset_name,
+                dataset_split,
+                dataset_column,
+                model,
+                tokenizer,
+            )
 
         print(f"{model_id} Native PPL: {native_ppl}")
 

--- a/tests/test_perplexity.py
+++ b/tests/test_perplexity.py
@@ -143,7 +143,7 @@ class TestPerplexity(unittest.TestCase):
         )
 
         dataset = self.opt_calibration_dataset if format == FORMAT.MARLIN or format == FORMAT.BITBLAS else self.tinyllama_calibration_dataset
-        model.quantize(dataset, batch_size=64)
+        model.quantize(dataset, batch_size=256)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             model.save(


### PR DESCRIPTION
        # if flash_attn was installed and _attn_implementation_autoset was None, flash attention would be loaded
        # but device map is cpu, it will trow non-supported device error
        if Version(transformers.__version__) >= Version("4.46.0"):
            args["_attn_implementation_autoset"] = True

move these codes from loader.py to minicpm tests only