### PR TITLE
Fix v2 for MoE 

### DIFF
--- a/gptqmodel/looper/native_processor.py
+++ b/gptqmodel/looper/native_processor.py
@@ -23,7 +23,7 @@ from ..looper.loop_processor import LoopProcessor
 from ..looper.named_module import NamedModule
 from ..models import BaseGPTQModel
 from ..quantization.config import QuantizeConfig
-from ..quantization.gptq import CPU, DEVICE_1
+from ..quantization.gptq import CPU, DEVICE_1, DEVICE_2
 from ..utils.logger import setup_logger
 
 log = setup_logger()
@@ -75,7 +75,7 @@ class NativeProcessor(LoopProcessor):
             inp = inp[0].detach()
 
             if self.qcfg.v2_memory_device == "auto":
-                v2_memory_device = DEVICE_1
+                v2_memory_device = DEVICE_2
             elif self.qcfg.v2_memory_device == "cpu":
                 # slower but >= 4x vram memory reduction
                 v2_memory_device = CPU
@@ -84,7 +84,7 @@ class NativeProcessor(LoopProcessor):
             elif isinstance(self.qcfg.v2_memory_device, torch.device):
                 v2_memory_device = self.qcfg.v2_memory_device
             else:
-                v2_memory_device = DEVICE_1
+                v2_memory_device = DEVICE_2
 
             self.native_inp_caches[name] += [inp.to(device=v2_memory_device)]
             del inp, out

--- a/gptqmodel/quantization/gptq.py
+++ b/gptqmodel/quantization/gptq.py
@@ -44,6 +44,7 @@ CPU = torch.device("cpu")
 DEVICE_0 = auto_select_torch_device(index=0)
 # device_1 may be same as device_0 if there is only 1 visible/active device
 DEVICE_1 = auto_select_torch_device(index=1)
+DEVICE_2 = auto_select_torch_device(index=2)
 
 lock = threading.Lock()
 

--- a/gptqmodel/quantization/gptqv2.py
+++ b/gptqmodel/quantization/gptqv2.py
@@ -106,11 +106,13 @@ class GPTQv2(GPTQ):
         # not compatible with Moe
         # native_inp = self.native_inps.pop(0).to(device=DEVICE_1, dtype=torch.float32)
 
-        native_inp = self.find_closest_native_input(inp).to(device=inp.device)
+        native_inp = self.find_closest_native_input(inp)
 
         if native_inp is None:
             log.error(f"Skipping input of shape `{inp.shape}` as it not matched to native_inputs. If this is MoE model, this is safe to ignore.")
             return
+
+        native_inp = native_inp.to(device=inp.device)
 
         if len(inp.shape) == 2:
             inp = inp.unsqueeze(0)

--- a/gptqmodel/utils/torch.py
+++ b/gptqmodel/utils/torch.py
@@ -137,12 +137,12 @@ def auto_select_torch_device(index: int = 0):
     if HAS_CUDA:
         # defensive check
         if index > 0 and torch.cuda.device_count() <= index :
-            index = 0
+            index = torch.cuda.device_count() - 1
         device = torch.device(f"cuda:{index}")
     elif HAS_XPU:
         # defensive check
         if index > 0 and torch.xpu.device_count() <= index:
-            index = 0
+            index = torch.xpu.device_count() - 1
         device = torch.device(f"xpu:{index}")
     elif HAS_MPS:
         device = torch.device("mps") # mps has no index


### PR DESCRIPTION
v2 requires native and quantized inputs to be stored. Unfortunately, MoE module activation will differ between native and quantized paths causing un-balanced/mismatched ordering of native_inp and inp (quantized). 