### PR TITLE
Flexible Pack DType

### DIFF
--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -286,6 +286,7 @@ class BaseGPTQModel(nn.Module):
             device=DEVICE(self.quantize_config.device),
             pack=True,
             format=self.quantize_config.format,
+            pack_dtype=self.quantize_config.pack_dtype,
         )
 
         # Use the provided tokenizer if one is passed to quantize()
@@ -842,6 +843,7 @@ class BaseGPTQModel(nn.Module):
             lm_head_name=self.lm_head,
             dynamic=self.quantize_config.dynamic,
             parallel_packing=self.quantize_config.parallel_packing,
+            pack_dtype=self.quantize_config.pack_dtype,
         )
 
         self.model.config.use_cache = forward_pass_use_cache

--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -302,13 +302,13 @@ def ModelLoader(cls):
         if config.model_type not in SUPPORTED_MODELS:
             raise TypeError(f"{config.model_type} isn't supported yet.")
 
-        quantize_config = QuantizeConfig.from_pretrained(model_local_path, **cached_file_kwargs, **kwargs)
+        qcfg = QuantizeConfig.from_pretrained(model_local_path, **cached_file_kwargs, **kwargs)
 
-        quantize_config.calculate_bits_per_weight()
+        qcfg.calculate_bits_per_weight()
 
         if backend == BACKEND.VLLM or backend == BACKEND.SGLANG:
-            if quantize_config.format != FORMAT.GPTQ:
-                raise ValueError(f"{backend} backend only supports FORMAT.GPTQ: actual = {quantize_config.format}")
+            if qcfg.format != FORMAT.GPTQ:
+                raise ValueError(f"{backend} backend only supports FORMAT.GPTQ: actual = {qcfg.format}")
             if backend == BACKEND.VLLM:
                 from ..utils.vllm import load_model_by_vllm, vllm_generate
 
@@ -335,12 +335,12 @@ def ModelLoader(cls):
             return cls(
                 model,
                 quantized=True,
-                quantize_config=quantize_config,
+                quantize_config=qcfg,
                 qlinear_kernel=None,
                 model_local_path=model_local_path,
             )
 
-        if quantize_config.format == FORMAT.MARLIN:
+        if qcfg.format == FORMAT.MARLIN:
             # format marlin requires marlin kernel
             if backend != BACKEND.MARLIN and backend != BACKEND.AUTO:
                 raise TypeError(f"FORMAT.MARLIN requires BACKEND.AUTO or BACKEND.MARLIN: actual = `{backend}`.")
@@ -350,13 +350,13 @@ def ModelLoader(cls):
 
         # check for marlin compat for cuda device onnly
         if backend != BACKEND.MARLIN and device == DEVICE.CUDA:
-            unsupported = _validate_marlin_compatibility(quantize_config)
+            unsupported = _validate_marlin_compatibility(qcfg)
             if unsupported is None and marlin_compatible:
                 logger.info(
                     "You passed a model that is compatible with the Marlin kernel. Use `BACKEND.MARLIN` for optimal inference with batching on Nvidia GPU: `model = GPTQModel.load(..., backend=BACKEND.MARLIN)`."
                 )
 
-        if quantize_config.format == FORMAT.BITBLAS:
+        if qcfg.format == FORMAT.BITBLAS:
             # format bitblas requires bitblas kernel
             if backend != BACKEND.BITBLAS and backend != BACKEND.AUTO:
                 raise TypeError(f"FORMAT.BITBLAS requires BACKEND.AUTO or BACKEND.BITBLAS: actual = `{backend}`.")
@@ -368,7 +368,7 @@ def ModelLoader(cls):
                 raise ValueError(BITBLAS_INSTALL_HINT)
 
         possible_model_basenames = [
-            f"gptq_model-{quantize_config.bits}bit-{quantize_config.group_size}g",
+            f"gptq_model-{qcfg.bits}bit-{qcfg.group_size}g",
             "model",
         ]
 
@@ -390,7 +390,7 @@ def ModelLoader(cls):
                 "Loading of .bin files are not allowed due to safety. Please convert your model to safetensor or pytorch format."
             )
 
-        quantize_config.runtime_format = quantize_config.format
+        qcfg.runtime_format = qcfg.format
 
         model_save_name = resolved_archive_file  # In case a model is sharded, this would be `model.safetensors.index.json` which may later break.
         if verify_hash:
@@ -443,7 +443,7 @@ def ModelLoader(cls):
 
             for name in list(layers.keys()):
                 # allow loading of quantized lm_head
-                if quantize_config.lm_head and name == cls.lm_head:
+                if qcfg.lm_head and name == cls.lm_head:
                     continue
 
                 if any(name.startswith(ignore_layer) for ignore_layer in ignore_layers) or all(
@@ -457,22 +457,23 @@ def ModelLoader(cls):
             preload_qlinear_kernel = make_quant(
                 model,
                 layers,
-                quantize_config.bits,
-                quantize_config.group_size,
-                backend=backend.AUTO if (backend == BACKEND.MARLIN and quantize_config.format == FORMAT.MARLIN) or backend == BACKEND.BITBLAS else backend,
-                format=quantize_config.format,
+                qcfg.bits,
+                qcfg.group_size,
+                backend=backend.AUTO if (backend == BACKEND.MARLIN and qcfg.format == FORMAT.MARLIN) or backend == BACKEND.BITBLAS else backend,
+                format=qcfg.format,
                 lm_head_name=cls.lm_head,
-                desc_act=quantize_config.desc_act,
-                sym=quantize_config.sym,
-                dynamic=quantize_config.dynamic,
+                desc_act=qcfg.desc_act,
+                sym=qcfg.sym,
+                dynamic=qcfg.dynamic,
                 device=device,
+                pack_dtype=qcfg.pack_dtype,
             )
             if preload_qlinear_kernel == IPEXQuantLinear:
-                quantize_config.runtime_format = FORMAT.IPEX
+                qcfg.runtime_format = FORMAT.IPEX
 
         load_checkpoint_in_model = False
         # compat: runtime convert checkpoint gptq(v1) to gptq_v2 format
-        if quantize_config.format == FORMAT.GPTQ and backend != BACKEND.IPEX:
+        if qcfg.format == FORMAT.GPTQ and backend != BACKEND.IPEX:
             load_checkpoint_in_model_then_tie_weights(
                 model,
                 dtype=torch_dtype,
@@ -483,7 +484,7 @@ def ModelLoader(cls):
                 offload_buffers=True,
             )
             # validate sym=False v1 loading needs to be protected for models produced with new v2 format codebase
-            if not quantize_config.sym and not quantize_config.is_quantized_by_v2():
+            if not qcfg.sym and not qcfg.is_quantized_by_v2():
                 raise ValueError(
                     f"Loading of a sym=False model with format={FORMAT.GPTQ} is only supported if produced by gptqmodel version >= {MIN_VERSION_WITH_V2}"
                 )
@@ -492,15 +493,15 @@ def ModelLoader(cls):
             logger.info(f"Converting `{FORMAT_FIELD_JSON}` from `{FORMAT.GPTQ}` to `{FORMAT.GPTQ_V2}`.")
             model = convert_gptq_v1_to_v2_format(
                 model,
-                quantize_config=quantize_config,
+                cfg=qcfg,
                 qlinear_kernel=preload_qlinear_kernel,
             )
             logger.info(f"Conversion complete: {time.time()-t}s")
             load_checkpoint_in_model = True
-            quantize_config.runtime_format = FORMAT.GPTQ_V2
+            qcfg.runtime_format = FORMAT.GPTQ_V2
 
         if backend == BACKEND.MARLIN and (
-                preload_qlinear_kernel == ExllamaV2QuantLinear or quantize_config.format == FORMAT.MARLIN):
+                preload_qlinear_kernel == ExllamaV2QuantLinear or qcfg.format == FORMAT.MARLIN):
             if is_sharded:
                 raise ValueError(
                     "The loading of sharded checkpoints with Marlin is currently not supported."
@@ -514,19 +515,19 @@ def ModelLoader(cls):
             if torch_dtype != torch.float16:
                 raise ValueError("Marlin kernel requires torch_dtype=torch.float16.")
 
-            _validate_marlin_compatibility(quantize_config, throw_error=True)
+            _validate_marlin_compatibility(qcfg, throw_error=True)
 
             # Prepare model for marlin load.
             # If is marlin serialized load then load directly. Otherwise, convert to marlin.
             model = prepare_model_for_marlin_load(
                 model=model,
-                quantize_config=quantize_config,
+                quantize_config=qcfg,
                 quant_linear_class=preload_qlinear_kernel,
                 torch_dtype=torch_dtype,
                 current_model_save_name=model_save_name,
                 device_map=device_map,
-                desc_act=quantize_config.desc_act,
-                sym=quantize_config.sym,
+                desc_act=qcfg.desc_act,
+                sym=qcfg.sym,
                 load_checkpoint_in_model=load_checkpoint_in_model,
             )
 
@@ -537,13 +538,13 @@ def ModelLoader(cls):
             # If is bitblas serialized load then load directly. Otherwise, convert to bitblas.
             model = prepare_model_for_bitblas_load(
                 model=model,
-                quantize_config=quantize_config,
+                quantize_config=qcfg,
                 quant_linear_class=preload_qlinear_kernel,
                 torch_dtype=torch_dtype,
                 model_save_name=model_save_name,
                 device_map=device_map,
-                desc_act=quantize_config.desc_act,
-                sym=quantize_config.sym,
+                desc_act=qcfg.desc_act,
+                sym=qcfg.sym,
                 load_checkpoint_in_model=load_checkpoint_in_model,
             )
 
@@ -564,14 +565,15 @@ def ModelLoader(cls):
         model = simple_dispatch_model(model, device_map)
 
         qlinear_kernel = select_quant_linear(
-            bits=quantize_config.bits,
-            dynamic=quantize_config.dynamic,
-            group_size=quantize_config.group_size,
-            desc_act=quantize_config.desc_act,
-            sym=quantize_config.sym,
+            bits=qcfg.bits,
+            dynamic=qcfg.dynamic,
+            group_size=qcfg.group_size,
+            desc_act=qcfg.desc_act,
+            sym=qcfg.sym,
             backend=backend,
-            format=quantize_config.format,
+            format=qcfg.format,
             device=device,
+            pack_dtype=qcfg.pack_dtype,
         )
 
         # == step4: set seqlen == #
@@ -587,7 +589,7 @@ def ModelLoader(cls):
             model.seqlen = 4096
 
         # Any post-initialization that require device information, for example buffers initialization on device.
-        model = gptqmodel_post_init(model, use_act_order=quantize_config.desc_act, quantize_config=quantize_config)
+        model = gptqmodel_post_init(model, use_act_order=qcfg.desc_act, quantize_config=qcfg)
 
         model.eval()
 
@@ -607,7 +609,7 @@ def ModelLoader(cls):
                 )
 
             with tempfile.TemporaryDirectory() as temp_dir:
-                mlx_weights, mlx_config = convert_gptq_to_mlx_weights(model_id_or_path, model, quantize_config.to_dict())
+                mlx_weights, mlx_config = convert_gptq_to_mlx_weights(model_id_or_path, model, qcfg.to_dict())
 
                 save_weights(temp_dir, mlx_weights, donate_weights=True)
                 save_config(mlx_config, config_path=temp_dir + "/config.json")
@@ -621,7 +623,7 @@ def ModelLoader(cls):
         return cls(
             model,
             quantized=True,
-            quantize_config=quantize_config,
+            quantize_config=qcfg,
             tokenizer=tokenizer,
             qlinear_kernel=qlinear_kernel,
             load_quantized_model=True,

--- a/gptqmodel/nn_modules/qlinear/bitblas.py
+++ b/gptqmodel/nn_modules/qlinear/bitblas.py
@@ -102,6 +102,7 @@ class BitBLASQuantLinear(BaseQuantLinear):
 
     SUPPORTS_DEVICES = [DEVICE.CUDA]
     SUPPORTS_PLATFORM = [PLATFORM.LINUX, PLATFORM.WIN32]
+    SUPPORTS_PACK_DTYPES = [torch.int32]
 
     OPT_FEATURES = [1, 16, 32, 64, 128, 256, 512]
     zeros_mode = "quantized"  # "original" or "rescale" or "quantized"
@@ -125,6 +126,7 @@ class BitBLASQuantLinear(BaseQuantLinear):
         sym: bool,
         infeatures: int,
         outfeatures: int,
+        pack_dtype: torch.dtype,
         bias: bool,
         enable_tuning: bool = True,
         fast_decoding: bool = True,
@@ -133,13 +135,12 @@ class BitBLASQuantLinear(BaseQuantLinear):
         layout: str = "nt",
         **kwargs,
     ):
-        super().__init__(bits=bits, group_size=group_size, sym=sym, desc_act=desc_act, infeatures=infeatures, outfeatures=outfeatures, **kwargs)
+        super().__init__(bits=bits, group_size=group_size, sym=sym, desc_act=desc_act, infeatures=infeatures, outfeatures=outfeatures,  pack_dtype=pack_dtype, **kwargs)
 
         import_bitblas()
 
         self._validate_parameters(group_size, infeatures, outfeatures)
 
-        self.bits = bits
         self.infeatures = infeatures
         self.outfeatures = outfeatures
         self.group_size = self._set_group_size(group_size, infeatures)

--- a/gptqmodel/nn_modules/qlinear/exllama.py
+++ b/gptqmodel/nn_modules/qlinear/exllama.py
@@ -72,13 +72,14 @@ class ExllamaQuantLinear(BaseQuantLinear):
 
     SUPPORTS_DEVICES = [DEVICE.CUDA, DEVICE.ROCM]
     SUPPORTS_PLATFORM = [PLATFORM.LINUX]
+    SUPPORTS_PACK_DTYPES = [torch.int32]
 
     # for transformers/optimum tests compat
     QUANT_TYPE = "exllama"
 
     """Linear layer implementation with per-group 4-bit quantization of the weights"""
 
-    def __init__(self, bits: int, group_size: int, desc_act: bool, sym: bool, infeatures: int, outfeatures: int, bias: bool,  **kwargs,):
+    def __init__(self, bits: int, group_size: int, desc_act: bool, sym: bool, infeatures: int, outfeatures: int, pack_dtype: torch.dtype, bias: bool,  **kwargs,):
         if exllama_import_exception is not None:
             raise ValueError(
                 f"Trying to use the exllama backend, but could not import the C++/CUDA dependencies with the following error: {exllama_import_exception}"
@@ -88,9 +89,7 @@ class ExllamaQuantLinear(BaseQuantLinear):
         self.outfeatures = outfeatures + (-outfeatures % 32)
         self.infeatures = infeatures + (-infeatures % self.group_size)
 
-        super().__init__(bits=bits, group_size=group_size, sym=sym, desc_act=desc_act, infeatures=self.infeatures, outfeatures=self.outfeatures, **kwargs)
-
-        self.bits = bits
+        super().__init__(bits=bits, group_size=group_size, sym=sym, desc_act=desc_act, infeatures=self.infeatures, outfeatures=self.outfeatures,  pack_dtype=pack_dtype, **kwargs)
 
         # backup original values
         self.original_outfeatures = outfeatures

--- a/gptqmodel/nn_modules/qlinear/exllamav2.py
+++ b/gptqmodel/nn_modules/qlinear/exllamav2.py
@@ -133,13 +133,14 @@ class ExllamaV2QuantLinear(BaseQuantLinear):
 
     SUPPORTS_DEVICES = [DEVICE.CUDA, DEVICE.ROCM]
     SUPPORTS_PLATFORM = [PLATFORM.LINUX]
+    SUPPORTS_PACK_DTYPES = [torch.int32]
 
     # for transformers/optimum tests compat
     QUANT_TYPE = "exllamav2"
 
     """Linear layer implementation with per-group 4-bit quantization of the weights"""
 
-    def __init__(self, bits: int, group_size: int, desc_act: bool, sym: bool, infeatures: int, outfeatures: int,
+    def __init__(self, bits: int, group_size: int, desc_act: bool, sym: bool, infeatures: int, outfeatures: int, pack_dtype: torch.dtype,
                  bias: bool,  **kwargs,):
 
         if exllama_v2_import_exception is not None:
@@ -152,12 +153,10 @@ class ExllamaV2QuantLinear(BaseQuantLinear):
         self.outfeatures = outfeatures + (-outfeatures % 32)
         self.infeatures = infeatures + (-infeatures % self.group_size)
 
-        super().__init__(bits=bits, group_size=group_size, sym=sym, desc_act=desc_act, infeatures=self.infeatures, outfeatures=self.outfeatures, **kwargs)
+        super().__init__(bits=bits, group_size=group_size, sym=sym, desc_act=desc_act, infeatures=self.infeatures, outfeatures=self.outfeatures, pack_dtype=pack_dtype, **kwargs)
 
         self.q_handle = None
         self.q_tensors = None
-
-        self.bits = bits
 
         # backup original values
         self.original_outfeatures = outfeatures

--- a/gptqmodel/nn_modules/qlinear/ipex.py
+++ b/gptqmodel/nn_modules/qlinear/ipex.py
@@ -102,6 +102,7 @@ class IPEXQuantLinear(BaseQuantLinear):
 
     SUPPORTS_DEVICES = [DEVICE.CPU, DEVICE.XPU]
     SUPPORTS_PLATFORM = [PLATFORM.LINUX]
+    SUPPORTS_PACK_DTYPES = [torch.int32]
 
     # for transformers/optimum tests compat
     QUANT_TYPE = "ipex"
@@ -114,20 +115,20 @@ class IPEXQuantLinear(BaseQuantLinear):
         sym: bool,
         infeatures: int,
         outfeatures: int,
+        pack_dtype: torch.dtype,
         bias: bool,
         kernel_switch_threshold=128,
         training=False,
         weight_dtype=None,
         **kwargs,
     ):
-        super().__init__(bits=bits, group_size=group_size, sym=sym, desc_act=desc_act, infeatures=infeatures, outfeatures=outfeatures, **kwargs)
+        super().__init__(bits=bits, group_size=group_size, sym=sym, desc_act=desc_act, infeatures=infeatures, outfeatures=outfeatures, pack_dtype=pack_dtype, **kwargs)
 
         if weight_dtype is None:
             weight_dtype = torch.float16 if HAS_XPU else torch.bfloat16
 
         self.infeatures = infeatures
         self.outfeatures = outfeatures
-        self.bits = bits
         self.group_size = group_size
         self.maxq = 2**self.bits - 1
         self.weight_dtype = weight_dtype

--- a/gptqmodel/nn_modules/qlinear/marlin.py
+++ b/gptqmodel/nn_modules/qlinear/marlin.py
@@ -170,18 +170,19 @@ class MarlinQuantLinear(BaseQuantLinear):
 
     SUPPORTS_DEVICES = [DEVICE.CUDA]
     SUPPORTS_PLATFORM = [PLATFORM.LINUX]
+    SUPPORTS_PACK_DTYPES = [torch.int32]
 
     # for transformers/optimum tests compat
     QUANT_TYPE = "marlin"
 
-    def __init__(self, bits: int, group_size: int, desc_act: bool, sym: bool, infeatures: int, outfeatures: int,
+    def __init__(self, bits: int, group_size: int, desc_act: bool, sym: bool, infeatures: int, outfeatures: int, pack_dtype: torch.dtype,
                  bias: bool, **kwargs):
         if marlin_import_exception is not None:
             raise ValueError(
                 f"Trying to use the marlin backend, but could not import the C++/CUDA dependencies with the following error: {marlin_import_exception}"
             )
 
-        super().__init__(bits=bits, group_size=group_size, sym=sym, desc_act=desc_act, infeatures=infeatures, outfeatures=outfeatures, **kwargs)
+        super().__init__(bits=bits, group_size=group_size, sym=sym, desc_act=desc_act, infeatures=infeatures, outfeatures=outfeatures, pack_dtype=pack_dtype, **kwargs)
 
         self.original_infeatures = infeatures
         self.original_outfeatures = outfeatures
@@ -199,7 +200,6 @@ class MarlinQuantLinear(BaseQuantLinear):
         else:
             group_size = infeatures
 
-        self.bits = bits
         self.group_size = group_size
         self.desc_act = desc_act
 

--- a/gptqmodel/nn_modules/qlinear/marlin.py
+++ b/gptqmodel/nn_modules/qlinear/marlin.py
@@ -352,7 +352,8 @@ class MarlinQuantLinear(BaseQuantLinear):
             self.g_idx_sort_indices,
             self.infeatures,
             self.outfeatures,
-            self.bits)
+            self.bits,
+            self.pack_dtype_bits)
         replace_tensor(self, "qweight", marlin_qweight)
 
         # Permute scales from autogptq format to marlin format.

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -77,7 +77,7 @@ class TorchQuantLinear(BaseQuantLinear):
         else:
             raise ValueError("Unsupported weight_dtype. Only int16 and int32 are supported.")
 
-        self.tensors_per_storage_dtype = 8 // self.bits
+        self.tensors_per_storage_dtype = self.storage_dtype_bits // self.bits
         # Initialize qweight and qzeros based on the chosen dtype
         self.register_buffer(
             "qweight",
@@ -110,7 +110,7 @@ class TorchQuantLinear(BaseQuantLinear):
             self.bias = None
 
         if self.bits in [2, 4, 8]:
-            self.wf = torch.tensor(list(range(0, 32, self.bits)), dtype=torch.int32).unsqueeze(0)
+            self.wf = torch.tensor(list(range(0, self.storage_dtype_bits, self.bits)), dtype=torch.int32).unsqueeze(0)
         elif self.bits == 3:
             self.wf = torch.tensor(
                 [

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -222,10 +222,9 @@ class TorchQuantLinear(BaseQuantLinear):
         num_itr = self.g_idx.shape[0] // x.shape[-1]
         weights = self.dequantize_weight(num_itr=num_itr)
 
-        out = torch.matmul(x, weights)
-        out = out.to(x_dtype)
-        out = out.reshape(out_shape)
-        out = out + self.bias if self.bias is not None else out
+        out = torch.matmul(x, weights).reshape(out_shape).to(x_dtype)
+        if self.bias:
+            out = out + self.bias
         return out
 
     # clear gptq only weights: useful in de-quantization

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -214,8 +214,7 @@ class TorchQuantLinear(BaseQuantLinear):
 
         out_shape = x.shape[:-1] + (self.outfeatures,)
         x = x.reshape(-1, x.shape[-1])
-        x_dtype = x.dtype
-        out = self._forward(x, x_dtype, out_shape)
+        out = self._forward(x, x.dtype, out_shape)
         return out
 
     def _forward(self, x, x_dtype, out_shape):

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -72,7 +72,7 @@ class TorchQuantLinear(BaseQuantLinear):
         if self.storage_dtype == torch.int8:
             self.storage_dtype_bits = 8
             self.storage_np_dtype = np.uint8
-        elif self.storage_dtype == torch.int8:
+        elif self.storage_dtype == torch.int16:
             self.storage_dtype_bits = 16
             self.storage_np_dtype = np.uint16
         elif self.storage_dtype == torch.int32:

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -78,7 +78,7 @@ class TorchQuantLinear(BaseQuantLinear):
                     math.ceil(infeatures / self.group_size),
                     outfeatures // self.pack_dtype_bits * self.bits,
                 ),
-                dtype=torch.float16,
+                dtype=self.pack_dtype,
             ),
         )
         self.register_buffer(

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -72,8 +72,10 @@ class TorchQuantLinear(BaseQuantLinear):
         # Determine the number of INT4 tensors that can be packed into the chosen dtype
         if self.storage_dtype == torch.int8:
             self.storage_dtype_bits = 8
+            self.storage_np_dtype = np.int8
         elif self.storage_dtype == torch.int32:
             self.storage_dtype_bits = 32
+            self.storage_np_dtype = np.int32
         else:
             raise ValueError("Unsupported weight_dtype. Only int16 and int32 are supported.")
 
@@ -150,9 +152,9 @@ class TorchQuantLinear(BaseQuantLinear):
 
         intweight = torch.round((W + scale_zeros[self.g_idx].T) / scales[self.g_idx].T).to(torch.int)
         intweight = intweight.t().contiguous()
-        intweight = intweight.numpy().astype(np.uint32)
+        intweight = intweight.numpy().astype(self.storage_np_dtype)
 
-        qweight = np.zeros((intweight.shape[0] // self.storage_dtype_bits * self.bits, intweight.shape[1]), dtype=np.uint32)
+        qweight = np.zeros((intweight.shape[0] // self.storage_dtype_bits * self.bits, intweight.shape[1]), dtype=self.storage_np_dtype)
         if self.bits in [2, 4, 8]:
             for row in range(qweight.shape[0]):
                 for j in range(self.tensors_per_storage_dtype):
@@ -174,10 +176,10 @@ class TorchQuantLinear(BaseQuantLinear):
                 for j in range(10):
                     qweight[row] |= intweight[row_offset + j] << (3 * j + 2)
 
-        self.qweight = torch.from_numpy(qweight.astype(np.int32 if self.storage_dtype == torch.int32 else np.int8))
+        self.qweight = torch.from_numpy(qweight.astype(self.storage_np_dtype))
 
-        zeros = zeros.numpy().astype(np.uint32)
-        qzeros = np.zeros((zeros.shape[0], zeros.shape[1] // self.storage_dtype_bits * self.bits), dtype=np.uint32)
+        zeros = zeros.numpy().astype(self.storage_np_dtype)
+        qzeros = np.zeros((zeros.shape[0], zeros.shape[1] // self.storage_dtype_bits * self.bits), dtype=self.storage_np_dtype)
         if self.bits in [2, 4, 8]:
             for col in range(qzeros.shape[1]):
                 for j in range(self.tensors_per_storage_dtype):
@@ -199,7 +201,7 @@ class TorchQuantLinear(BaseQuantLinear):
                 for j in range(10):
                     qzeros[:, col] |= zeros[:, col_offset + j] << (3 * j + 2)
 
-        self.qzeros = torch.from_numpy(qzeros.astype(np.int32 if self.storage_dtype == torch.int32 else np.int8))
+        self.qzeros = torch.from_numpy(qzeros.astype(self.storage_np_dtype))
 
     def forward(self, x: torch.Tensor):
         if x.size(-1) != self.padded_infeatures:

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -71,13 +71,13 @@ class TorchQuantLinear(BaseQuantLinear):
 
         if self.storage_dtype == torch.int8:
             self.storage_dtype_bits = 8
-            self.storage_np_dtype = np.uint8
+            self.storage_np_dtype = np.int8
         elif self.storage_dtype == torch.int16:
             self.storage_dtype_bits = 16
-            self.storage_np_dtype = np.uint16
+            self.storage_np_dtype = np.int16
         elif self.storage_dtype == torch.int32:
             self.storage_dtype_bits = 32
-            self.storage_np_dtype = np.uint32
+            self.storage_np_dtype = np.int32
         else:
             raise ValueError("Unsupported weight_dtype. Only int16 and int32 are supported.")
 
@@ -239,14 +239,14 @@ class TorchQuantLinear(BaseQuantLinear):
 
         if self.bits in [2, 4, 8]:
             zeros = torch.bitwise_right_shift(
-                torch.unsqueeze(self.qzeros, 2).expand(-1, -1, 32 // self.bits),
+                torch.unsqueeze(self.qzeros, 2).expand(-1, -1, self.tensors_per_storage_dtype),
                 self.wf.unsqueeze(0),
             ).to(torch.int16 if self.bits == 8 else torch.int8)
             zeros = torch.bitwise_and(zeros, (2 ** self.bits) - 1).reshape(self.scales.shape)
 
             weight = torch.bitwise_and(
                 torch.bitwise_right_shift(
-                    torch.unsqueeze(self.qweight, 1).expand(-1, 32 // self.bits, -1),
+                    torch.unsqueeze(self.qweight, 1).expand(-1, self.tensors_per_storage_dtype, -1),
                     self.wf.unsqueeze(-1),
                 ).to(torch.int16 if self.bits == 8 else torch.int8),
                 (2 ** self.bits) - 1

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -81,7 +81,7 @@ class TorchQuantLinear(BaseQuantLinear):
         # Initialize qweight and qzeros based on the chosen dtype
         self.register_buffer(
             "qweight",
-            torch.zeros((infeatures // self.tensors_per_storage_dtype * self.bits, outfeatures), dtype=self.storage_dtype),
+            torch.zeros((infeatures // self.storage_dtype_bits * self.bits, outfeatures), dtype=self.storage_dtype),
         )
         self.register_buffer(
             "qzeros",

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -42,7 +42,7 @@ class TorchQuantLinear(BaseQuantLinear):
 
     SUPPORTS_DEVICES = [DEVICE.ALL]
     SUPPORTS_PLATFORM = [PLATFORM.ALL]
-    SUPPORTS_PACK_DTYPES = [torch.int8, torch.int16, torch.int32, torch.int64]
+    SUPPORTS_PACK_DTYPES = [torch.int8, torch.int16, torch.int32]
 
     # for transformers/optimum tests compat
     QUANT_TYPE = "torch"

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -69,18 +69,20 @@ class TorchQuantLinear(BaseQuantLinear):
         self.maxq = 2**self.bits - 1
         self.storage_dtype = storage_dtype
 
-        # Determine the number of INT4 tensors that can be packed into the chosen dtype
         if self.storage_dtype == torch.int8:
             self.storage_dtype_bits = 8
-            self.storage_np_dtype = np.int8
+            self.storage_np_dtype = np.uint8
+        elif self.storage_dtype == torch.int8:
+            self.storage_dtype_bits = 16
+            self.storage_np_dtype = np.uint16
         elif self.storage_dtype == torch.int32:
             self.storage_dtype_bits = 32
-            self.storage_np_dtype = np.int32
+            self.storage_np_dtype = np.uint32
         else:
             raise ValueError("Unsupported weight_dtype. Only int16 and int32 are supported.")
 
         self.tensors_per_storage_dtype = self.storage_dtype_bits // self.bits
-        # Initialize qweight and qzeros based on the chosen dtype
+
         self.register_buffer(
             "qweight",
             torch.zeros((infeatures // self.storage_dtype_bits * self.bits, outfeatures), dtype=self.storage_dtype),

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -136,7 +136,7 @@ class TorchQuantLinear(BaseQuantLinear):
         if linear.bias is not None:
             self.bias = linear.bias.clone().to(dtype=torch.float16)
 
-        intweight = torch.round((W + scale_zeros[self.g_idx].T) / scales[self.g_idx].T).to(torch.int)
+        intweight = torch.round((W + scale_zeros[self.g_idx].T) / scales[self.g_idx].T).to(torch.int32)
         intweight = intweight.t().contiguous()
         intweight = intweight.numpy().astype(self.pack_np_dtype)
 

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -78,6 +78,9 @@ class TorchQuantLinear(BaseQuantLinear):
         elif self.storage_dtype == torch.int32:
             self.storage_dtype_bits = 32
             self.storage_np_dtype = np.int32
+        elif self.storage_dtype == torch.int64:
+            self.storage_dtype_bits = 64
+            self.storage_np_dtype = np.int64
         else:
             raise ValueError("Unsupported weight_dtype. Only int16 and int32 are supported.")
 

--- a/gptqmodel/nn_modules/qlinear/tritonv2.py
+++ b/gptqmodel/nn_modules/qlinear/tritonv2.py
@@ -62,6 +62,7 @@ class TritonV2QuantLinear(BaseQuantLinear, TritonModuleMixin):
 
     SUPPORTS_DEVICES = [DEVICE.CUDA, DEVICE.XPU]
     SUPPORTS_PLATFORM = [PLATFORM.LINUX, PLATFORM.WIN32]
+    SUPPORTS_PACK_DTYPES = [torch.int32]
 
     # for transformers/optimum tests compat
     QUANT_TYPE = "tritonv2"
@@ -74,16 +75,15 @@ class TritonV2QuantLinear(BaseQuantLinear, TritonModuleMixin):
     dequant and matmul into single kernel.add()
     """
 
-    def __init__(self, bits: int, group_size: int, desc_act: bool, sym: bool, infeatures, outfeatures, bias, **kwargs,):
+    def __init__(self, bits: int, group_size: int, desc_act: bool, sym: bool, infeatures, outfeatures, pack_dtype, bias, **kwargs,):
         if not TRITON_AVAILABLE:
             raise ValueError(TRITON_INSTALL_HINT)
-        super().__init__(bits=bits, group_size=group_size, sym=sym, desc_act=desc_act, infeatures=infeatures, outfeatures=outfeatures, **kwargs)
+        super().__init__(bits=bits, group_size=group_size, sym=sym, desc_act=desc_act, infeatures=infeatures, outfeatures=outfeatures, pack_dtype=pack_dtype, **kwargs)
         self.infeatures = infeatures
         self.outfeatures = outfeatures
 
         self.padded_infeatures = infeatures + (-infeatures % group_size)
 
-        self.bits = bits
         self.group_size = group_size if group_size != -1 else infeatures
         self.maxq = 2**self.bits - 1
 

--- a/gptqmodel/quantization/config.py
+++ b/gptqmodel/quantization/config.py
@@ -34,6 +34,7 @@ FORMAT_FIELD_CODE = "format"
 FORMAT_FIELD_JSON = "checkpoint_format"
 FORMAT_FIELD_COMPAT_MARLIN = "is_marlin_format"
 QUANT_METHOD_FIELD = "quant_method"
+PACK_DTYPE_FIELD = "pack_dtype"
 QUANT_CONFIG_FILENAME = "quantize_config.json"
 QUANT_CONFIG_FILENAME_COMPAT = [QUANT_CONFIG_FILENAME, "quant_config.json", "config.json"]
 
@@ -55,6 +56,7 @@ META_FIELD_STATIC_GROUPS = "static_groups"
 META_FIELD_TRUE_SEQUENTIAL = "true_sequential"
 
 META_FIELD_MSE = "mse"
+
 
 # pkg names
 PKG_AUTO_ROUND = "auto-round"
@@ -133,24 +135,34 @@ def dynamic_get(dynamic: Dict[str, Dict[str, Union[int, bool]]], layer_name: str
 @dataclass
 class QuantizeConfig():
     bits: int = field(default=4, metadata={"choices": [2, 3, 4, 8]})
+
     # allow dynamic bitsize per layer, if None or some layer not set, use bits
     dynamic: Optional[Dict[str, Dict[str, Union[int, bool]]]] = field(default=None)
-    # 128 offer good balance between inference speed and quantization quality
+
+    # 128 offer good balance between inference speed, vram usage (bpw), and quality
+    # use 32 for highest quality with slower inference and higher vram usage
     group_size: int = field(default=128)
+
     # increase damp if NaN is encountred during `.quantize()` and/or increase calib dataset size
     damp_percent: float = field(default=0.01)
     damp_auto_increment: float = field(default=0.0025)
+
     desc_act: bool = field(default=True)
     static_groups: bool = field(default=False)
     sym: bool = field(default=True)
     true_sequential: bool = field(default=True)
+
     lm_head: bool = field(default=False)
-    lm_head_low_gpu_mem_usage: bool = field(default=False)
+    # there are 2 methods for lm_head quantization: high/low gpu vram modes where high will result in lower error loss
+    lm_head_low_gpu_mem_usage: bool = field(default=True)
+
     quant_method: str = field(default=QUANT_METHOD.GPTQ)
+
     # default to gptq v1 format for maximum compat with 3rd party inference libs with minimal loss vs v2
     # if you inference with gptqmodel, save to gptq_v2 format for best result
     format: FORMAT = field(default=FORMAT.GPTQ)
 
+    # mean square error calculation: may reduce error loss for some models
     mse: float = field(default=0.0)
 
     # parallel packing will make ~40% speedup for many models, but may cause OOM in some large models
@@ -164,8 +176,28 @@ class QuantizeConfig():
     # normalized to DEVICE after passing to load()
     device: Optional[Union[str, torch.device]] = field(default=None)
 
+    # gptq was originally designed to pack quantized weights inside INT32 dtypes
+    # allowing using different dtypes used for packing quantized weights
+    # affects [`qweights`, `qzeros`]
+    pack_dtype: Optional[Union[str, torch.int64, torch.int32, torch.int16, torch.int8]] = field(default=torch.int32)
+
     def __post_init__(self):
         fields_info = fields(self)
+
+        # validate/normalizes pack_dtype from string and dtype to valid dtype
+        if self.pack_dtype is None:
+            self.pack_dtype = torch.int32
+        else:
+            if isinstance(self.pack_dtype, str):
+                self.pack_dtype = self.pack_dtype.lower()
+                if not self.pack_dtype in ["int64", "int32", "int16", "int8"]:
+                    raise ValueError(f"Unsupported pack_dtype: {self.pack_dtype}")
+                self.pack_dtype = getattr(torch, self.pack_dtype)
+            elif isinstance(self.pack_dtype, torch.dtype):
+                if not self.pack_dtype in [torch.int64, torch.int32, torch.int16, torch.int8]:
+                    raise ValueError(f"Unsupported pack_dtype: {self.pack_dtype}")
+            else:
+                raise ValueError(f"Unsupported pack_dtype: {self.pack_dtype}")
 
         # validate quant method and format is matched
         valid_formats = QUANT_METHOD_FORMAT_MAPPING.get(self.quant_method, None)
@@ -360,6 +392,7 @@ class QuantizeConfig():
             "lm_head": self.lm_head,
             QUANT_METHOD_FIELD:self.quant_method,
             FORMAT_FIELD_JSON: self.format,
+            PACK_DTYPE_FIELD: str(self.pack_dtype).split(".")[-1],
             META_FIELD: self.meta,
         }
         dict_scale_dtype_to_str(out)

--- a/gptqmodel/utils/importer.py
+++ b/gptqmodel/utils/importer.py
@@ -139,6 +139,7 @@ def hf_select_quant_linear(
         pack=pack,
         allow_marlin=True, # TODO: remove this after marlin padding is fixed
         dynamic=None,
+        pack_dtype=torch.int32,
     )
 
 
@@ -154,6 +155,7 @@ def select_quant_linear(
         pack: bool = False,
         allow_marlin: bool = True,  # TODO: remove this after marlin padding is fixed
         dynamic=None,
+        pack_dtype: torch.dtype = None,
 ) -> Type[BaseQuantLinear]:
     if device is None:
         device = DEVICE.XPU if backend == BACKEND.IPEX else DEVICE.CUDA
@@ -229,7 +231,7 @@ def select_quant_linear(
     else:
         qlinear = TorchQuantLinear
 
-    validate, err = qlinear.validate(bits=bits, group_size=group_size, desc_act=desc_act, sym=sym, dynamic=dynamic, device=device, trainable=trainable)
+    validate, err = qlinear.validate(bits=bits, group_size=group_size, desc_act=desc_act, sym=sym, pack_dtype=pack_dtype, dynamic=dynamic, device=device, trainable=trainable)
     if not validate:
         raise ValueError(err)
     else:

--- a/gptqmodel/utils/marlin.py
+++ b/gptqmodel/utils/marlin.py
@@ -104,7 +104,7 @@ def _validate_marlin_device_support() -> bool:
 
 # Adapted from https://github.com/rib-2/marlin/tree/conversion
 def _validate_marlin_compatibility(cfg: QuantizeConfig, throw_error: bool = False):
-    validate, err = MarlinQuantLinear.validate(bits=cfg.bits, group_size=cfg.group_size, desc_act=cfg.desc_act, sym=cfg.sym, dynamic=cfg.dynamic)
+    validate, err = MarlinQuantLinear.validate(bits=cfg.bits, group_size=cfg.group_size, desc_act=cfg.desc_act, sym=cfg.sym, dynamic=cfg.dynamic, pack_dtype=cfg.pack_dtype)
     if throw_error and err is not None:
         raise ValueError(err)
     return err

--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -161,6 +161,7 @@ def make_quant(
     dynamic=None,
     device: DEVICE = None,
     from_quantized: bool = False,
+    pack_dtype: torch.dtype = None,
 ) -> BaseQuantLinear:
     QuantLinear = select_quant_linear(
         bits=bits,
@@ -172,6 +173,7 @@ def make_quant(
         pack=pack,
         dynamic=dynamic,
         device=device,
+        pack_dtype=pack_dtype,
     )
 
     if pack:
@@ -186,7 +188,7 @@ def make_quant(
                 logger.info(f"Use {QuantLinear} failed, try to use {linear} instead.")
 
             result = create_quant_layer(linear, bits, desc_act, dynamic, group_size, module, names, sym, device
-                                        , lm_head_name)
+                                        , lm_head_name, pack_dtype=pack_dtype)
             return result
         except NotImplementedError as e:
             # only fallback to other quant linears when backend is auto.
@@ -196,7 +198,7 @@ def make_quant(
     raise ValueError("no support quant linear was found for this module.")
 
 
-def create_quant_layer(QuantLinear, bits, desc_act, dynamic, group_size, module, names, sym, device, lm_head_name: str
+def create_quant_layer(QuantLinear, bits: int, desc_act: bool, dynamic, group_size: int, module, names, sym: bool, device: DEVICE, lm_head_name: str, pack_dtype: torch.dtype,
                        ) -> BaseQuantLinear:
     if isinstance(module, QuantLinear):
         return QuantLinear
@@ -221,7 +223,7 @@ def create_quant_layer(QuantLinear, bits, desc_act, dynamic, group_size, module,
 
             # when load a quantized model, device is target device passed in GPTQModel.load()
             # check in_features and out_features validate
-            _, err = QuantLinear.validate(bits=bits, group_size=group_size, desc_act=desc_act, sym=sym, infeatures=in_features, outfeatures=out_features, device=device)
+            _, err = QuantLinear.validate(bits=bits, group_size=group_size, desc_act=desc_act, sym=sym, infeatures=in_features, outfeatures=out_features, pack_dtype=pack_dtype, device=device)
             if err is not None:
                 raise err
 
@@ -249,8 +251,9 @@ def create_quant_layer(QuantLinear, bits, desc_act, dynamic, group_size, module,
                 sym=d_sym,
                 infeatures=in_features,
                 outfeatures=out_features,
+                pack_dtype=pack_dtype,
                 bias=bias,
-                weight_dtype=submodule.qweight.dtype if isinstance(submodule, BaseQuantLinear) else submodule.weight.dtype,
+                #weight_dtype=submodule.qweight.dtype if isinstance(submodule, BaseQuantLinear) else submodule.weight.dtype,
                 name=name,
                 lm_head_name=lm_head_name,
             )
@@ -267,15 +270,15 @@ def hf_convert_gptq_v1_to_v2_format(
     meta: Optional[Dict[str, any]],
 ) -> Tuple[nn.Module, bool]:
     if checkpoint_format == "gptq":
-        quantize_config = QuantizeConfig(bits=bits)
-        return convert_gptq_v1_to_v2_format(model, quantize_config, qlinear_kernel), True
+        cfg = QuantizeConfig(bits=bits)
+        return convert_gptq_v1_to_v2_format(model, cfg, qlinear_kernel), True
     else:
         return model, False
 
-
+# TODO: FIXME: the v1 -> v2 zeropoint offsets are assuming INT32 pack_dtype
 def convert_gptq_v1_to_v2_format(
     model,
-    quantize_config: QuantizeConfig,
+    cfg: QuantizeConfig,
     qlinear_kernel: Type[BaseQuantLinear],
 ):
     # skip v1 to v2 conversion for ipex
@@ -290,9 +293,17 @@ def convert_gptq_v1_to_v2_format(
             # v1 checkpoint format with sym=False saved via convert_gptq_v2_to_v1_format() will
             # overflow ~<=13% based on testing
             if isinstance(submodule, qlinear_kernel):
-                if quantize_config.bits == 2:
-                    submodule.qzeros.data += 0b01010101010101010101010101010101
-                elif quantize_config.bits == 3:
+                if cfg.bits == 2:
+                    if cfg.pack_dtype == torch.int64:
+                        submodule.qzeros.data += 0b0101010101010101010101010101010101010101010101010101010101010101
+                    elif cfg.pack_dtype == torch.int32:
+                        submodule.qzeros.data += 0b01010101010101010101010101010101
+                    elif cfg.pack_dtype == torch.int16:
+                        submodule.qzeros.data += 0b0101010101010101
+                    elif cfg.pack_dtype == torch.int8:
+                        submodule.qzeros.data += 0b01010101
+                elif cfg.bits == 3:
+                    raise Exception("FIX ME")
                     submodule.qzeros.data[:, range(0, submodule.qzeros.data.shape[1], 3)] += (
                         0b00100100100100100100100100100100
                     )
@@ -302,10 +313,24 @@ def convert_gptq_v1_to_v2_format(
                     submodule.qzeros.data[:, range(2, submodule.qzeros.data.shape[1], 3)] += (
                         0b01001001001001001001001001001001
                     )
-                elif quantize_config.bits == 4:
-                    submodule.qzeros.data += 0b00010001000100010001000100010001
-                elif quantize_config.bits == 8:
-                    submodule.qzeros.data += 0b00000001000000010000000100000001
+                elif cfg.bits == 4:
+                    if cfg.pack_dtype == torch.int64:
+                        submodule.qzeros.data += 0b0001000100010001000100010001000100010001000100010001000100010001
+                    elif cfg.pack_dtype == torch.int32:
+                        submodule.qzeros.data += 0b00010001000100010001000100010001
+                    elif cfg.pack_dtype == torch.int16:
+                        submodule.qzeros.data += 0b0001000100010001
+                    elif cfg.pack_dtype == torch.int8:
+                        submodule.qzeros.data += 0b00010001
+                elif cfg.bits == 8:
+                    if cfg.pack_dtype == torch.int64:
+                        submodule.qzeros.data += 0b0000000100000001000000010000000100000001000000010000000100000001
+                    elif cfg.pack_dtype == torch.int32:
+                        submodule.qzeros.data += 0b00000001000000010000000100000001
+                    elif cfg.pack_dtype == torch.int16:
+                        submodule.qzeros.data += 0b0000000100000001
+                    elif cfg.pack_dtype == torch.int8:
+                        submodule.qzeros.data += 0b00000001
                 else:
                     raise NotImplementedError("Only 2,3,4,8 bits are supported.")
 
@@ -395,6 +420,7 @@ def pack_model(
     sym: bool = True,
     dynamic=None,
     parallel_packing: bool = True,
+    pack_dtype: torch.dtype = None,
 ):
     QuantLinear = select_quant_linear(
         bits=bits,
@@ -405,6 +431,7 @@ def pack_model(
         backend=backend,
         format=format,
         pack=True,
+        pack_dtype=pack_dtype,
     )
 
     model.to(CPU)
@@ -424,6 +451,7 @@ def pack_model(
         desc_act=desc_act,
         pack=True,
         dynamic=dynamic,
+        pack_dtype=pack_dtype,
     )
     qlayers = find_layers(model, [QuantLinear])
     names = list(qlayers.keys())

--- a/gptqmodel_ext/marlin/marlin_repack.cuh
+++ b/gptqmodel_ext/marlin/marlin_repack.cuh
@@ -12,5 +12,5 @@ __global__ void gptq_marlin_repack_kernel(
 
 torch::Tensor gptq_marlin_repack(torch::Tensor& b_q_weight, torch::Tensor& perm,
                                  int64_t size_k, int64_t size_n,
-                                 int64_t num_bits);
+                                 int64_t num_bits, int64_t pack_bits);
 


### PR DESCRIPTION
Allow quantized weights to be packed in:

* int32 (default, original gptq)
* int16
* int8

Some kernels/gpus may benefit to the different alignments for concurrent dequant

Completed Kernels: 

* [x] Torch
* [x] Triton
* [ ] Cuda
* [ ] Exllama
* [ ] Exllama v2
* [ ] Marlin
