### PR TITLE
Replace module hooking with tree-defined targeting

### DIFF
--- a/gptqmodel/looper/eora_processor.py
+++ b/gptqmodel/looper/eora_processor.py
@@ -29,7 +29,7 @@ from ..models import BaseGPTQModel
 from ..models.writer import (PROCESS_LOG_FWD_TIME, PROCESS_LOG_LAYER, PROCESS_LOG_MODULE,
                              PROCESS_LOG_NAME, PROCESS_LOG_TIME, PROCESS_MAX_MEMORY)
 from ..quantization.config import QuantizeConfig
-from ..quantization.gptq import CPU
+from ..quantization.gptq import CPU, CUDA_0, CUDA_1
 from ..utils.logger import setup_logger
 from ..utils.model import move_to
 from ..utils.torch import torch_compile, torch_sync

--- a/gptqmodel/looper/module_looper.py
+++ b/gptqmodel/looper/module_looper.py
@@ -27,7 +27,7 @@ from ..looper.loop_processor import LoopProcessor
 from ..looper.named_module import NamedModule
 from ..models import BaseGPTQModel
 from ..models._const import SUPPORTS_MODULE_TYPES
-from ..nn_modules.hooked_linear import replace_linear_with_hooked_linear
+from ..nn_modules.hooked_linear import replace_module_with_hooked_tree
 from ..quantization.gptq import CPU, CUDA_0, CUDA_1
 from ..utils.logger import setup_logger
 from ..utils.model import (find_modules, get_device, get_module, get_module_by_name_prefix,
@@ -86,7 +86,7 @@ class ModuleLooper():
         layers[0] = layers[0].to(self.gptq_model.quantize_config.device)
         ori_outside_layer_module_devices = {}
         for module_name in self.gptq_model.base_modules:
-            module = get_module_by_name_prefix(self.gptq_model.model, module_name)
+            module, _ = get_module_by_name_prefix(self.gptq_model.model, [module_name])
 
             if module is None:
                 continue
@@ -119,7 +119,7 @@ class ModuleLooper():
         handle.remove()
         move_to(layers[0], device=CPU)
         for module_name in self.gptq_model.base_modules:
-            module = get_module_by_name_prefix(self.gptq_model.model, module_name)
+            module, _ = get_module_by_name_prefix(self.gptq_model.model, [module_name])
             if module is not None:
                 move_to(module, device=ori_outside_layer_module_devices[module_name])
         if auto_gc:
@@ -153,7 +153,7 @@ class ModuleLooper():
         forward_pass_use_cache = self.gptq_model.model.config.use_cache if hasattr(self.gptq_model.model.config, "use_cache") else False
         self.gptq_model.model.config.use_cache = False
 
-        layers = get_module_by_name_prefix(self.gptq_model.model, self.gptq_model.layers_node)
+        layers, layers_prefix = get_module_by_name_prefix(self.gptq_model.model, self.gptq_model.layers_node)
 
         for p_index, processor in enumerate(self.processors):
             if not processor.verify_calibration_dataset(p_index):
@@ -200,8 +200,11 @@ class ModuleLooper():
 
         shared_kv_cache_dict = {}
 
-        # replace linear with hooked linear
-        replace_linear_with_hooked_linear(self.gptq_model.model)
+        # replace quantizable modules with hooked version
+        if self.gptq_model.layers_modules_tree:
+            replace_module_with_hooked_tree(self.gptq_model.model, self.gptq_model.layers_modules_tree)
+        else:
+            replace_module_with_hooked_legacy(self.gptq_model.model)
 
         for layer_index in quant_modules_pb:
             is_lm_head_module = layer_index >= layer_count
@@ -248,7 +251,7 @@ class ModuleLooper():
                     skipped_modules = []
 
                     for name in subset:
-                        layer_name = self.gptq_model.lm_head if is_lm_head_module else f"{self.gptq_model.layers_node}.{layer_index}.{name}"
+                        layer_name = self.gptq_model.lm_head if is_lm_head_module else f"{layers_prefix}.{layer_index}.{name}"
 
                         # gptq task is created and stored inside processor
                         if not isinstance(subset[name], NamedModule):

--- a/gptqmodel/looper/module_looper.py
+++ b/gptqmodel/looper/module_looper.py
@@ -27,7 +27,7 @@ from ..looper.loop_processor import LoopProcessor
 from ..looper.named_module import NamedModule
 from ..models import BaseGPTQModel
 from ..models._const import SUPPORTS_MODULE_TYPES
-from ..nn_modules.hooked_linear import replace_module_with_hooked_tree
+from ..nn_modules.hooked_linear import replace_module_with_hooked_legacy, replace_module_with_hooked_tree
 from ..quantization.gptq import CPU, CUDA_0, CUDA_1
 from ..utils.logger import setup_logger
 from ..utils.model import (find_modules, get_device, get_module, get_module_by_name_prefix,
@@ -202,7 +202,7 @@ class ModuleLooper():
 
         # replace quantizable modules with hooked version
         if self.gptq_model.layers_modules_tree:
-            replace_module_with_hooked_tree(self.gptq_model.model, self.gptq_model.layers_modules_tree)
+            replace_module_with_hooked_tree(self.gptq_model.model, self.gptq_model.layers_modules_tree, debug=False)
         else:
             replace_module_with_hooked_legacy(self.gptq_model.model)
 

--- a/gptqmodel/models/_const.py
+++ b/gptqmodel/models/_const.py
@@ -20,7 +20,6 @@ import torch
 import torch.nn as nn
 import transformers
 from torch import device
-from torch.nn.modules.conv import _ConvNd
 
 from ..utils import BACKEND
 from ..utils.rocm import IS_ROCM
@@ -34,7 +33,7 @@ XPU_0 = device("xpu:0")
 MPS = device("mps")
 ROCM = device("cuda:0")  # rocm maps to fake cuda
 
-SUPPORTS_MODULE_TYPES = [nn.Linear, _ConvNd, transformers.Conv1D]
+SUPPORTS_MODULE_TYPES = [nn.Linear, nn.Conv1d, nn.Conv2d, transformers.Conv1D]
 
 DEFAULT_MAX_SHARD_SIZE = "4GB"
 

--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -32,7 +32,7 @@ from transformers import (AutoModelForCausalLM, AutoProcessor, PreTrainedModel,
                           PreTrainedTokenizerBase, ProcessorMixin, modeling_utils)
 
 from ..adapter.adapter import Adapter
-from ..nn_modules.hooked_linear import replace_linear_with_hooked_linear
+from ..nn_modules.hooked_linear import replace_module_with_hooked_tree
 from ..nn_modules.qlinear import BaseQuantLinear
 from ..nn_modules.qlinear.torch import TorchQuantLinear
 from ..quantization import GPTQ, QuantizeConfig
@@ -81,6 +81,8 @@ class BaseGPTQModel(nn.Module):
     layer_type: Union[List[str], str] = None
     # for each repeating layer there are multiple modules within each layer
     layer_modules: List[List[str]] = None
+    # a tree node of all the roots that contain quantizable modules
+    layers_modules_tree: List[str] = None
 
     # Strict=True -> all layer_modules must exists in model
     # Some models (deepseek2-lite) dynamically create lora modules based on config.rank
@@ -876,7 +878,7 @@ class BaseGPTQModel(nn.Module):
         shared_kv_cache_dict = {}
 
         # replace linear with hooked linear
-        replace_linear_with_hooked_linear(self.model)
+        replace_module_with_hooked_tree(self.model)
 
         quantized_weights = {}
         for module_index in quant_modules_pb:
@@ -1313,7 +1315,7 @@ class BaseGPTQModel(nn.Module):
 
     def lm_head_pre_quantize_generate_hook(self, inputs: List[List[torch.tensor]]) -> List[List[torch.tensor]]:
         if self.pre_lm_head_norm_module:
-            norm = get_module_by_name_prefix(self.model, self.pre_lm_head_norm_module)
+            norm, _ = get_module_by_name_prefix(self.model, [self.pre_lm_head_norm_module])
             self.pre_quantize(norm)
 
             for element in inputs:

--- a/gptqmodel/models/definitions/baichuan.py
+++ b/gptqmodel/models/definitions/baichuan.py
@@ -23,7 +23,7 @@ class BaiChuanGPTQ(BaseGPTQModel):
     pre_lm_head_norm_module = "model.norm"
 
     # repeating layers
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "DecoderLayer"
     layer_modules = [
         ["self_attn.W_pack"],

--- a/gptqmodel/models/definitions/base_qwen2_vl.py
+++ b/gptqmodel/models/definitions/base_qwen2_vl.py
@@ -32,13 +32,23 @@ class BaseQwen2VLGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
 
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
         ["self_attn.o_proj"],
         ["mlp.up_proj", "mlp.gate_proj"],
         ["mlp.down_proj"],
+    ]
+
+    layers_modules_tree = [
+        "model",
+        "layers",
+        "#",
+        {
+            "self_attn": ("k_proj", "v_proj", "q_proj", "o_proj"),
+            "mlp": ("up_proj", "gate_proj", "down_proj"),
+        }
     ]
 
     modality = [MODALITY.TEXT, MODALITY.IMAGE_TO_TEXT]

--- a/gptqmodel/models/definitions/bloom.py
+++ b/gptqmodel/models/definitions/bloom.py
@@ -27,7 +27,7 @@ class BloomGPTQ(BaseGPTQModel):
     pre_lm_head_norm_module = "transformer.ln_f"
 
     # repeating layers
-    layers_node = "transformer.h"
+    layers_node = ["transformer.h"]
     layer_type = "BloomBlock"
     layer_modules = [
         ["self_attention.query_key_value"],

--- a/gptqmodel/models/definitions/chatglm.py
+++ b/gptqmodel/models/definitions/chatglm.py
@@ -27,7 +27,7 @@ class ChatGLM(BaseGPTQModel):
     base_modules = ["transformer.embedding.word_embeddings", "transformer.output_layer"]
     pre_lm_head_norm_module = "transformer.encoder.final_layernorm"
 
-    layers_node = "transformer.encoder.layers"
+    layers_node = ["transformer.encoder.layers"]
     layer_type = "GLMBlock"
     layer_modules = [
         ["self_attention.query_key_value"],

--- a/gptqmodel/models/definitions/codegen.py
+++ b/gptqmodel/models/definitions/codegen.py
@@ -21,7 +21,7 @@ class CodeGenGPTQ(BaseGPTQModel):
     base_modules = ["transformer.wte", "transformer.ln_f"]
     pre_lm_head_norm_module = "transformer.ln_f"
 
-    layers_node = "transformer.h"
+    layers_node = ["transformer.h"]
     layer_type = "CodeGenBlock"
     layer_modules = [
         ["attn.qkv_proj"],

--- a/gptqmodel/models/definitions/cohere.py
+++ b/gptqmodel/models/definitions/cohere.py
@@ -21,7 +21,7 @@ class CohereGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "CohereDecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/cohere2.py
+++ b/gptqmodel/models/definitions/cohere2.py
@@ -22,7 +22,7 @@ class Cohere2GPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "Cohere2DecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/dbrx_converted.py
+++ b/gptqmodel/models/definitions/dbrx_converted.py
@@ -24,7 +24,7 @@ class DbrxConvertedGPTQ(BaseGPTQModel):
     base_modules = ["transformer.wte", "transformer.norm_f"]
     pre_lm_head_norm_module = "transformer.norm_f"
 
-    layers_node = "transformer.blocks"
+    layers_node = ["transformer.blocks"]
     layer_type = "DbrxBlock"
     layer_modules = [
         ["norm_attn_norm.attn.q_proj", "norm_attn_norm.attn.k_proj", "norm_attn_norm.attn.v_proj"],

--- a/gptqmodel/models/definitions/decilm.py
+++ b/gptqmodel/models/definitions/decilm.py
@@ -24,7 +24,7 @@ class DeciLMGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "DeciLMDecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/deepseek_v2.py
+++ b/gptqmodel/models/definitions/deepseek_v2.py
@@ -30,7 +30,7 @@ class DeepSeekV2GPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "DeepseekV2DecoderLayer"
 
     # DeepSeek V2-Lite uses dynamic modules based on lora(rank):

--- a/gptqmodel/models/definitions/deepseek_v3.py
+++ b/gptqmodel/models/definitions/deepseek_v3.py
@@ -31,7 +31,7 @@ class DeepSeekV3GPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "DeepseekV3DecoderLayer"
 
     # DeepSeek V3 uses dynamic modules based on lora(rank):

--- a/gptqmodel/models/definitions/dream.py
+++ b/gptqmodel/models/definitions/dream.py
@@ -30,7 +30,7 @@ class DreamGPTQ(BaseGPTQModel):
 
     # Below describes all the repeating layers in this transformer model
     # `model.layers` is a node/module that hold all the repeating layers. The parent node for all n-layers.
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     # Each repeating layer in `model.layers` is of type `LlamaDecoderLayer`
     layer_type = "DreamDecoderLayer"
     # Inside each `LlamaDecoderLayer` layer are many internal modules

--- a/gptqmodel/models/definitions/exaone.py
+++ b/gptqmodel/models/definitions/exaone.py
@@ -24,7 +24,7 @@ class ExaoneGPTQ(BaseGPTQModel):
     base_modules = ["transformer.ln_f", "transformer.wte"]
     pre_lm_head_norm_module = "transformer.ln_f"
 
-    layers_node = "transformer.h"
+    layers_node = ["transformer.h"]
     layer_type = "ExaoneBlock"
     layer_modules = [
         ["attn.attention.k_proj", "attn.attention.v_proj", "attn.attention.q_proj"],

--- a/gptqmodel/models/definitions/gemma.py
+++ b/gptqmodel/models/definitions/gemma.py
@@ -21,7 +21,7 @@ class GemmaGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "GemmaDecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/gemma2.py
+++ b/gptqmodel/models/definitions/gemma2.py
@@ -26,7 +26,7 @@ class Gemma2GPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "Gemma2DecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/gemma3.py
+++ b/gptqmodel/models/definitions/gemma3.py
@@ -21,7 +21,7 @@ class Gemma3GPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "Gemma3DecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/glm.py
+++ b/gptqmodel/models/definitions/glm.py
@@ -22,7 +22,7 @@ class GLM(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "GlmDecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/gpt2.py
+++ b/gptqmodel/models/definitions/gpt2.py
@@ -21,7 +21,7 @@ class GPT2GPTQ(BaseGPTQModel):
     base_modules = ["transformer.wte", "transformer.wpe", "transformer.ln_f"]
     pre_lm_head_norm_module = "transformer.ln_f"
 
-    layers_node = "transformer.h"
+    layers_node = ["transformer.h"]
     layer_type = "GPT2Block"
     layer_modules = [
         ["attn.c_attn"],

--- a/gptqmodel/models/definitions/gpt_bigcode.py
+++ b/gptqmodel/models/definitions/gpt_bigcode.py
@@ -21,7 +21,7 @@ class GPTBigCodeGPTQ(BaseGPTQModel):
     base_modules = ["transformer.wpe", "transformer.wte", "transformer.ln_f"]
     pre_lm_head_norm_module = "transformer.ln_f"
 
-    layers_node = "transformer.h"
+    layers_node = ["transformer.h"]
     layer_type = "GPTBigCodeBlock"
     layer_modules = [
         ["attn.c_attn"],

--- a/gptqmodel/models/definitions/gpt_neox.py
+++ b/gptqmodel/models/definitions/gpt_neox.py
@@ -22,7 +22,7 @@ class GPTNeoXGPTQ(BaseGPTQModel):
     pre_lm_head_norm_module = "gpt_neox.final_layer_norm"
     lm_head = "embed_out"
 
-    layers_node = "gpt_neox.layers"
+    layers_node = ["gpt_neox.layers"]
     layer_type = "GPTNeoXLayer"
     layer_modules = [
         ["attention.query_key_value"],

--- a/gptqmodel/models/definitions/gptj.py
+++ b/gptqmodel/models/definitions/gptj.py
@@ -21,7 +21,7 @@ class GPTJGPTQ(BaseGPTQModel):
     base_modules = ["transformer.wte", "transformer.ln_f"]
     pre_lm_head_norm_module = "transformer.ln_f"
 
-    layers_node = "transformer.h"
+    layers_node = ["transformer.h"]
     layer_type = "GPTJBlock"
     layer_modules = [
         ["attn.k_proj", "attn.v_proj", "attn.q_proj"],

--- a/gptqmodel/models/definitions/granite.py
+++ b/gptqmodel/models/definitions/granite.py
@@ -21,7 +21,7 @@ class GraniteGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "GraniteDecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/grinmoe.py
+++ b/gptqmodel/models/definitions/grinmoe.py
@@ -27,7 +27,7 @@ class GrinMOEGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "GRINMoEDecoderLayer"
     layer_modules = [
         ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj"],

--- a/gptqmodel/models/definitions/hymba.py
+++ b/gptqmodel/models/definitions/hymba.py
@@ -33,7 +33,7 @@ class HymbaGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.final_layernorm"]
     pre_lm_head_norm_module = "model.final_layernorm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "HymbaDecoderLayer"
     layer_modules = [
         ["mamba.in_proj"],

--- a/gptqmodel/models/definitions/instella.py
+++ b/gptqmodel/models/definitions/instella.py
@@ -23,7 +23,7 @@ class InstellaGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "InstellaDecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/internlm.py
+++ b/gptqmodel/models/definitions/internlm.py
@@ -23,7 +23,7 @@ class InternLMGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "InternLMDecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/internlm2.py
+++ b/gptqmodel/models/definitions/internlm2.py
@@ -24,7 +24,7 @@ class InternLM2GPTQ(BaseGPTQModel):
     base_modules = ["model.tok_embeddings", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "InternLM2DecoderLayer"
     layer_modules = [
         ["attention.wqkv", "attention.wo"],

--- a/gptqmodel/models/definitions/llama.py
+++ b/gptqmodel/models/definitions/llama.py
@@ -25,9 +25,25 @@ class LlamaGPTQ(BaseGPTQModel):
 
     # Below describes all the repeating layers in this transformer model
     # `model.layers` is a node/module that hold all the repeating layers. The parent node for all n-layers.
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     # Each repeating layer in `model.layers` is of type `LlamaDecoderLayer`
     layer_type = "LlamaDecoderLayer"
+
+    # Full tree of quantizable modules
+    # `#` means match any number
+    # List[] for serial top/down nodes
+    # Dict{} for nested nodes
+    # Tuple() for target_nodes, final modules to quantize
+    layers_modules_tree = [
+        "model",
+        "layers",
+        "#",
+        {
+            "self_attn": ("k_proj", "v_proj", "q_proj", "o_proj"),
+            "mlp": ("up_proj", "gate_proj", "down_proj"),
+        }
+    ]
+
     # Inside each `LlamaDecoderLayer` layer are many internal modules
     # List them in the order executed in model forward() code
     # Many models have same execution order of: attention (q_k_v) projection, attention (output) projection, mlp (n) projections

--- a/gptqmodel/models/definitions/llama.py
+++ b/gptqmodel/models/definitions/llama.py
@@ -31,9 +31,9 @@ class LlamaGPTQ(BaseGPTQModel):
 
     # Full tree of quantizable modules
     # `#` means match any number
-    # List[] for serial top/down nodes
-    # Dict{} for nested nodes
-    # Tuple() for target_nodes, final modules to quantize
+    # List[str] for serial linked nodes. List str are linear depth linked modules presented in a linear fashion with no divergence.
+    # Dict{str: List[str] | Dict[str]} for diverging nodes where a node splits into multiple paths/nodes.
+    # Tuple(str) for final targeted modules/nodes: there are only strings representing the final targeted modules
     layers_modules_tree = [
         "model",
         "layers",

--- a/gptqmodel/models/definitions/llama.py
+++ b/gptqmodel/models/definitions/llama.py
@@ -30,9 +30,9 @@ class LlamaGPTQ(BaseGPTQModel):
     layer_type = "LlamaDecoderLayer"
 
     # Full tree of quantizable modules
-    # `#` means match any number
+    # `#` str will match any number: useful for layers and moe indexing.
     # List[str] for serial linked nodes. List str are linear depth linked modules presented in a linear fashion with no divergence.
-    # Dict{str: List[str] | Dict[str]} for diverging nodes where a node splits into multiple paths/nodes.
+    # Dict{str: List[str] | Dict | Tuple[str]} for diverging nodes where a node splits into multiple paths/nodes.
     # Tuple(str) for final targeted modules/nodes: there are only strings representing the final targeted modules
     layers_modules_tree = [
         "model",

--- a/gptqmodel/models/definitions/longllama.py
+++ b/gptqmodel/models/definitions/longllama.py
@@ -21,7 +21,7 @@ class LongLlamaGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "LongLlamaDecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/minicpm.py
+++ b/gptqmodel/models/definitions/minicpm.py
@@ -21,7 +21,7 @@ class MiniCPMGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens",]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "MiniCPMDecoderLayer"
     layer_modules = [
         ["self_attn.q_proj"],

--- a/gptqmodel/models/definitions/minicpm3.py
+++ b/gptqmodel/models/definitions/minicpm3.py
@@ -21,7 +21,7 @@ class MiniCPM3GPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens",]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "MiniCPM3DecoderLayer"
     layer_modules = [
         ["self_attn.q_a_proj","self_attn.kv_a_proj_with_mqa"],

--- a/gptqmodel/models/definitions/mistral.py
+++ b/gptqmodel/models/definitions/mistral.py
@@ -21,7 +21,7 @@ class MistralGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "MistralDecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/mixtral.py
+++ b/gptqmodel/models/definitions/mixtral.py
@@ -21,7 +21,7 @@ class MixtralGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "MixtralDecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/mllama.py
+++ b/gptqmodel/models/definitions/mllama.py
@@ -31,7 +31,7 @@ class MLlamaGPTQ(BaseGPTQModel):
 
     # Below describes all the repeating layers in this transformer model
     # `model.layers` is a node/module that hold all the repeating layers. The parent node for all n-layers.
-    layers_node = "language_model.model.layers"
+    layers_node = ["language_model.model.layers"]
     # MLllama has two types of repeating layers. Repeats in groups of 4 layers: 0-2 (first 3 layers) is text layers, 3 (4th) is cross-attention layer for vision
     layer_type = "MllamaSelfAttentionDecoderLayer"
     # Inside each `LlamaDecoderLayer` layer are many internal modules

--- a/gptqmodel/models/definitions/mobilellm.py
+++ b/gptqmodel/models/definitions/mobilellm.py
@@ -23,7 +23,7 @@ class MobileLLMGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "LlamaDecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/moss.py
+++ b/gptqmodel/models/definitions/moss.py
@@ -21,7 +21,7 @@ class MOSSGPTQ(BaseGPTQModel):
     base_modules = ["transformer.wte", "transformer.ln_f"]
     pre_lm_head_norm_module = "transformer.ln_f"
 
-    layers_node = "transformer.h"
+    layers_node = ["transformer.h"]
     layer_type = "MossBlock"
     layer_modules = [
         ["attn.qkv_proj"],

--- a/gptqmodel/models/definitions/mpt.py
+++ b/gptqmodel/models/definitions/mpt.py
@@ -21,7 +21,7 @@ class MPTGPTQ(BaseGPTQModel):
     base_modules = ["transformer.wte", "transformer.norm_f"]
     pre_lm_head_norm_module = "transformer.norm_f"
 
-    layers_node = "transformer.blocks"
+    layers_node = ["transformer.blocks"]
     layer_type = "MPTBlock"
     layer_modules = [
         ["attn.Wqkv"],

--- a/gptqmodel/models/definitions/olmo2.py
+++ b/gptqmodel/models/definitions/olmo2.py
@@ -22,7 +22,7 @@ class Olmo2GPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "Olmo2DecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/opt.py
+++ b/gptqmodel/models/definitions/opt.py
@@ -31,7 +31,7 @@ class OPTGPTQ(BaseGPTQModel):
     ]
     pre_lm_head_norm_module = "model.decoder.final_layer_norm"
 
-    layers_node = "model.decoder.layers"
+    layers_node = ["model.decoder.layers"]
     layer_type = "OPTDecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
@@ -44,7 +44,7 @@ class OPTGPTQ(BaseGPTQModel):
         if self.config.do_layer_norm_before and not self.config._remove_final_layer_norm:
             inputs = super().lm_head_pre_quantize_generate_hook(inputs)
 
-        project_out = get_module_by_name_prefix(self.model, "model.decoder.project_out")
+        project_out, _ = get_module_by_name_prefix(self.model, ["model.decoder.project_out"])
         if project_out is not None:
             self.pre_quantize(project_out)
 

--- a/gptqmodel/models/definitions/ovis.py
+++ b/gptqmodel/models/definitions/ovis.py
@@ -31,9 +31,35 @@ class OvisGPTQ(BaseGPTQModel):
     base_modules = ["llm.model.embed_tokens", "llm.model.norm", "visual_tokenizer", "vte"]
     pre_lm_head_norm_module = "llm.model.norm"
 
-    layers_node = "llm.model.layers"
+    layers_node = ["llm.model.layers"] #, "visual_tokenizer.backbone.trunk.blocks"]
     layer_type = ["LlamaDecoderLayer", "Gemma2DecoderLayer", "Qwen2DecoderLayer"]
+
+    layers_modules_tree = {
+        # "visual_tokenizer": [
+        #     "backbone",
+        #     "trunk",
+        #     "blocks",
+        #     "#",
+        #     {
+        #         "attn": ("qkv", "proj"),
+        #         "mlp": ("fc1", "fc2", "fc3"),
+        #     },
+        # ],
+        "llm": [
+            "model",
+            "layers",
+            "#",
+            {
+                "self_attn": ("k_proj", "v_proj", "q_proj", "o_proj"),
+                "mlp": ("up_proj", "gate_proj", "down_proj"),
+            }
+        ],
+    }
+
+    layer_modules_strict = False # the layer modules are in different decode layers
     layer_modules = [
+        ["qkv", "proj"],
+        ["fc1", "fc2", "fc3"],
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
         ["self_attn.o_proj"],
         ["mlp.up_proj", "mlp.gate_proj"],

--- a/gptqmodel/models/definitions/phi.py
+++ b/gptqmodel/models/definitions/phi.py
@@ -21,7 +21,7 @@ class PhiGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.final_layernorm"]
     pre_lm_head_norm_module = "model.final_layernorm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "PhiDecoderLayer"
     layer_modules = [
         ["self_attn.q_proj"],

--- a/gptqmodel/models/definitions/phi3.py
+++ b/gptqmodel/models/definitions/phi3.py
@@ -22,7 +22,7 @@ class Phi3GPTQ(BaseGPTQModel):
     pre_lm_head_norm_module = "model.norm"
 
     layers_node = "model.layers"
-    layer_type = "Phi3DecoderLayer"
+    layer_type = ["Phi3DecoderLayer"]
     layer_modules = [
         ["self_attn.qkv_proj"],
         ["self_attn.o_proj"],

--- a/gptqmodel/models/definitions/qwen.py
+++ b/gptqmodel/models/definitions/qwen.py
@@ -26,7 +26,7 @@ class QwenGPTQ(BaseGPTQModel):
     ]
     pre_lm_head_norm_module = "transformer.ln_f"
 
-    layers_node = "transformer.h"
+    layers_node = ["transformer.h"]
     layer_type = "QWenBlock"
     layer_modules = [
         ["attn.c_attn"],

--- a/gptqmodel/models/definitions/qwen2.py
+++ b/gptqmodel/models/definitions/qwen2.py
@@ -21,11 +21,21 @@ class Qwen2GPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "Qwen2DecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
         ["self_attn.o_proj"],
         ["mlp.up_proj", "mlp.gate_proj"],
         ["mlp.down_proj"],
+    ]
+
+    layers_modules_tree = [
+        "model",
+        "layers",
+        "#",
+        {
+            "self_attn": ("k_proj", "v_proj", "q_proj", "o_proj"),
+            "mlp": ("up_proj", "gate_proj", "down_proj"),
+        }
     ]

--- a/gptqmodel/models/definitions/qwen2_moe.py
+++ b/gptqmodel/models/definitions/qwen2_moe.py
@@ -26,15 +26,31 @@ class Qwen2MoeGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "Qwen2DecoderLayer"
     layer_modules = [
         ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj"],
         ["self_attn.o_proj"],
+
         ["mlp.shared_expert.up_proj", "mlp.shared_expert.gate_proj"],
         ["mlp.shared_expert.down_proj"],
 
         # uses dynamic_expert_index
         [f"mlp.experts.{EXPERT_INDEX_PLACEHOLDER}.up_proj", f"mlp.experts.{EXPERT_INDEX_PLACEHOLDER}.gate_proj"],
         [f"mlp.experts.{EXPERT_INDEX_PLACEHOLDER}.down_proj"],
+    ]
+
+    layers_modules_tree = [
+        "model",
+        "layers",
+        "#",
+        {
+            "self_attn": ("k_proj", "v_proj", "q_proj", "o_proj"),
+            "mlp": {
+                "shared_expert": ("up_proj", "gate_proj", "down_proj"),
+                "experts": {
+                    "#": ("up_proj", "gate_proj", "down_proj"),
+                },
+            },
+        }
     ]

--- a/gptqmodel/models/definitions/qwen3.py
+++ b/gptqmodel/models/definitions/qwen3.py
@@ -21,11 +21,21 @@ class Qwen3GPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "Qwen3DecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
         ["self_attn.o_proj"],
         ["mlp.up_proj", "mlp.gate_proj"],
         ["mlp.down_proj"],
+    ]
+
+    layers_modules_tree = [
+        "model",
+        "layers",
+        "#",
+        {
+            "self_attn": ("k_proj", "v_proj", "q_proj", "o_proj"),
+            "mlp": ("up_proj", "gate_proj", "down_proj"),
+        }
     ]

--- a/gptqmodel/models/definitions/qwen3_moe.py
+++ b/gptqmodel/models/definitions/qwen3_moe.py
@@ -26,15 +26,27 @@ class Qwen3MoeGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "Qwen3DecoderLayer"
     layer_modules = [
         ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj"],
         ["self_attn.o_proj"],
-        # ["mlp.shared_expert.up_proj", "mlp.shared_expert.gate_proj"],
-        # ["mlp.shared_expert.down_proj"],
 
         # uses dynamic_expert_index
         [f"mlp.experts.{EXPERT_INDEX_PLACEHOLDER}.up_proj", f"mlp.experts.{EXPERT_INDEX_PLACEHOLDER}.gate_proj"],
         [f"mlp.experts.{EXPERT_INDEX_PLACEHOLDER}.down_proj"],
+    ]
+
+    layers_modules_tree = [
+        "model",
+        "layers",
+        "#",
+        {
+            "self_attn": ("k_proj", "v_proj", "q_proj", "o_proj"),
+            "mlp": {
+                "experts": {
+                    "#": ("up_proj", "gate_proj", "down_proj"),
+                },
+            },
+        }
     ]

--- a/gptqmodel/models/definitions/rw.py
+++ b/gptqmodel/models/definitions/rw.py
@@ -21,7 +21,7 @@ class RWGPTQ(BaseGPTQModel):
     base_modules = ["transformer.word_embeddings", "transformer.ln_f"]
     pre_lm_head_norm_module = "transformer.ln_f"
 
-    layers_node = "transformer.h"
+    layers_node = ["transformer.h"]
     layer_type = "DecoderLayer"
     layer_modules = [
         ["self_attention.query_key_value"],

--- a/gptqmodel/models/definitions/stablelmepoch.py
+++ b/gptqmodel/models/definitions/stablelmepoch.py
@@ -21,7 +21,7 @@ class StableLMEpochGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "DecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/starcoder2.py
+++ b/gptqmodel/models/definitions/starcoder2.py
@@ -21,7 +21,7 @@ class Starcoder2GPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "Starcoder2DecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/definitions/telechat2.py
+++ b/gptqmodel/models/definitions/telechat2.py
@@ -10,7 +10,7 @@ class TeleChat2GPTQ(BaseGPTQModel):
     require_dtype = torch.float16
 
     layer_type = "TelechatBlock"
-    layers_node = "transformer.h"
+    layers_node = ["transformer.h"]
     base_modules = ["transformer.word_embeddings", "transformer.ln_f"]
     pre_lm_head_norm_module = "transformer.ln_f"
 

--- a/gptqmodel/models/definitions/yi.py
+++ b/gptqmodel/models/definitions/yi.py
@@ -21,7 +21,7 @@ class YiGPTQ(BaseGPTQModel):
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"
 
-    layers_node = "model.layers"
+    layers_node = ["model.layers"]
     layer_type = "YiDecoderLayer"
     layer_modules = [
         ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],

--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -446,7 +446,7 @@ def ModelLoader(cls):
                 if qcfg.lm_head and name == cls.lm_head:
                     continue
 
-                if not name.startswith(cls.layers_node) or any(name.startswith(ignore_module) for ignore_module in ignore_modules) or all(
+                if not any(name.startswith(prefix) for prefix in cls.layers_node) or any(name.startswith(ignore_module) for ignore_module in ignore_modules) or all(
                         not name.endswith(ignore_module) for sublist in cls.layer_modules for ignore_module in sublist
                 ):
                     # log non-lm-head quantized modules only

--- a/gptqmodel/nn_modules/hooked_linear.py
+++ b/gptqmodel/nn_modules/hooked_linear.py
@@ -13,74 +13,32 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Optional, Tuple, Union
+import copy
+from typing import Dict, List, Tuple, Union
 
 import torch
 import transformers
-from torch import Tensor
-from torch.nn.modules.conv import _ConvNd
+from torch import nn
 
+from ..utils.logger import setup_logger
 
-class HookedConvND(_ConvNd):
-    def __init__(self,
-        weight: Tensor,
-        in_channels: int,
-        out_channels: int,
-        kernel_size: Tuple[int, ...],
-        stride: Tuple[int, ...],
-        padding: Union[str, Tuple[int, ...]],
-        dilation: Tuple[int, ...],
-        transposed: bool,
-        output_padding: Tuple[int, ...],
-        groups: int,
-        padding_mode: str,
-        bias: Optional[Tensor],
-        _reversed_padding_repeated_twice: List[int]):
+log = setup_logger()
 
+# Models using conv1d: gpt2
+class HookedConv1D(transformers.Conv1D):
+    def __init__(self, nf: int, nx: int) -> None:
         torch.nn.Module.__init__(self)
-        self.in_channels = in_channels
-        self.out_channels = out_channels
-        self.kernel_size = kernel_size
-        self.stride = stride
-        self.padding = padding
-        self.dilation = dilation
-        self.transposed = transposed
-        self.output_padding = output_padding
-        self.groups = groups
-        self.padding_mode = padding_mode
-        self.weight = weight
-        self.bias = bias
-        self._reversed_padding_repeated_twice = _reversed_padding_repeated_twice
-
+        self.nf = nf
+        self.nx = nx
         self.forward_hook = None
 
     @staticmethod
-    def from_convNd(module: _ConvNd):
-        # "stride",
-        # "padding",
-        # "dilation",
-        # "groups",
-        # "padding_mode",
-        # "output_padding",
-        # "in_channels",
-        # "out_channels",
-        # "kernel_size",
-        #
-        return HookedConvND(
-            weight=module.weight,
-            bias=module.bias,
-            in_channels=module.in_channels,
-            out_channels=module.out_channels,
-            kernel_size=module.kernel_size,
-            stride=module.stride,
-            padding=module.padding,
-            dilation=module.dilation,
-            transposed=module.transposed,
-            output_padding=module.output_padding,
-            groups=module.groups,
-            padding_mode=module.padding_mode,
-            _reversed_padding_repeated_twice=module._reversed_padding_repeated_twice,
-        )
+    def from_conv1d(m: transformers.Conv1D):
+        assert isinstance(m, transformers.Conv1D)
+        custom = HookedConv1D(m.nf, m.nx)
+        custom.weight = m.weight
+        custom.bias = m.bias
+        return custom
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         output = super().forward(input)
@@ -88,8 +46,113 @@ class HookedConvND(_ConvNd):
             self.forward_hook(self, (input,), output)
         return output
 
-# Models using conv1d: gpt2
-class HookedConv1D(transformers.Conv1D):
+class HookedConv1d(torch.nn.Conv1d):
+    def __init__(
+        self,
+    ) -> None:
+        # in_channels,
+        # out_channels,
+        # kernel_size,
+        # stride,
+        # padding,
+        # dilation,
+        # groups,
+        # padding_mode,
+        torch.nn.Module.__init__(self)
+        # TODO: call super().__init__() is too slow, need to find a better way
+        # super().__init__(
+        #     in_channels,
+        #     out_channels,
+        #     kernel_size,
+        #     stride,
+        #     padding,
+        #     dilation,
+        #     groups,
+        #     padding_mode,
+        # )
+        self.forward_hook = None
+
+    @staticmethod
+    def from_conv1d(m: torch.nn.Conv1d):
+        assert isinstance(m, torch.nn.Conv1d)
+
+        custom = HookedConv1d()
+        custom.in_channels = m.in_channels
+        custom.out_channels = m.out_channels
+        custom.kernel_size = m.kernel_size
+        custom.stride = m.stride
+        custom.padding = m.padding
+        custom.dilation = m.dilation
+        custom.transposed = m.transposed
+        custom.output_padding = m.output_padding
+        custom.groups = m.groups
+        custom.padding_mode = m.padding_mode
+
+        custom.weight = m.weight
+        custom.bias = m.bias
+        return custom
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        output = super().forward(input)
+        if self.forward_hook:
+            self.forward_hook(self, (input,), output)
+        return output
+
+# Models using conv2d: ovis
+class HookedConv2d(torch.nn.Conv2d):
+    def __init__(
+        self,
+    ) -> None:
+        # in_channels,
+        # out_channels,
+        # kernel_size,
+        # stride,
+        # padding,
+        # dilation,
+        # groups,
+        # padding_mode,
+        torch.nn.Module.__init__(self)
+        # TODO: call super().__init__() is too slow, need to find a better way
+        # super().__init__(
+        #     in_channels,
+        #     out_channels,
+        #     kernel_size,
+        #     stride,
+        #     padding,
+        #     dilation,
+        #     groups,
+        #     padding_mode,
+        # )
+        self.forward_hook = None
+
+    @staticmethod
+    def from_conv2d(m: torch.nn.Conv2d):
+        assert isinstance(m, torch.nn.Conv2d)
+
+        custom = HookedConv2d()
+        custom.in_channels = m.in_channels
+        custom.out_channels = m.out_channels
+        custom.kernel_size = m.kernel_size
+        custom.stride = m.stride
+        custom.padding = m.padding
+        custom.dilation = m.dilation
+        custom.transposed = m.transposed
+        custom.output_padding = m.output_padding
+        custom.groups = m.groups
+        custom.padding_mode = m.padding_mode
+
+        custom.weight = m.weight
+        custom.bias = m.bias
+        return custom
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        output = super().forward(input)
+        if self.forward_hook:
+            self.forward_hook(self, (input,), output)
+        return output
+
+# Models using transformers.conv1d: gpt2
+class HookedTransformerConv1D(transformers.Conv1D):
     def __init__(self, nf: int, nx: int) -> None:
         torch.nn.Module.__init__(self)
         self.nf = nf
@@ -109,30 +172,9 @@ class HookedConv1D(transformers.Conv1D):
             self.forward_hook(self, (input,), output)
         return output
 
-# Models using conv2d: ovis
-# class HookedConv2d(torch.nn.Conv2d):
-#     def __init__(self, in_channels: int, out_channels: int, kernel_size: int, stride: int, padding: int) -> None:
-#         # TODO: call super().__init__() is too slow, need to find a better way
-#         super().__init__(in_channels, out_channels, kernel_size, stride, padding)
-#         self.forward_hook = None
-#
-#     @staticmethod
-#     def from_conv2d(conv2d: torch.nn.Conv2d):
-#         custom_conv2d = HookedConv2d(conv2d.in_channels, conv2d.out_channels, conv2d.kernel_size, conv2d.stride, conv2d.padding)
-#         custom_conv2d.weight = conv2d.weight
-#         custom_conv2d.bias = conv2d.bias
-#         return custom_conv2d
-#
-#     def forward(self, input: torch.Tensor) -> torch.Tensor:
-#         output = super().forward(input)
-#         if self.forward_hook:
-#             self.forward_hook(self, (input,), output)
-#         return output
-
-
 class HookedLinear(torch.nn.Linear):
     def __init__(self, in_features: int, out_features: int) -> None:
-        # avoid calling super().__init__() as it would allocate memory baased on in/out features
+        # avoid calling super().__init__() as it would allocate memory based on in/out features
         torch.nn.Module.__init__(self)
         self.in_features = in_features
         self.out_features = out_features
@@ -152,16 +194,114 @@ class HookedLinear(torch.nn.Linear):
             self.forward_hook(self, (input,), output)
         return output
 
-
-def replace_linear_with_hooked_linear(module):
+def replace_module_with_hooked_legacy(module):
     for name, child in module.named_children():
         if isinstance(child, torch.nn.Linear):
             setattr(module, name, HookedLinear.from_linear(child))
-        elif isinstance(child, _ConvNd):
-            setattr(module, name, HookedConvND.from_convNd(child))
+        elif isinstance(child, nn.Conv1d):
+            setattr(module, name, HookedConv1d.from_conv1d(child))
+        elif isinstance(child, nn.Conv2d):
+            setattr(module, name, HookedConv2d.from_conv2d(child))
         elif isinstance(child, transformers.Conv1D):
             setattr(module, name, HookedConv1D.from_conv1d(child))
         # elif isinstance(child, torch.nn.Conv2d):
         #     setattr(module, name, HookedConv2d.from_conv2d(child))
         else:
-            replace_linear_with_hooked_linear(child)
+            replace_module_with_hooked_legacy(child)
+
+def replace_module_with_hooked_tree(module, tree: Union[List,Dict] = [], level: int = 0, debug: bool = False):
+    tree = copy.copy(tree) # defensive copy
+
+    # tuple represents targeted modules
+    execute_replace = isinstance(tree, Tuple)
+
+    # level indent
+    level_indent = "---" * level
+
+    for name, child in module.named_children():
+        log.info(f"{level_indent} child name: {name}")
+        if execute_replace:
+            if name in tree:
+                if isinstance(child, torch.nn.Linear):
+                    log.info(f"{level_indent} Hook: nn.Linear: {name}")
+                    setattr(module, name, HookedLinear.from_linear(child))
+                elif isinstance(child, transformers.Conv1D):
+                    log.info(f"{level_indent} Hook: transformers.Conv1D: {name}")
+                    setattr(module, name, HookedTransformerConv1D.from_conv1d(child))
+                elif isinstance(child, nn.Conv1d):
+                    log.info(f"{level_indent} Hook: nn.Conv1d: {name}")
+                    setattr(module, name, HookedConv1d.from_conv1d(child))
+                elif isinstance(child, nn.Conv2d):
+                    log.info(f"{level_indent} Hook: nn.Conv2d: {name}")
+                    setattr(module, name, HookedConv2d.from_conv2d(child))
+                else:
+                    log.error(f"{level_indent} Hook: execute_replace but layer skipped due to type not supported: {name}")
+            else:
+                log.warn(f"{level_indent} Hook: execute_replace but layer skipped due to not targeted: {name}")
+        else:
+            if isinstance(tree, Dict):
+                if name in tree:
+                    log.info(f"{level_indent} Hook: follow tree node: {name} -> nest into {name}")
+                    replace_module_with_hooked_tree(child, tree=tree[name],
+                                                    level=level + 1, debug=debug)
+                elif "#" in tree and name.isdigit():
+                    log.info(f"{level_indent} Hook: follow tree node: {name} -> nest into {name}")
+                    replace_module_with_hooked_tree(child, tree=tree["#"],
+                                                    level=level + 1, debug=debug)
+                else:
+                    log.warn(f"{level_indent} Hook: skipped unknown tree node dict: {name} vs tree: {tree}")
+            elif isinstance(tree, List):
+                next_node = tree[0]
+                if isinstance(next_node, Dict):
+                    if name in next_node:
+                        log.info(f"{level_indent} Hook: follow tree node: {name} -> nest into {name}")
+                        replace_module_with_hooked_tree(child, tree=next_node[name],
+                                                        level=level + 1, debug=debug)
+                    elif name.isdigit and "#" in next_node:
+                        log.info(f"{level_indent} Hook: follow tree node: {name} -> nest into {name}")
+                        replace_module_with_hooked_tree(child, tree=next_node["#"],
+                                                        level=level + 1, debug=debug)
+                    else:
+                        log.warn(
+                            f"{level_indent} Hook: skipped unknown tree node dict: {name} vs next_node: {next_node}")
+                elif name == next_node or (next_node == "#" and name.isdigit()):
+                    log.info(f"{level_indent} Hook: follow tree node: {name} -> nest into {name}")
+                    replace_module_with_hooked_tree(child, tree=tree[1:],
+                                                    level=level + 1, debug=debug)
+                else:
+                    log.warn(f"{level_indent} Hook: skipped unknown tree node list: {name} vs next_node: {next_node}")
+
+            # if len(tree) > 0:
+            #     # list or dict
+            #     node = next(tree_iter)
+            #     log.info(f"{level_indent} next node: {node}")
+            #
+            #     # matched user designed tree node/path
+            #     if name == node or (node == "#" and name.isdigit()):
+            #         log.info(f"{level_indent} Hook: follow tree node: {node} -> nest into {name}")
+            #         replace_module_with_hooked(child, tree=tree[1:] if isinstance(tree, List) else tree[name], level=level + 1, debug=debug)
+            #     # # list: simple node
+            #     # elif isinstance(node, List):
+            #     #     if name in node:
+            #     #         log.info(f"{level_indent} Hook: follow tree node list: {node} -> {name} -> nest into {name}")
+            #     #         replace_module_with_hooked(child, tree=tree[1:], level=level + 1, debug=debug)
+            #     #     elif name.isdigit() and "#" in node:
+            #     #         log.info(f"{level_indent} Hook: follow tree node list: {node} -> # -> nest into {name}")
+            #     #         replace_module_with_hooked(child, tree=tree[1:], level=level + 1, debug=debug)
+            #     #     else:
+            #     #         log.warn(f"{level_indent} Hook: stopped at unknown tree node list: {node} -> {name}")
+            #     # # dict: nested node with final modules larget as value [list]
+            #     # elif isinstance(node, Dict):
+            #     #     if name in node:
+            #     #         log.info(f"{level_indent} Hook: follow tree node dict: {node} -> {name} -> nest into {name}")
+            #     #         replace_module_with_hooked(child, tree=node[name], level=level + 1, debug=debug)
+            #     #     elif name.isdigit() and "#" in node:
+            #     #         log.info(f"{level_indent} Hook: follow tree node dict: {node} -> # -> nest into {name}")
+            #     #         replace_module_with_hooked(child, tree=node["#"], level=level + 1, debug=debug)
+            #     #     else:
+            #     #         log.warn(f"{level_indent} Hook: stopped at unknown tree node dict: {node} -> {name}")
+            #     else:
+            #         log.warn(f"{level_indent} Hook: skipped at unknown tree node: {name}")
+            # else:
+            #     log.warn(f"{level_indent} Hook: follow naively -> nest into {name}")
+            #     replace_module_with_hooked(child, [], level=level + 1, debug=debug)

--- a/gptqmodel/quantization/gptq.py
+++ b/gptqmodel/quantization/gptq.py
@@ -29,7 +29,6 @@ import torch
 import torch.nn as nn
 import transformers
 from torch.nn.modules.conv import _ConvNd
-from transformers import Conv1D
 
 from ..looper.named_module import NamedModule
 from ..quantization import QuantizeConfig
@@ -106,7 +105,7 @@ class GPTQ:
 
     @staticmethod
     def _validate_module(module):
-        assert isinstance(module, (nn.Linear, _ConvNd, Conv1D)), f"We supports only linear and convolutional layers. actual = `{module}`"
+        assert isinstance(module, (nn.Linear, nn.Conv1d, nn.Conv2d, transformers.Conv1D)), f"We supports only linear and convolutional layers. actual = `{module}`"
 
     # def has_hessian_issues(self) -> bool:
     #     return any([self.issue_zero_samples, self.issue_nan_hessian, self.issue_non_invertible])

--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -141,9 +141,8 @@ def find_modules(module: nn.Module, layers=None, name: str="") -> Dict[str, nn.M
     if not layers:
         layers = SUPPORTS_MODULE_TYPES
 
-    for layer in layers:
-        if isinstance(module, layer):
-            return {name: module}
+    if isinstance(module, tuple(layers)):
+       return {name: module}
 
     res = {}
     for name1, child in module.named_children():
@@ -151,10 +150,11 @@ def find_modules(module: nn.Module, layers=None, name: str="") -> Dict[str, nn.M
     return res
 
 
-def get_module_by_name_prefix(model, module_name: str):
+def get_module_by_name_prefix(model, module_name: List[str]):
     for name, module in model.named_modules():
-        if name.startswith(module_name):
-            return module
+        for prefix in module_name:
+            if name.startswith(prefix):
+                return module, prefix
 
 
 def get_module_by_name_suffix(model, module_name: str):

--- a/tests/models/test_qwen2_moe.py
+++ b/tests/models/test_qwen2_moe.py
@@ -4,7 +4,7 @@ import torch
 from gptqmodel import BACKEND, GPTQModel
 
 
-class TestQwen15Moe(unittest.TestCase):
+class TestQwen2Moe(unittest.TestCase):
     def test_inference(self):
         model = GPTQModel.load("Qwen/Qwen1.5-MoE-A2.7B-Chat-GPTQ-Int4",
                 device=torch.device("cuda:0"),

--- a/tests/models/test_qwen2_moe_quant.py
+++ b/tests/models/test_qwen2_moe_quant.py
@@ -14,19 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..base import BaseGPTQModel
+from model_test import ModelTest
 
 
-class XverseGPTQ(BaseGPTQModel):
-    require_pkgs_version = ["transformers<=4.38.2", "tokenizers<=0.15.2"]
-    base_modules = ["model.embed_tokens", "model.norm"]
-    pre_lm_head_norm_module = "model.norm"
+class TestQwen2_5_Moe(ModelTest):
+    NATIVE_MODEL_ID = "/monster/data/model/Qwen1.5-MoE-A2.7B" # Qwen/Qwen1.5-MoE-A2.7B
+    QUANT_ARC_MAX_DELTA_FLOOR_PERCENT = 0.2
+    NATIVE_ARC_CHALLENGE_ACC = 0.2739
+    NATIVE_ARC_CHALLENGE_ACC_NORM = 0.3055
+    TRUST_REMOTE_CODE = False
+    APPLY_CHAT_TEMPLATE = True
+    EVAL_BATCH_SIZE = 6
 
-    layers_node = ["model.layers"]
-    layer_type = "XverseDecoderLayer"
-    layer_modules = [
-        ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
-        ["self_attn.o_proj"],
-        ["mlp.up_proj", "mlp.gate_proj"],
-        ["mlp.down_proj"],
-    ]
+    def test_qwen2_5(self):
+        self.quant_lm_eval()


### PR DESCRIPTION
Even though existing code does not error, we should never ever hook/wrap a module that will never particpates  in quantization. This doesn't make any sense. The fix is much more complicated and likely require for 2-3 PRs to refractor. 

Currently add optional pin-point module targeting via `tree` of `base.layers_modules_tree`.  This will play nicely into more generic multi-modal support as mm models embeds up to 3 separate models essentially into 1. The existing static-non-tree based config will be harder to support. 

Tree syntax

```py
# Full tree of quantizable modules
# `#` str will match any number: useful for layers and moe indexing.
# List[str] for serial linked nodes. List str are linear depth linked modules presented in a linear fashion with no divergence.
# Dict{str: List[str] | Dict | Tuple[str]} for diverging nodes where a node splits into multiple paths/nodes.
# Tuple(str) for final targeted modules/nodes: there are only strings representing the final targeted modules
layers_modules_tree = [
    "model",
    "layers",
    "#",
    {
        "self_attn": ("k_proj", "v_proj", "q_proj", "o_proj"),
        "mlp": ("up_proj", "gate_proj", "down_proj"),
    }
]
 ```