### PR TITLE
Add Falcon H1 model support

### DIFF
--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -123,6 +123,7 @@ from .definitions.starcoder2 import Starcoder2GPTQ  # noqa: E402
 from .definitions.telechat2 import TeleChat2GPTQ
 from .definitions.xverse import XverseGPTQ  # noqa: E402
 from .definitions.yi import YiGPTQ  # noqa: E402
+from .definitions.falcon_h1 import FalconH1GPTQ  # noqa: E402
 
 # make quants and inference more determinisitc
 torch.manual_seed(787)
@@ -194,6 +195,7 @@ MODEL_MAP = {
     "telechat": TeleChat2GPTQ,
     "instella": InstellaGPTQ,
     "mimo": MimoGPTQ,
+    "falcon_h1": FalconH1GPTQ,
 }
 
 SUPPORTED_MODELS = list(MODEL_MAP.keys())

--- a/gptqmodel/models/definitions/__init__.py
+++ b/gptqmodel/models/definitions/__init__.py
@@ -74,3 +74,4 @@ from .starcoder2 import Starcoder2GPTQ
 from .telechat2 import TeleChat2GPTQ
 from .xverse import XverseGPTQ
 from .yi import YiGPTQ
+from .falcon_h1 import FalconH1GPTQ

--- a/gptqmodel/models/definitions/falcon_h1.py
+++ b/gptqmodel/models/definitions/falcon_h1.py
@@ -25,8 +25,7 @@ class FalconH1GPTQ(BaseGPTQModel):
     layers_node = "model.layers"
     layer_type = "FalconH1DecoderLayer"
     layer_modules = [
-        ["feed_forward.gate_proj"],
-        ["feed_forward.up_proj"],
+        ["feed_forward.gate_proj", "feed_forward.up_proj"],
         ["feed_forward.down_proj"],
     ]
 

--- a/gptqmodel/models/definitions/falcon_h1.py
+++ b/gptqmodel/models/definitions/falcon_h1.py
@@ -1,0 +1,33 @@
+# Copyright 2024-2025 ModelCloud.ai
+# Copyright 2024-2025 qubitium@modelcloud.ai
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..base import BaseGPTQModel
+
+
+class FalconH1GPTQ(BaseGPTQModel):
+
+    base_modules = ["model.embed_tokens", "model.norm_f"]
+    pre_lm_head_norm_module = "model.norm_f"
+
+    layers_node = "model.layers"
+    layer_type = "FalconH1DecoderLayer"
+    layer_modules = [
+        ["feed_forward.gate_proj"],
+        ["feed_forward.up_proj"],
+        ["feed_forward.down_proj"],
+    ]
+
+


### PR DESCRIPTION
This pull request adds support for the Falcon H1 model to the GPTQModel repository. The following changes have been made:

- Added the falcon_h1 definition to the `gptqmodel/models/definitions` folder.
- Imported the falcon_h1 model in `gptqmodel/models/definitions/__init__.py`.
- Included falcon_h1 in the MODEL_MAP within `gptqmodel/models/auto.py`.

These updates enable the integration and usage of the Falcon H1 model within the framework.