### PR TITLE
fix older python didn't have EnumType

### DIFF
--- a/gptqmodel/utils/eval.py
+++ b/gptqmodel/utils/eval.py
@@ -16,7 +16,11 @@
 
 import json
 import os
-from enum import Enum, EnumType
+from enum import Enum
+try:
+    from enum import EnumType
+except ImportError:
+    EnumType = type(Enum)
 from typing import Dict, List, Optional, Type, Union
 
 from .evalplus import patch_evalplus


### PR DESCRIPTION
This PR fixes #1555

@Qubitium 