### PR TITLE
Remove overflow saftey code

### DIFF
--- a/gptqmodel_ext/exllama/cuda_func/q4_matmul.cu
+++ b/gptqmodel_ext/exllama/cuda_func/q4_matmul.cu
@@ -87,7 +87,7 @@ __global__ void q4_matmul_kernel
             if constexpr (use_half2)
             {
                 half2 w_scale = w_scales_.item_half2half2(group, w_column);
-                uint32_t w_zero = w_zeros_.item(group, w_column) & 0x0f;  // Avoid overflows.
+                uint32_t w_zero = w_zeros_.item(group, w_column); // & 0x0f;  // Avoid overflows.
 
                 if constexpr (use_x_map) acc = dot_product_8_x_map(acc, x_, x_row, k, w_, k, w_column, w_scale, w_zero, groupsize / 8, x_map);
                 else                     acc = dot_product_8      (acc, x_, x_row, k, w_, k, w_column, w_scale, w_zero, groupsize / 8);
@@ -95,7 +95,7 @@ __global__ void q4_matmul_kernel
             else
             {
                 half w_scale = w_scales_.item(group, w_column);
-                uint32_t w_zero = w_zeros_.item(group, w_column) & 0x0f;  // Avoid overflows.
+                uint32_t w_zero = w_zeros_.item(group, w_column); // & 0x0f;  // Avoid overflows.
 
                 if constexpr (use_x_map) acc_h = dot_product_8_x_map_h(acc_h, x_, x_row, k, w_, k, w_column, w_scale, w_zero, groupsize / 8, x_map);
                 else                     acc_h = dot_product_8_h      (acc_h, x_, x_row, k, w_, k, w_column, w_scale, w_zero, groupsize / 8);
@@ -112,7 +112,7 @@ __global__ void q4_matmul_kernel
             {
                 int group = k / groupsize;
                 half2 w_scale = w_scales_.item_half2half2(group, w_column);
-                uint32_t w_zero = w_zeros_.item(group, w_column) & 0x0f;  // Avoid overflows.
+                uint32_t w_zero = w_zeros_.item(group, w_column); // & 0x0f;  // Avoid overflows.
 
                 if constexpr (use_x_map) acc = dot_product_8_x_map(acc, x_, x_row, k, w_, k, w_column, w_scale, w_zero, 1, x_map);
                 else                     acc = dot_product_8      (acc, x_, x_row, k, w_, k, w_column, w_scale, w_zero, 1);
@@ -121,7 +121,7 @@ __global__ void q4_matmul_kernel
             {
                 int group = k / groupsize;
                 half w_scale = w_scales_.item(group, w_column);
-                uint32_t w_zero = w_zeros_.item(group, w_column) & 0x0f;  // Avoid overflows.
+                uint32_t w_zero = w_zeros_.item(group, w_column); // & 0x0f;  // Avoid overflows.
 
                 if constexpr (use_x_map) acc_h = dot_product_8_x_map_h(acc_h, x_, x_row, k, w_, k, w_column, w_scale, w_zero, 1, x_map);
                 else                     acc_h = dot_product_8_h      (acc_h, x_, x_row, k, w_, k, w_column, w_scale, w_zero, 1);

--- a/gptqmodel_ext/exllamav2/cuda/q_gemm_kernel_gptq.cuh
+++ b/gptqmodel_ext/exllamav2/cuda/q_gemm_kernel_gptq.cuh
@@ -125,10 +125,10 @@ __global__ void gemm_half_q_half_gptq_kernel
     b_gptq_scales_.item4_f(scales, group, n);
 
     // Avoid zeros overflow with & 0x0f.
-    dequant_4bit_8_prep_zero(zeros[0] & 0x0f, z1z16[0], y1y16[0]);
-    dequant_4bit_8_prep_zero(zeros[1] & 0x0f, z1z16[1], y1y16[1]);
-    dequant_4bit_8_prep_zero(zeros[2] & 0x0f, z1z16[2], y1y16[2]);
-    dequant_4bit_8_prep_zero(zeros[3] & 0x0f, z1z16[3], y1y16[3]);
+    dequant_4bit_8_prep_zero(zeros[0], z1z16[0], y1y16[0]); // & 0x0f
+    dequant_4bit_8_prep_zero(zeros[1], z1z16[1], y1y16[1]); // & 0x0f
+    dequant_4bit_8_prep_zero(zeros[2], z1z16[2], y1y16[2]); // & 0x0f
+    dequant_4bit_8_prep_zero(zeros[3], z1z16[3], y1y16[3]); // & 0x0f
 
 //    __syncthreads();
 
@@ -149,10 +149,10 @@ __global__ void gemm_half_q_half_gptq_kernel
             b_gptq_scales_.item4_f(scales, group, n);
 
             // Avoid zeros overflow with & 0x0f.
-            dequant_4bit_8_prep_zero(zeros[0] & 0x0f, z1z16[0], y1y16[0]);
-            dequant_4bit_8_prep_zero(zeros[1] & 0x0f, z1z16[1], y1y16[1]);
-            dequant_4bit_8_prep_zero(zeros[2] & 0x0f, z1z16[2], y1y16[2]);
-            dequant_4bit_8_prep_zero(zeros[3] & 0x0f, z1z16[3], y1y16[3]);
+            dequant_4bit_8_prep_zero(zeros[0], z1z16[0], y1y16[0]); // & 0x0f
+            dequant_4bit_8_prep_zero(zeros[1], z1z16[1], y1y16[1]); // & 0x0f
+            dequant_4bit_8_prep_zero(zeros[2], z1z16[2], y1y16[2]); // & 0x0f
+            dequant_4bit_8_prep_zero(zeros[3], z1z16[3], y1y16[3]); // & 0x0f
         }
 
         #pragma unroll

--- a/gptqmodel_ext/exllamav2/cuda/q_matrix.cu
+++ b/gptqmodel_ext/exllamav2/cuda/q_matrix.cu
@@ -236,10 +236,10 @@ __global__ void reconstruct_gptq_kernel
             b_gptq_scales_.item4_h2(scales, group, n);
 
             // Avoid zeros overflow with & 0x0f.
-            dequant_4bit_8_prep_zero(zeros[0] & 0x0f, z1z16[0], y1y16[0]);
-            dequant_4bit_8_prep_zero(zeros[1] & 0x0f, z1z16[1], y1y16[1]);
-            dequant_4bit_8_prep_zero(zeros[2] & 0x0f, z1z16[2], y1y16[2]);
-            dequant_4bit_8_prep_zero(zeros[3] & 0x0f, z1z16[3], y1y16[3]);
+            dequant_4bit_8_prep_zero(zeros[0], z1z16[0], y1y16[0]); // & 0x0f
+            dequant_4bit_8_prep_zero(zeros[1], z1z16[1], y1y16[1]); // & 0x0f
+            dequant_4bit_8_prep_zero(zeros[2], z1z16[2], y1y16[2]); // & 0x0f
+            dequant_4bit_8_prep_zero(zeros[3], z1z16[3], y1y16[3]); // & 0x0f
         }
 
         for (int p = 0; p < 4; p++)


### PR DESCRIPTION
How can decoded qweight and qzeros overlfow? This should not be possible unless quant code failed, packing failed, or de-quant failed.