### PR TITLE
Fix supported models list (syntax error)

### DIFF
--- a/gptqmodel/models/_const.py
+++ b/gptqmodel/models/_const.py
@@ -157,7 +157,7 @@ SUPPORTED_MODELS = [
     "cohere",
     "cohere2",
     "minicpm",
-    "minicpm3"
+    "minicpm3",
     "qwen2_moe",
     "qwen2_vl",
     "dbrx_converted",


### PR DESCRIPTION
* There was a missing ',' after minicpm which was breaking model detection
* I noticed this after trying to use the PR: https://github.com/ModelCloud/GPTQModel/pull/1116

* Test: Build on local and try out minicpmo