### PR TITLE
Fix rotation for tied embedding models

### DIFF
--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -421,7 +421,7 @@ class BaseGPTQModel(nn.Module):
                                     f"current model is {self.__class__.__name__}")
 
             if self.model.config.tie_word_embeddings:
-                print("Rotation requires word embeddings to be untied. Untying.")
+                log.info("Rotation requires word embeddings to be untied. Untying.")
                 self.model.config.tie_word_embeddings = False
                 lm_head, _ = get_module_by_name_prefix(self.model, self.lm_head)
                 lm_head.weight = nn.Parameter(lm_head.weight.data.clone())

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -106,7 +106,7 @@ class TorchQuantLinear(PackableQuantLinear):
 
         if backend is None:
             # MPS doesn't support inductor.
-            backend = "inductor" if self.dequantize_weight.device.type != "mps" else "aot_eager"
+            backend = "inductor" if self.list_buffers()[0].device.type != "mps" else "aot_eager"
 
         # compile dequantize
         self.dequantize_weight = torch_compile(self.dequantize_weight, backend=backend, mode=mode, fullgraph=fullgraph)

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -100,9 +100,13 @@ class TorchQuantLinear(PackableQuantLinear):
         # torch benefits the most from torch.compile, enable it by default
         self.optimize()
 
-    def optimize(self, backend: str = "inductor", mode: str = None, fullgraph: bool = False):
+    def optimize(self, backend: str = None, mode: str = None, fullgraph: bool = False):
         if self.optimized:
             return
+
+        if backend is None:
+            # MPS doesn't support inductor.
+            backend = "inductor" if self.dequantize_weight.device.type != "mps" else "aot_eager"
 
         # compile dequantize
         self.dequantize_weight = torch_compile(self.dequantize_weight, backend=backend, mode=mode, fullgraph=fullgraph)

--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -150,9 +150,10 @@ def find_modules(module: nn.Module, layers=None, name: str="") -> Dict[str, nn.M
     return res
 
 
-def get_module_by_name_prefix(model, module_name: List[str]):
+def get_module_by_name_prefix(model, module_name: Union[List[str], str]):
+    module_name_list = module_name if isinstance(module_name, list) else [module_name]
     for name, module in model.named_modules():
-        for prefix in module_name:
+        for prefix in module_name_list:
             if name.startswith(prefix):
                 return module, prefix
 


### PR DESCRIPTION
When embeddings are tied, fusing the `pre_head_layernorm` into `lm_head` also impacts `embed_tokens`. This happens in a few common models: Qwen2.5-0.5B, Llama3.2 for example. Possible this is the source of the issue mentioned in https://github.com/ModelCloud/GPTQModel/pull/1425#issuecomment-2717194335.

The solution is to untie the weights.

Also made some related changes along the way, happy to revert them or split them into separate PRs:
- Allow rotation for all quant_methods. May not always help, but doesn't need to be QQQ-specific.
- Couple small fixes to improve MPS compatibility. (Not perfect, e.g. still need to comment out `rotate_ov_proj`.)