### PR TITLE
Process threads

### DIFF
--- a/gptqmodel/eora/eora.py
+++ b/gptqmodel/eora/eora.py
@@ -25,8 +25,8 @@ from ..utils.rocm import IS_ROCM
 
 log = setup_logger()
 
-def eora_process_input(input: Tensor, name: str, eigen_scaling_diag_matrix: Dict[str, torch.dtype], sample_size: int):
-    inp = input[0].to(dtype=torch.float32)
+def eora_process_input(input: Tensor, name: str, eigen_scaling_diag_matrix: Dict[str, torch.dtype], sample_size: int, device: torch.device):
+    inp = input[0].to(device=device, dtype=torch.float32)
     if inp.dim() == 2:
         inp = inp.unsqueeze(0)
 
@@ -41,18 +41,18 @@ def eora_process_input(input: Tensor, name: str, eigen_scaling_diag_matrix: Dict
     del inp, tmp, adds, adds_sum
 
 def eora_compute_lora(
-        device: torch.device,
         w_wq_delta: Tensor, # need the w (original weight) and wq (quantized qweight) delta in float32
         module: NamedModule,
         eigen_scaling_diag_matrix: torch.dtype,
         rank: int,
-        dtype: torch.dtype = torch.bfloat16,
+        dtype: torch.dtype,
+        device: torch.device,
 ) -> Tuple[Tensor, Tensor]:
 
     assert w_wq_delta.dtype == torch.float32
 
     # save this later for SVD
-    raw_scaling_diag_matrix = eigen_scaling_diag_matrix.to(dtype=torch.float64, device=device)
+    raw_scaling_diag_matrix = eigen_scaling_diag_matrix.to(device=device, dtype=torch.float64)
 
     if IS_ROCM:
         # hip cannot resolve linalg ops

--- a/gptqmodel/looper/eora_processor.py
+++ b/gptqmodel/looper/eora_processor.py
@@ -29,10 +29,9 @@ from ..models import BaseGPTQModel
 from ..models.writer import (PROCESS_LOG_FWD_TIME, PROCESS_LOG_LAYER, PROCESS_LOG_MODULE,
                              PROCESS_LOG_NAME, PROCESS_LOG_TIME, PROCESS_MAX_MEMORY)
 from ..quantization.config import QuantizeConfig
-from ..quantization.gptq import CPU, DEVICE_0, DEVICE_1
 from ..utils.logger import setup_logger
 from ..utils.model import move_to
-from ..utils.torch import torch_compile, torch_sync
+from ..utils.torch import torch_compile, torch_sync, CPU
 
 log = setup_logger()
 

--- a/gptqmodel/looper/eora_processor.py
+++ b/gptqmodel/looper/eora_processor.py
@@ -31,7 +31,7 @@ from ..models.writer import (PROCESS_LOG_FWD_TIME, PROCESS_LOG_LAYER, PROCESS_LO
 from ..quantization.config import QuantizeConfig
 from ..utils.logger import setup_logger
 from ..utils.model import move_to
-from ..utils.torch import torch_compile, torch_sync, CPU
+from ..utils.torch import CPU, torch_compile, torch_sync
 
 log = setup_logger()
 

--- a/gptqmodel/looper/eora_processor.py
+++ b/gptqmodel/looper/eora_processor.py
@@ -31,7 +31,7 @@ from ..models.writer import (PROCESS_LOG_FWD_TIME, PROCESS_LOG_LAYER, PROCESS_LO
 from ..quantization.config import QuantizeConfig
 from ..utils.logger import setup_logger
 from ..utils.model import move_to
-from ..utils.torch import CPU, torch_compile, torch_sync, torch_streamCtx, DEVICE_0, DEVICE_1
+from ..utils.torch import CPU, DEVICE_0, DEVICE_1, torch_compile, torch_streamCtx, torch_sync
 
 log = setup_logger()
 

--- a/gptqmodel/looper/eora_processor.py
+++ b/gptqmodel/looper/eora_processor.py
@@ -31,7 +31,7 @@ from ..models.writer import (PROCESS_LOG_FWD_TIME, PROCESS_LOG_LAYER, PROCESS_LO
 from ..quantization.config import QuantizeConfig
 from ..utils.logger import setup_logger
 from ..utils.model import move_to
-from ..utils.torch import CPU, torch_compile, torch_sync
+from ..utils.torch import CPU, torch_compile, torch_sync, torch_streamCtx, DEVICE_0, DEVICE_1
 
 log = setup_logger()
 
@@ -39,7 +39,7 @@ log = setup_logger()
 class EoraProcessor(LoopProcessor):
     def __init__(self, tokenizer, qcfg: QuantizeConfig, calibration_dataset, prepare_dataset_func,
                  calibration_dataset_concat_size: Optional[int], batch_size: int,
-                 logger_board: str = "", require_fwd: bool = True,
+                 logger_board: str = "", require_fwd: bool = True
                  ):
         super().__init__(tokenizer=tokenizer, qcfg=qcfg, calibration_dataset=calibration_dataset,
                          calibration_dataset_concat_size=calibration_dataset_concat_size,
@@ -48,7 +48,6 @@ class EoraProcessor(LoopProcessor):
 
         # dict: key is module name, value is the accumulated eigen_scaling_diag_matrix
         self.eigen_scaling_diag_matrix: Dict[str, torch.float32] = {}
-
 
         # Increase the dynamo cache size limit, default of 8 is too low
         if torch._dynamo.config.cache_size_limit < 64:
@@ -106,14 +105,24 @@ class EoraProcessor(LoopProcessor):
         return module.adapter_cfg in [None, {}]
 
     def preprocess_fwd_hook(self, name: str) -> Callable[[Module, Tuple[torch.Tensor, ...], torch.Tensor], None]:
-        def tmp(_, input: Tuple[torch.Tensor, ...], output: torch.Tensor):
+        def tmp(module, input: Tuple[torch.Tensor, ...], output: torch.Tensor):
             self.eora_process_input(
                 input=input,
                 name=name,
                 eigen_scaling_diag_matrix=self.eigen_scaling_diag_matrix,
-                sample_size=self.num_batches
+                sample_size=self.num_batches,
+                device=module.target_device,
             )
         return tmp
+
+    def pre_process_stream_hook(self, module: NamedModule):
+        eigen_matrix = self.eigen_scaling_diag_matrix[module.name]
+        with torch_streamCtx(module.target_device_stream):
+            if eigen_matrix is not None:
+                self.eigen_scaling_diag_matrix[module.name] = eigen_matrix.to(device=module.target_device, non_blocking=True)
+
+            module.state["w_wq_diff"] = module.state["w_wq_diff"].to(device=module.target_device, non_blocking=True)
+            module.state["wq"] = module.state["wq"].to(device=module.target_device, non_blocking=True)
 
     def process(self, module: NamedModule, auto_gc: bool = True):
         assert isinstance(module.adapter_cfg, Lora)
@@ -124,29 +133,20 @@ class EoraProcessor(LoopProcessor):
 
         eigen_scaling_diag_matrix = self.eigen_scaling_diag_matrix[module.name]
 
-        w: torch.Tensor = module.state.pop("w")
-        w_device = w.device  # TODO clear up device situation between w and wq
+        w_wq_delta: torch.Tensor = module.state.pop("w_wq_diff").to(dtype=torch.float32)
         wq: torch.Tensor = module.state["wq"]
 
         # print(f"types: w = `{w.dtype}`, device = `{w.device}`, wq = `{wq.dtype}`,  device = `{wq.device}`")
-        if w.dtype != torch.float32:
-            w_wq_delta = w.to(dtype=torch.float32) - wq # wq is float16
-        else:
-            w_wq_delta = w - wq
-
         assert w_wq_delta.dtype == torch.float32, f"w_wq_delta dtype: {w_wq_delta.dtype}"
-
-        # print(f"types: w_q_delta = `{w_wq_delta.dtype}`,  device = `{w_wq_delta.device}`")
-        del w
 
         # log.info(f"EoRA: module native dtype = `{module_native_dtype}")
         A, B = self.eora_compute_lora(
-            device=w_device,
             w_wq_delta=w_wq_delta,
             module=module,
             eigen_scaling_diag_matrix=eigen_scaling_diag_matrix,
             rank=module.adapter_cfg.rank,
             dtype=module.module_dtype,
+            device=module.target_device,
         )
 
         # wq with A/B applied
@@ -157,7 +157,7 @@ class EoraProcessor(LoopProcessor):
         })
 
         # override module weight with computed weight with B@A delta
-        module.weight.data = computed_wq.to(dtype=module.weight.data.dtype)
+        module.weight.data = computed_wq.to(dtype=module.weight.data.dtype, device=module.weight.data.device)
 
         # for assert weight
         # module.state.update({

--- a/gptqmodel/looper/gptq_processor.py
+++ b/gptqmodel/looper/gptq_processor.py
@@ -36,14 +36,14 @@ log = setup_logger()
 class GPTQProcessor(LoopProcessor):
     def __init__(self, tokenizer, qcfg: QuantizeConfig, calibration_dataset, prepare_dataset_func,
                  calibration_dataset_concat_size: Optional[int], batch_size: int,
-                 logger_board: str = "", require_fwd: bool = True, retain_w: bool = False):
+                 logger_board: str = "", require_fwd: bool = True, calculate_w_wq_diff: bool = False):
 
         super().__init__(tokenizer=tokenizer, qcfg=qcfg, calibration_dataset=calibration_dataset,
                          calibration_dataset_concat_size=calibration_dataset_concat_size,
                          prepare_dataset_func=prepare_dataset_func, batch_size=batch_size,
                          logger_board=logger_board, require_fwd=require_fwd)
 
-        self.retain_w = retain_w
+        self.calculate_w_wq_diff = calculate_w_wq_diff
         self.avg_losses = []
 
     def log_plotly(self):
@@ -62,13 +62,6 @@ class GPTQProcessor(LoopProcessor):
 
     def set_calibration_dataset(self, calibration_dataset):
         raise NotImplementedError("GPTQProcessor's calibration_dataset cannot be modified")
-
-    def pre_process_stream_hook(self, module: NamedModule):
-        g = self.tasks[module.name]
-        with torch_streamCtx(g.device_stream):
-            if g.H is not None:
-                g.H = g.H.to(device=g.device, non_blocking=True)
-            module.weight.data = module.weight.data.to(device=g.device, non_blocking=True)
 
     def preprocess(self, module: NamedModule, buffered_fwd: bool):
         # entire module is skipped
@@ -121,12 +114,19 @@ class GPTQProcessor(LoopProcessor):
             return False
 
     def preprocess_fwd_hook(self, name: str) -> Callable[[Module, Tuple[torch.Tensor, ...], torch.Tensor], None]:
-        def tmp(_, inp: Tuple[torch.Tensor, ...], out: torch.Tensor):
+        def tmp(module, inp: Tuple[torch.Tensor, ...], out: torch.Tensor):
             # gptq is mutable.
             g = self.tasks[name]  # noqa: F821
             g.add_batch(inp[0].data, out.data)  # noqa: F821
             del inp, out
         return tmp
+
+    def pre_process_stream_hook(self, module: NamedModule):
+        g = self.tasks[module.name]
+        with torch_streamCtx(module.target_device_stream):
+            if g.H is not None:
+                g.H = g.H.to(device=module.target_device, non_blocking=True)
+            module.weight.data = module.weight.data.to(device=module.target_device, non_blocking=True)
 
     def process(self, module: NamedModule, auto_gc: bool = True, DEVICE_1=None):
         # need to sync stream copies
@@ -213,11 +213,19 @@ class GPTQProcessor(LoopProcessor):
             "g_idx": g_idx,
         })
 
-        if self.retain_w:
+        # TODO FIX ME...rename to .calculate_w_wq_dff
+        if self.calculate_w_wq_diff:
+            if module.weight.data.dtype == torch.float16:
+                # diff in float16
+                w_wq_diff = module.weight.data - wq
+            else:
+                # diff in float32
+                w_wq_diff = module.weight.data.to(dtype=torch.float32) - wq.to(dtype=torch.float32)
+
             # original weights
-            w = module.weight.data
+            #w = module.weight.data
             module.state.update({
-                "w": w,  # bf16/fp16, non-quantized native weight
+                "w_wq_diff": w_wq_diff,  # bf16/fp16, non-quantized native weight
             })
 
         self.tasks[module.name].free()
@@ -226,7 +234,7 @@ class GPTQProcessor(LoopProcessor):
         # module.weight.data = torch.empty(1,1) # hack to remove weight.data
         # if auto_gc:
         #     torch_empty_cache()
-        with torch_streamCtx(g.device_stream):
+        with torch_streamCtx(module.target_device_stream):
             wq = wq.to(device=DEVICE_0, non_blocking=True) # TODO FIX ME
 
         # logger.info(f"Quantizing module END: {name}, {gptq[name].shape()}")
@@ -238,8 +246,8 @@ class GPTQProcessor(LoopProcessor):
         module.weight.data = wq
         del old
 
-        if auto_gc:
-            torch_empty_cache()
+        # if auto_gc:
+        #     torch_empty_cache()
 
     # submodule_finalized is called in reverse after all next sequential processes are called
     def submodule_finalize(self, module: NamedModule):

--- a/gptqmodel/looper/gptq_processor.py
+++ b/gptqmodel/looper/gptq_processor.py
@@ -195,10 +195,16 @@ class GPTQProcessor(LoopProcessor):
 
         #log.info(stat)
 
+        # self.result_save(module.full_name, {
+        #     "scale": move_to(scale, device=CPU, stream=self.stream),
+        #     "zero": move_to(zero, device=CPU, stream=self.stream),
+        #     "g_idx": move_to(g_idx, device=CPU, stream=self.stream),
+        # })
+
         self.result_save(module.full_name, {
-            "scale": move_to(scale, device=CPU, stream=self.stream),
-            "zero": move_to(zero, device=CPU, stream=self.stream),
-            "g_idx": move_to(g_idx, device=CPU, stream=self.stream),
+            "scale": scale,
+            "zero": zero,
+            "g_idx": g_idx,
         })
 
         if self.retain_w:

--- a/gptqmodel/looper/gptq_processor.py
+++ b/gptqmodel/looper/gptq_processor.py
@@ -29,7 +29,7 @@ from ..quantization import GPTQ, GPTQv2
 from ..quantization.config import QUANT_METHOD, QuantizeConfig
 from ..utils.logger import setup_logger
 from ..utils.model import move_to, pack_model
-from ..utils.torch import torch_empty_cache, torch_sync, DEVICE_0, CPU, torch_streamCtx
+from ..utils.torch import CPU, DEVICE_0, torch_empty_cache, torch_streamCtx, torch_sync
 
 log = setup_logger()
 

--- a/gptqmodel/looper/gptq_processor.py
+++ b/gptqmodel/looper/gptq_processor.py
@@ -103,8 +103,8 @@ class GPTQProcessor(LoopProcessor):
         # all sub-modules within a single layer needs to store all the inputs.
         # deepseek has massive # of sub-modules per layer, causing vram pressure
         # buffered mode is slower due to gpu<->cpu movement
-        if buffered_fwd:  # TODO tweak this number for masive MoE
-            log.info(f"Experimental: enabling fwd buffered mode for: `{module.name}`")
+        if buffered_fwd:
+            log.info.once(f"Quantize: enabling fwd buffered mode for: `{module.name}`")
             tmp.fwd_inputs_buffered = True
 
         tmp.quantizer.configure(

--- a/gptqmodel/looper/gptq_processor.py
+++ b/gptqmodel/looper/gptq_processor.py
@@ -27,10 +27,9 @@ from ..models.writer import (PROCESS_LOG_FWD_TIME, PROCESS_LOG_LAYER, PROCESS_LO
                              PROCESS_LOG_TIME, PROCESS_MAX_MEMORY, QUANT_LOG_DAMP, QUANT_LOG_LOSS, QUANT_LOG_NSAMPLES)
 from ..quantization import GPTQ, GPTQv2
 from ..quantization.config import QUANT_METHOD, QuantizeConfig
-from ..quantization.gptq import CPU, DEVICE_0, DEVICE_1
 from ..utils.logger import setup_logger
 from ..utils.model import move_to, pack_model
-from ..utils.torch import torch_empty_cache, torch_sync
+from ..utils.torch import torch_empty_cache, torch_sync, DEVICE_0, CPU
 
 log = setup_logger()
 
@@ -122,7 +121,7 @@ class GPTQProcessor(LoopProcessor):
             del inp, out
         return tmp
 
-    def process(self, module: NamedModule, auto_gc: bool = True):
+    def process(self, module: NamedModule, auto_gc: bool = True, DEVICE_1=None):
         # need to sync stream copies
         # if torch.cuda.device_count() > 1:
         #     torch.cuda.synchronize()

--- a/gptqmodel/looper/gptq_processor.py
+++ b/gptqmodel/looper/gptq_processor.py
@@ -213,7 +213,6 @@ class GPTQProcessor(LoopProcessor):
             "g_idx": g_idx,
         })
 
-        # TODO FIX ME...rename to .calculate_w_wq_dff
         if self.calculate_w_wq_diff:
             if module.weight.data.dtype == torch.float16:
                 # diff in float16
@@ -222,10 +221,8 @@ class GPTQProcessor(LoopProcessor):
                 # diff in float32
                 w_wq_diff = module.weight.data.to(dtype=torch.float32) - wq.to(dtype=torch.float32)
 
-            # original weights
-            #w = module.weight.data
             module.state.update({
-                "w_wq_diff": w_wq_diff,  # bf16/fp16, non-quantized native weight
+                "w_wq_diff": w_wq_diff,
             })
 
         self.tasks[module.name].free()
@@ -290,5 +287,6 @@ class GPTQProcessor(LoopProcessor):
             return True
 
     def name(self) -> str:
+        # TODO fix me..this hacks inherited base class logic, why not override name in gptqv2?
         qcfg = self.qcfg_dynamic if self.qcfg_dynamic is not None else self.qcfg
         return "gptq v2" if qcfg.v2 else "gptq"

--- a/gptqmodel/looper/gptq_processor.py
+++ b/gptqmodel/looper/gptq_processor.py
@@ -66,7 +66,8 @@ class GPTQProcessor(LoopProcessor):
     def pre_process_stream_hook(self, module: NamedModule):
         g = self.tasks[module.name]
         with torch_streamCtx(g.device_stream):
-            g.H = g.H.to(device=g.device, non_blocking=True)
+            if g.H is not None:
+                g.H = g.H.to(device=g.device, non_blocking=True)
             module.weight.data = module.weight.data.to(device=g.device, non_blocking=True)
 
     def preprocess(self, module: NamedModule, buffered_fwd: bool):

--- a/gptqmodel/looper/gptq_processor.py
+++ b/gptqmodel/looper/gptq_processor.py
@@ -124,8 +124,8 @@ class GPTQProcessor(LoopProcessor):
 
     def process(self, module: NamedModule, auto_gc: bool = True):
         # need to sync stream copies
-        if torch.cuda.device_count() > 1:
-            torch.cuda.synchronize()
+        # if torch.cuda.device_count() > 1:
+        #     torch.cuda.synchronize()
 
         # Reset peak memory stats
         #torch.cuda.reset_peak_memory_stats()

--- a/gptqmodel/looper/loop_processor.py
+++ b/gptqmodel/looper/loop_processor.py
@@ -55,7 +55,7 @@ class LoopProcessor:
         self._results: Dict[str, Any] = {}
 
         # toggle to enable stream from gpu to cpu
-        self.stream = False
+        self.stream = True
 
         self.tokenizer = tokenizer
         self.qcfg = qcfg

--- a/gptqmodel/looper/loop_processor.py
+++ b/gptqmodel/looper/loop_processor.py
@@ -294,7 +294,7 @@ class LoopProcessor:
         pass
 
     # do work and return processor.self state which will updated/merged
-    def process(self, module: NamedModule):
+    def process(self, module: NamedModule, device: torch.device = None):
         pass
 
     # last step, after all loop processor is called

--- a/gptqmodel/looper/loop_processor.py
+++ b/gptqmodel/looper/loop_processor.py
@@ -293,6 +293,10 @@ class LoopProcessor:
     def preprocess_fwd_hook(self, name: str) -> Callable[[Module, Tuple[torch.Tensor, ...], torch.Tensor], None]:
         pass
 
+    # do work right before process where stream async/weight copies may happen
+    def pre_process_stream_hook(self, module: NamedModule):
+        pass
+
     # do work and return processor.self state which will updated/merged
     def process(self, module: NamedModule, device: torch.device = None):
         pass

--- a/gptqmodel/looper/loop_processor.py
+++ b/gptqmodel/looper/loop_processor.py
@@ -55,7 +55,7 @@ class LoopProcessor:
         self._results: Dict[str, Any] = {}
 
         # toggle to enable stream from gpu to cpu
-        self.stream = True
+        self.stream = False
 
         self.tokenizer = tokenizer
         self.qcfg = qcfg

--- a/gptqmodel/looper/module_looper.py
+++ b/gptqmodel/looper/module_looper.py
@@ -30,11 +30,10 @@ from ..looper.native_processor import NativeProcessor
 from ..models import BaseGPTQModel
 from ..models._const import SUPPORTS_MODULE_TYPES
 from ..nn_modules.hooked_linear import replace_module_with_hooked_legacy, replace_module_with_hooked_tree
-from ..quantization.gptq import CPU, DEVICE_0, DEVICE_1, DEVICE_2, DEVICE_3, DEVICE_4, ALL_DEVICES
 from ..utils.logger import setup_logger
 from ..utils.model import (find_modules, get_device, get_module, get_module_by_name_prefix,
                            get_moe_layer_modules, move_to, nested_move_to)
-from ..utils.torch import torch_empty_cache, torch_devices, HAS_CUDA, torch_sync, torch_new_stream_ctx
+from ..utils.torch import torch_empty_cache, torch_devices, HAS_CUDA, torch_sync, torch_new_stream_ctx, CPU, ALL_DEVICES
 
 log = setup_logger()
 

--- a/gptqmodel/looper/module_looper.py
+++ b/gptqmodel/looper/module_looper.py
@@ -34,7 +34,7 @@ from ..quantization.gptq import CPU, DEVICE_0, DEVICE_1, DEVICE_2, DEVICE_3, DEV
 from ..utils.logger import setup_logger
 from ..utils.model import (find_modules, get_device, get_module, get_module_by_name_prefix,
                            get_moe_layer_modules, move_to, nested_move_to)
-from ..utils.torch import torch_empty_cache
+from ..utils.torch import torch_empty_cache, torch_devices, HAS_CUDA
 
 log = setup_logger()
 
@@ -370,74 +370,73 @@ class ModuleLooper():
 
                         for name in moe_skip_modules:
                             subset.pop(name)
-                    
-                    # for name_index, name in enumerate(subset):
-                    #     m = subset[name]
-                    #     processor.process(module=m, auto_gc=auto_gc)
-                    #     processed_subset[name] = m
-                    from concurrent.futures import ThreadPoolExecutor
 
-                    cuda_devices = [DEVICE_0, DEVICE_1, DEVICE_2, DEVICE_3, DEVICE_4]
-                    device_index = [0]  # Using list to make it mutable
-
-                    # Create a stream for asynchronous copies for each device
-                    streams = [torch.cuda.Stream(device=f'cuda:{i}') for i in range(len(cuda_devices))]
-
-                    # Counter to cycle through devices
-                    device_index = 0
-
-                    for name in subset:
-                        m = subset[name]
-
-                        # Get current device and stream
-                        current_device = cuda_devices[device_index]
-                        current_stream = streams[device_index]
-
-                        log.info(f"stream device -> {current_device}")
-
-                        # Move tensors asynchronously
-                        with torch.cuda.stream(current_stream):
-                            # Move H tensor
-                            # if hasattrattr(m, 'H'):
-                            g = processor.tasks[name]
-                            g.H = g.H.to(device=current_device, non_blocking=True)
-
-                            # Move weight.data tensor
-                            # if hasattr(m, 'weight') and hasattr(m.weight, 'data'):
-                            m.weight.data = m.weight.data.to(device=current_device, non_blocking=True)
-
-                        # Cycle to next device
-                        device_index = (device_index + 1) % len(cuda_devices)
-
-                    # Synchronize all streams to ensure copies are complete
-                    for stream in streams:
-                        stream.synchronize()
-
-                    log.info("streams synced")
-
-                    # Use ThreadPoolExecutor with 3 threads
-                    with ThreadPoolExecutor(max_workers=len(cuda_devices)) as executor:
-                        futures = []
-                        # with self.lock:
-                        #     device = devices[device_index[0]]
-                        #     device_index[0] = (device_index[0] + 1) % len(devices)
-                        #
-                        # log.info(f"using device = {device}")
-                        def process_module(name, m):
+                    sys_devices = torch_devices()
+                    if len(sys_devices) <= 1:
+                        for name_index, name in enumerate(subset):
+                            m = subset[name]
                             processor.process(module=m, auto_gc=auto_gc)
-                            return name, m
+                            processed_subset[name] = m
+                    else:
+                        from concurrent.futures import ThreadPoolExecutor
+
+                        # Create a stream for asynchronous copies for each device
+                        if HAS_CUDA:
+                            streams = [torch.cuda.Stream(device=device) for device in sys_devices]
+                        else:
+                            streams = [torch.xpu.Stream(device=device) for device in sys_devices]
+
+                        # Counter to cycle through devices
+                        device_index = 0
 
                         for name in subset:
                             m = subset[name]
-                            futures.append(executor.submit(
-                                process_module,
-                                name,
-                                m
-                            ))
 
-                        for future in futures:
-                            name, m = future.result()
-                            processed_subset[name] = m
+                            # Get current device and stream
+                            current_device = sys_devices[device_index]
+                            current_stream = streams[device_index]
+
+                            log.info(f"stream device -> {current_device}")
+
+                            # Move tensors asynchronously
+                            ctx = torch.cuda.stream(current_stream) if HAS_CUDA else torch.xpu.stream(current_stream)
+                            with ctx:
+                                # Move H tensor
+                                # if hasattrattr(m, 'H'):
+                                g = processor.tasks[name]
+                                g.H = g.H.to(device=current_device, non_blocking=True)
+
+                                # Move weight.data tensor
+                                # if hasattr(m, 'weight') and hasattr(m.weight, 'data'):
+                                m.weight.data = m.weight.data.to(device=current_device, non_blocking=True)
+
+                            # Cycle to next device
+                            device_index = (device_index + 1) % len(sys_devices)
+
+                        # Synchronize all streams to ensure copies are complete
+                        for stream in streams:
+                            stream.synchronize()
+
+                        log.info("streams synced")
+
+                        # Use ThreadPoolExecutor with 3 threads
+                        with ThreadPoolExecutor(max_workers=len(sys_devices)) as executor:
+                            futures = []
+                            def process_module(name, m):
+                                processor.process(module=m, auto_gc=auto_gc)
+                                return name, m
+
+                            for name in subset:
+                                m = subset[name]
+                                futures.append(executor.submit(
+                                    process_module,
+                                    name,
+                                    m
+                                ))
+
+                            for future in futures:
+                                name, m = future.result()
+                                processed_subset[name] = m
 
                     # Prepare arguments for each task
                     # args_list = [

--- a/gptqmodel/looper/named_module.py
+++ b/gptqmodel/looper/named_module.py
@@ -21,6 +21,8 @@ import transformers
 from torch import nn
 from torch.nn.modules.conv import _ConvNd
 
+from gptqmodel.utils.torch import device_next
+
 
 class NamedModule(torch.nn.Module):
     def __init__(self, module: torch.nn.Module, name: str, full_name:str, layer_index: int) -> None:
@@ -31,6 +33,9 @@ class NamedModule(torch.nn.Module):
         self.name = name # module name
         self.full_name = full_name # module full name (path) within model
         self.layer_index = layer_index # layerid in a repeating layer, if in outside layer, this info may be fake
+
+        # some processing will move this module to target_device gptq, eora, etc
+        self.target_device, self.target_device_stream = device_next()
 
         # persistent work state forLoopProcessors
         # store all `processed()` work state/data/result here

--- a/gptqmodel/looper/named_module.py
+++ b/gptqmodel/looper/named_module.py
@@ -18,10 +18,9 @@ from typing import Any, Dict
 
 import torch
 import transformers
+from gptqmodel.utils.torch import device_next
 from torch import nn
 from torch.nn.modules.conv import _ConvNd
-
-from gptqmodel.utils.torch import device_next
 
 
 class NamedModule(torch.nn.Module):

--- a/gptqmodel/looper/native_processor.py
+++ b/gptqmodel/looper/native_processor.py
@@ -34,7 +34,7 @@ NATIVE_INPUTS_STATE_KEY = "native_inp"
 class NativeProcessor(LoopProcessor):
     def __init__(self, tokenizer, qcfg: QuantizeConfig, calibration_dataset, prepare_dataset_func,
                  calibration_dataset_concat_size: Optional[int], batch_size: int,
-                 logger_board: str = "", require_fwd: bool = True, retain_w: bool = False):
+                 logger_board: str = "", require_fwd: bool = True):
 
         super().__init__(tokenizer=tokenizer, qcfg=qcfg, calibration_dataset=calibration_dataset,
                          calibration_dataset_concat_size=calibration_dataset_concat_size,
@@ -42,7 +42,6 @@ class NativeProcessor(LoopProcessor):
                          logger_board=logger_board, require_fwd=require_fwd, fwd_after_process=False,
                          fwd_all_modules_in_single_pass=True)
 
-        self.retain_w = retain_w
         self.native_inp_caches = {}
 
     def log_plotly(self):

--- a/gptqmodel/looper/native_processor.py
+++ b/gptqmodel/looper/native_processor.py
@@ -23,8 +23,8 @@ from ..looper.loop_processor import LoopProcessor
 from ..looper.named_module import NamedModule
 from ..models import BaseGPTQModel
 from ..quantization.config import QuantizeConfig
-from ..quantization.gptq import CPU, DEVICE_1
 from ..utils.logger import setup_logger
+from ..utils.torch import CPU, DEVICE_1
 
 log = setup_logger()
 

--- a/gptqmodel/looper/qqq_processor.py
+++ b/gptqmodel/looper/qqq_processor.py
@@ -27,11 +27,10 @@ from ..models import BaseGPTQModel
 from ..models.writer import (PROCESS_LOG_FWD_TIME, PROCESS_LOG_LAYER, PROCESS_LOG_MODULE, PROCESS_LOG_NAME,
                              PROCESS_LOG_TIME, QUANT_LOG_DAMP, QUANT_LOG_LOSS, QUANT_LOG_NSAMPLES)
 from ..quantization.config import QUANT_METHOD, QuantizeConfig
-from ..quantization.gptq import CPU
 from ..quantization.qqq import QQQ
 from ..utils.logger import setup_logger
 from ..utils.model import move_to, pack_model
-from ..utils.torch import torch_sync
+from ..utils.torch import torch_sync, CPU
 
 log = setup_logger()
 

--- a/gptqmodel/looper/qqq_processor.py
+++ b/gptqmodel/looper/qqq_processor.py
@@ -30,21 +30,21 @@ from ..quantization.config import QUANT_METHOD, QuantizeConfig
 from ..quantization.qqq import QQQ
 from ..utils.logger import setup_logger
 from ..utils.model import move_to, pack_model
-from ..utils.torch import CPU, torch_sync
+from ..utils.torch import CPU, torch_sync, torch_streamCtx, DEVICE_0
 
 log = setup_logger()
 
 class QQQProcessor(LoopProcessor):
     def __init__(self, tokenizer, qcfg: QuantizeConfig, calibration_dataset, prepare_dataset_func,
                  calibration_dataset_concat_size: Optional[int], batch_size: int,
-                 logger_board: str = "", require_fwd: bool = True, retain_w: bool = False):
+                 logger_board: str = "", require_fwd: bool = True, calculate_w_wq_diff: bool = False):
 
         super().__init__(tokenizer=tokenizer, qcfg=qcfg, calibration_dataset=calibration_dataset,
                          calibration_dataset_concat_size=calibration_dataset_concat_size,
                          prepare_dataset_func=prepare_dataset_func, batch_size=batch_size,
                          logger_board=logger_board, require_fwd=require_fwd)
 
-        self.retain_w = retain_w
+        self.calculate_w_wq_diff = calculate_w_wq_diff
         self.avg_losses = []
 
     def log_plotly(self):
@@ -89,8 +89,8 @@ class QQQProcessor(LoopProcessor):
         # all sub-modules within a single layer needs to store all the inputs.
         # deepseek has massive # of sub-modules per layer, causing vram pressure
         # buffered mode is slower due to gpu<->cpu movement
-        if buffered_fwd:  # TODO tweak this number for masive MoE
-            log.info(f"Experimental: enabling fwd buffered mode for: `{module.name}`")
+        if buffered_fwd:
+            log.info(f"Quantize: Enabling fwd buffered mode for: `{module.name}`")
             tmp.fwd_inputs_buffered = True
 
         tmp.quantizer.configure(
@@ -109,22 +109,29 @@ class QQQProcessor(LoopProcessor):
     def preprocess_fwd_hook(self, name: str) -> Callable[[Module, Tuple[torch.Tensor, ...], torch.Tensor], None]:
         def tmp(_, inp: Tuple[torch.Tensor, ...], out: torch.Tensor):
             # gptq is mutable.
-            g = self.tasks[name]  # noqa: F821
-            g.add_batch(inp[0].data, out.data)  # noqa: F821
+            q = self.tasks[name]  # noqa: F821
+            q.add_batch(inp[0].data, out.data)  # noqa: F821
         return tmp
 
-    def process(self, module: NamedModule):
+    def pre_process_stream_hook(self, module: NamedModule):
+        q = self.tasks[module.name]
+        with torch_streamCtx(module.target_device_stream):
+            if q.H is not None:
+                q.H = q.H.to(device=module.target_device, non_blocking=True)
+            module.weight.data = module.weight.data.to(device=module.target_device, non_blocking=True)
+
+
+    def process(self, module: NamedModule, auto_gc: bool = True):
         # need to sync stream copies
-        if torch.cuda.device_count() > 1:
-            torch.cuda.synchronize()
+        torch_sync()
 
         self.pb.title(f"Quantizing {module.name} in layer ").draw()
-        gptq = self.tasks
+        qqq = self.tasks
 
         # logger.info(f"Quantizing module START: {name}, {gptq[name].shape()}")
         ## Need to return the quantized_weight for offloading
-        g = gptq[module.name]
-        wq, scale, zero, g_idx, duration, avg_loss, damp_percent, scale_extra, nsamples = g.quantize()
+        q = qqq[module.name]
+        wq, scale, zero, g_idx, duration, avg_loss, damp_percent, scale_extra, nsamples = q.quantize()
         ## Assign the quantized weight to the weight
         #gptq[name].layer.weight.data = q_full_weight.to(device=gptq[name].device)
 
@@ -153,7 +160,7 @@ class QQQProcessor(LoopProcessor):
             PROCESS_LOG_NAME:  self.name(),
             PROCESS_LOG_LAYER: module.layer_index,
             PROCESS_LOG_MODULE: module.name,
-            QUANT_LOG_LOSS: f"{avg_loss:.5f}",
+            QUANT_LOG_LOSS: f"{avg_loss:.10f}",
             QUANT_LOG_NSAMPLES: f"{nsamples}",
             QUANT_LOG_DAMP: f"{damp_percent:.5f}",
             PROCESS_LOG_TIME: f"{duration:.3f}",
@@ -164,7 +171,7 @@ class QQQProcessor(LoopProcessor):
             stat["dynamic"] = self.qcfg.dynamic_get(layer_name=module.full_name)
 
         self.log.append(stat)
-        log.info(stat)
+        self.log_new_row(stat)
 
         self.result_save(module.full_name, {
             "scale": move_to(scale, device=CPU, stream=self.stream),
@@ -173,20 +180,20 @@ class QQQProcessor(LoopProcessor):
             "scale_extra": move_to(scale_extra, device=CPU, stream=self.stream),
         })
 
-        if self.retain_w:
-            # TODO need modify qqq.GPTQ
-            # original weights
-            w = module.weight.data
+        if self.calculate_w_wq_diff:
+            if module.weight.data.dtype == torch.float16:
+                # diff in float16
+                w_wq_diff = module.weight.data - wq
+            else:
+                # diff in float32
+                w_wq_diff = module.weight.data.to(dtype=torch.float32) - wq.to(dtype=torch.float32)
+
             module.state.update({
-                "w": w,  # bf16/fp16, non-quantized native weight
+                "w_wq_diff": w_wq_diff,
             })
 
-        gptq[module.name].free()
-
-        # logger.info(f"Quantizing module END: {name}, {gptq[name].shape()}")
-        module.state.update({
-            "wq": wq,  # fp16, quantized weight but not int4 (packed qweight)
-        })
+        with torch_streamCtx(module.target_device_stream):
+            wq = wq.to(device=DEVICE_0, non_blocking=True) # move to d0 for post quant inference
 
         # prepare for module.forward post generate
         module.weight.data = wq
@@ -194,7 +201,7 @@ class QQQProcessor(LoopProcessor):
     # submodule_finalized is called in reverse after all next sequential processes are called
     def submodule_finalize(self, module: NamedModule):
         # generate complete, safe to move to cpu
-        module.weight.data = move_to(module.state.pop("wq"), device=CPU, stream=self.stream) # large weights is slow to init on cpu
+        module.weight.data = move_to(module.weight.data, device=CPU, stream=self.stream) # large weights is slow to init on cpu
         module.state.pop("w", None) # no need for original weights now
 
     def finalize(self, model: BaseGPTQModel, **kwargs):

--- a/gptqmodel/looper/qqq_processor.py
+++ b/gptqmodel/looper/qqq_processor.py
@@ -30,7 +30,7 @@ from ..quantization.config import QUANT_METHOD, QuantizeConfig
 from ..quantization.qqq import QQQ
 from ..utils.logger import setup_logger
 from ..utils.model import move_to, pack_model
-from ..utils.torch import torch_sync, CPU
+from ..utils.torch import CPU, torch_sync
 
 log = setup_logger()
 

--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -59,7 +59,7 @@ from ..quantization import QUANT_CONFIG_FILENAME  # noqa: E402
 from ..utils import BACKEND  # noqa: E402
 from ..utils.eval import EVAL  # noqa: E402
 from ..utils.model import find_modules  # noqa: E402
-from ..utils.torch import torch_empty_cache, CPU  # noqa: E402
+from ..utils.torch import CPU, torch_empty_cache  # noqa: E402
 from .base import BaseGPTQModel, QuantizeConfig  # noqa: E402
 from .definitions.baichuan import BaiChuanGPTQ  # noqa: E402
 from .definitions.bloom import BloomGPTQ  # noqa: E402

--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -56,11 +56,10 @@ from transformers import AutoConfig, GenerationConfig, PreTrainedModel, PreTrain
 from ..adapter.adapter import Adapter, Lora, normalize_adapter  # noqa: E402
 from ..nn_modules.qlinear.torch import TorchQuantLinear  # noqa: E402
 from ..quantization import QUANT_CONFIG_FILENAME  # noqa: E402
-from ..quantization.gptq import CPU  # noqa: E402
 from ..utils import BACKEND  # noqa: E402
 from ..utils.eval import EVAL  # noqa: E402
 from ..utils.model import find_modules  # noqa: E402
-from ..utils.torch import torch_empty_cache  # noqa: E402
+from ..utils.torch import torch_empty_cache, CPU  # noqa: E402
 from .base import BaseGPTQModel, QuantizeConfig  # noqa: E402
 from .definitions.baichuan import BaiChuanGPTQ  # noqa: E402
 from .definitions.bloom import BloomGPTQ  # noqa: E402

--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -422,7 +422,7 @@ class BaseGPTQModel(nn.Module):
             "calibration_dataset_concat_size": calibration_dataset_concat_size,
             "batch_size": batch_size,
             "logger_board": logger_board,
-            "retain_w": needs_lora,  # lora needs original w
+            "calculate_w_wq_diff": needs_lora,  # lora needs original w - wq delta
         }
 
         # rotate model

--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -465,7 +465,9 @@ class BaseGPTQModel(nn.Module):
 
         if self.quantize_config.v2 is True:
             from ..looper.native_processor import NativeProcessor
-            quantize_processor.insert(0, NativeProcessor(**args))
+            args_clone = copy.deepcopy(args)
+            args_clone.pop("calculate_w_wq_diff", None)
+            quantize_processor.insert(0, NativeProcessor(**args_clone))
 
         processors = quantize_processor
         # Append EoRA processor for lora adapter

--- a/gptqmodel/nn_modules/hooked_linear.py
+++ b/gptqmodel/nn_modules/hooked_linear.py
@@ -41,9 +41,8 @@ class HookedConv1D(transformers.Conv1D):
         return custom
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        input_device = input.device
         input = input.to(device=self.weight.data.device)
-        output = super().forward(input).to(device=input_device)
+        output = super().forward(input)
         if self.forward_hook:
             self.forward_hook(self, (input,), output)
         return output
@@ -95,9 +94,8 @@ class HookedConv1d(torch.nn.Conv1d):
         return custom
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        input_device = input.device
         input = input.to(device=self.weight.data.device)
-        output = super().forward(input).to(device=input_device)
+        output = super().forward(input)
         if self.forward_hook:
             self.forward_hook(self, (input,), output)
         return output
@@ -150,9 +148,8 @@ class HookedConv2d(torch.nn.Conv2d):
         return custom
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        input_device = input.device
         input = input.to(device=self.weight.data.device)
-        output = super().forward(input).to(device=input_device)
+        output = super().forward(input)
         if self.forward_hook:
             self.forward_hook(self, (input,), output)
         return output
@@ -173,9 +170,8 @@ class HookedTransformerConv1D(transformers.Conv1D):
         return custom
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        input_device = input.device
         input = input.to(device=self.weight.data.device)
-        output = super().forward(input).to(device=input_device)
+        output = super().forward(input)
         if self.forward_hook:
             self.forward_hook(self, (input,), output)
         return output
@@ -197,9 +193,8 @@ class HookedLinear(torch.nn.Linear):
         return custom_linear
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        input_device = input.device
         input = input.to(device=self.weight.data.device)
-        output = super().forward(input).to(device=input_device)
+        output = super().forward(input)
         if self.forward_hook:
             self.forward_hook(self, (input,), output)
         return output

--- a/gptqmodel/nn_modules/hooked_linear.py
+++ b/gptqmodel/nn_modules/hooked_linear.py
@@ -41,7 +41,9 @@ class HookedConv1D(transformers.Conv1D):
         return custom
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        output = super().forward(input)
+        input_device = input.device
+        input = input.to(device=self.weight.data.device)
+        output = super().forward(input).to(device=input_device)
         if self.forward_hook:
             self.forward_hook(self, (input,), output)
         return output
@@ -93,7 +95,9 @@ class HookedConv1d(torch.nn.Conv1d):
         return custom
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        output = super().forward(input)
+        input_device = input.device
+        input = input.to(device=self.weight.data.device)
+        output = super().forward(input).to(device=input_device)
         if self.forward_hook:
             self.forward_hook(self, (input,), output)
         return output
@@ -146,7 +150,9 @@ class HookedConv2d(torch.nn.Conv2d):
         return custom
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        output = super().forward(input)
+        input_device = input.device
+        input = input.to(device=self.weight.data.device)
+        output = super().forward(input).to(device=input_device)
         if self.forward_hook:
             self.forward_hook(self, (input,), output)
         return output
@@ -167,7 +173,9 @@ class HookedTransformerConv1D(transformers.Conv1D):
         return custom
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        output = super().forward(input)
+        input_device = input.device
+        input = input.to(device=self.weight.data.device)
+        output = super().forward(input).to(device=input_device)
         if self.forward_hook:
             self.forward_hook(self, (input,), output)
         return output
@@ -189,7 +197,9 @@ class HookedLinear(torch.nn.Linear):
         return custom_linear
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        output = super().forward(input)
+        input_device = input.device
+        input = input.to(device=self.weight.data.device)
+        output = super().forward(input).to(device=input_device)
         if self.forward_hook:
             self.forward_hook(self, (input,), output)
         return output

--- a/gptqmodel/quantization/gptq.py
+++ b/gptqmodel/quantization/gptq.py
@@ -238,9 +238,12 @@ class GPTQ:
             self.process_batch(inp)
 
     def process_batch(self, inp: torch.Tensor):
+        device = inp.device
         # device = DEVICE_1
-        device = DEVICE_0
-        reshaped_inp = inp.to(device=device, dtype=torch.float32)
+        # device = DEVICE_0
+        # reshaped_inp = inp.to(device=device, dtype=torch.float32)
+        # del inp
+        reshaped_inp = inp
         del inp
 
         # input reshaping
@@ -279,6 +282,7 @@ class GPTQ:
                 reshaped_inp = unfold(reshaped_inp)
             reshaped_inp = reshaped_inp.transpose(1, 2).flatten(0, 1)
 
+        reshaped_inp = reshaped_inp.to(device=device, dtype=torch.float32)
         batch_token_size = reshaped_inp.shape[0]
 
         if self.H is None:

--- a/gptqmodel/quantization/gptq.py
+++ b/gptqmodel/quantization/gptq.py
@@ -32,7 +32,7 @@ from torch.nn.modules.conv import _ConvNd
 from ..looper.named_module import NamedModule
 from ..quantization import QuantizeConfig
 from ..utils.logger import setup_logger
-from ..utils.torch import torch_compile, torch_sync, CPU, device_next
+from ..utils.torch import CPU, device_next, torch_compile, torch_sync
 from .quantizer import HF_OPTIMUM, Quantizer
 
 log = setup_logger()

--- a/gptqmodel/quantization/gptq.py
+++ b/gptqmodel/quantization/gptq.py
@@ -19,7 +19,6 @@
 import math
 import os
 import sys
-import threading
 import time
 from typing import Optional
 
@@ -32,7 +31,7 @@ from torch.nn.modules.conv import _ConvNd
 from ..looper.named_module import NamedModule
 from ..quantization import QuantizeConfig
 from ..utils.logger import setup_logger
-from ..utils.torch import CPU, device_next, torch_compile, torch_streamCtx, torch_sync
+from ..utils.torch import device_next, torch_compile, torch_streamCtx, torch_sync
 from .quantizer import HF_OPTIMUM, Quantizer
 
 log = setup_logger()

--- a/gptqmodel/quantization/gptqv2.py
+++ b/gptqmodel/quantization/gptqv2.py
@@ -73,8 +73,8 @@ class GPTQv2(GPTQ):
     #     del native_inp, reshaped_inp
 
     def process_batch(self, inp):
-        inp = inp.to(device=self.device, dtype=torch.float32)
-        native_inp = self.native_inps.pop(0).to(device=self.device, dtype=torch.float32)
+        inp = inp.to(device=self.module.target_device, dtype=torch.float32)
+        native_inp = self.native_inps.pop(0).to(device=inp.device, dtype=torch.float32)
         if len(inp.shape) == 2:
             inp = inp.unsqueeze(0)
             native_inp = native_inp.unsqueeze(0)

--- a/gptqmodel/utils/torch.py
+++ b/gptqmodel/utils/torch.py
@@ -119,8 +119,10 @@ def torch_empty_cache(device: torch.device = None, gc: bool = True):
     # check all backends
     if device is None:
         if HAS_CUDA:
+            torch.cuda.synchronize()
             torch.cuda.empty_cache()
         if HAS_XPU:
+            torch.xpu.synchronize()
             torch.xpu.empty_cache()
         if HAS_MPS:
             torch.mps.empty_cache()

--- a/gptqmodel/utils/torch.py
+++ b/gptqmodel/utils/torch.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 import contextlib
 import gc as py_gc
-from typing import Callable, Union, List
+from typing import Callable, List, Union
 
 import torch
 from packaging.version import Version

--- a/gptqmodel/utils/torch.py
+++ b/gptqmodel/utils/torch.py
@@ -174,7 +174,7 @@ ALL_STREAMS = [torch.cuda.Stream(device=device) for device in ALL_DEVICES] if HA
 
 NEXT_DEVICE_INDEX = 0
 
-def device_next() -> (torch.device, Union[torch.cuda.StreamContext, torch.xpu.StreamContext]):
+def device_next() -> (torch.device, Union[torch.cuda.Stream, torch.xpu.Stream]):
     global NEXT_DEVICE_INDEX
     device = ALL_DEVICES[NEXT_DEVICE_INDEX]
     device_stream = ALL_STREAMS[NEXT_DEVICE_INDEX]
@@ -182,3 +182,6 @@ def device_next() -> (torch.device, Union[torch.cuda.StreamContext, torch.xpu.St
         NEXT_DEVICE_INDEX += 1
 
     return (device, device_stream)
+
+def torch_streamCtx(stream: Union[torch.cuda.Stream, torch.xpu.Stream]) -> StreamContext:
+    return torch.cuda.stream(stream) if HAS_CUDA else torch.xpu.stream(stream)

--- a/gptqmodel/utils/torch.py
+++ b/gptqmodel/utils/torch.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import gc as py_gc
-from typing import Callable, Union
+from typing import Callable, Union, List
 
 import torch
 from packaging.version import Version
@@ -150,3 +150,14 @@ def auto_select_torch_device(index: int = 0):
         device = torch.device("cpu") # cpu has no index
 
     return device
+
+# some device types can have multiple gpus cuda/rocm + xpu
+def torch_devices() -> List[torch.device]:
+    if HAS_CUDA:
+        return [torch.device(f"cuda:{i}") for i in range(torch.cuda.device_count())]
+    elif HAS_XPU:
+        return [torch.device(f"xpu:{i}") for i in range(torch.xpu.device_count())]
+    elif HAS_MPS:
+        return [torch.device("mps")]
+    else:
+        return [torch.device("cpu")]

--- a/gptqmodel/utils/torch.py
+++ b/gptqmodel/utils/torch.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import contextlib
 import gc as py_gc
 from typing import Callable, Union, List
 
@@ -83,7 +83,7 @@ def torch_new_stream_ctx():
         return torch.cuda.stream(torch_new_stream())
     if HAS_XPU:
         return torch.xpu.Stream(torch_new_stream())
-    return None
+    return contextlib.nullcontext()
 
 def torch_sync(device: torch.device = None):
     # check all backends

--- a/tests/models/model_test.py
+++ b/tests/models/model_test.py
@@ -211,7 +211,7 @@ class ModelTest(unittest.TestCase):
         is_ovis_model = model.__class__.__name__ == "OvisGPTQ"
         need_create_processor = is_image_to_text_model and not is_ovis_model
         if not is_quantized:
-            model.quantize(calibration_dataset, backend=self.QUANT_BACKEND, batch_size=batch_size)
+            model.quantize(calibration_dataset, backend=self.QUANT_BACKEND, batch_size=batch_size, buffered_fwd=True)
 
             self.check_kernel(model, self.KERNEL_QUANT)
 

--- a/tests/models/test_qwen3_moe.py
+++ b/tests/models/test_qwen3_moe.py
@@ -1,0 +1,30 @@
+# Copyright 2024-2025 ModelCloud.ai
+# Copyright 2024-2025 qubitium@modelcloud.ai
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from model_test import ModelTest
+
+
+class TestQwen3Moe(ModelTest):
+    NATIVE_MODEL_ID = "/monster/data/model/Qwen3-30B-A3B"
+    QUANT_ARC_MAX_DELTA_FLOOR_PERCENT = 0.2
+    NATIVE_ARC_CHALLENGE_ACC = 0.2739
+    NATIVE_ARC_CHALLENGE_ACC_NORM = 0.3055
+    TRUST_REMOTE_CODE = True
+    APPLY_CHAT_TEMPLATE = True
+    EVAL_BATCH_SIZE = 6
+
+    def test_mimo(self):
+        self.quant_lm_eval()

--- a/tests/test_quant_and_eora.py
+++ b/tests/test_quant_and_eora.py
@@ -51,7 +51,7 @@ class Test(ModelTest):
     @parameterized.expand(
         [
             (QUANT_METHOD.GPTQ, FORMAT.GPTQ, True), # gptq v2
-            (QUANT_METHOD.GPTQ, FORMAT.GPTQ, False), # gptq v1
+            # (QUANT_METHOD.GPTQ, FORMAT.GPTQ, False), # gptq v1
             #(QUANT_METHOD.QQQ, FORMAT.QQQ),
         ]
     )

--- a/tests/test_quant_and_eora.py
+++ b/tests/test_quant_and_eora.py
@@ -51,7 +51,7 @@ class Test(ModelTest):
     @parameterized.expand(
         [
             (QUANT_METHOD.GPTQ, FORMAT.GPTQ, True), # gptq v2
-            # (QUANT_METHOD.GPTQ, FORMAT.GPTQ, False), # gptq v1
+            (QUANT_METHOD.GPTQ, FORMAT.GPTQ, False), # gptq v1
             #(QUANT_METHOD.QQQ, FORMAT.QQQ),
         ]
     )


### PR DESCRIPTION
Refractor multi-gpu quantization with python threads. Compare to previous efforts:

* 2-3x less memory usage if you assign multiple GPUS up to 3 for Llama/Qwen style or 5 (tested) for MoE style. 
* Performance hit is much reduced verious pervious method. Small model only saw 1% slowdown. 
* This is not tensor-parallel so it will not make things faster, but actually around 1-5% slower dependng on model, gpu, and gpu to gpu memory latency.

With advent of python 3.13-3.14 and pytorch 2.7 concurrent gil context, it is possible to get Nx GPU improvement to MoE quantiation for next major refractor if we can cleanly decouple the thread/module code with multiple python/torch GIL context without any usage of tensor-parallel which I want to avoid at all-costs for now. 