### PR TITLE
fix(build): fix building from source with ROCm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,9 @@ def get_version_tag() -> str:
 
     import torch
 
+    if ROCM_VERSION:
+        return f"rocm{ROCM_VERSION}"
+
     cuda_version = os.environ.get("CUDA_VERSION", torch.version.cuda)
     if not cuda_version or not cuda_version.split("."):
         print(
@@ -106,8 +109,6 @@ def get_version_tag() -> str:
         )
         sys.exit(1)
 
-    if ROCM_VERSION:
-        return f"rocm{ROCM_VERSION}"
 
     CUDA_VERSION = "".join(cuda_version.split("."))
 


### PR DESCRIPTION
Fix for #1161 
Trying to build the package from source with ROCm for AMD GPUs fails as an environment variable `CUDA_VERSION` is required but not used anywhere.

Here I'm following the simple fix by changing the order of execution in the `get_version_tag` function in setup.py.
More information can be found in the Issue #1161