### PR TITLE
fix the error when downloading models using modelscope

### DIFF
--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -32,7 +32,6 @@ if os.getenv('GPTQMODEL_USE_MODELSCOPE', 'False').lower() in ['true', '1']:
 else:
     from huggingface_hub import snapshot_download
 
-from huggingface_hub import snapshot_download
 from packaging.version import InvalidVersion, Version
 from transformers import AutoConfig, AutoTokenizer, PretrainedConfig
 from transformers.modeling_utils import no_init_weights


### PR DESCRIPTION
Hi, I noticed an issue while using the gptqmodel. Even though I’ve set the environment variables properly, the model isn’t being downloaded from ModelScope. It seems like the code might be preventing the modelscope snapshot_download logic from executing entirely. 