### PR TITLE
feat(gemma3): also support larger gemma3 models and not only small te…

### DIFF
--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -80,7 +80,7 @@ from .definitions.dream import DreamGPTQ  # noqa: E402
 from .definitions.exaone import ExaoneGPTQ  # noqa: E402
 from .definitions.gemma import GemmaGPTQ  # noqa: E402
 from .definitions.gemma2 import Gemma2GPTQ  # noqa: E402
-from .definitions.gemma3 import Gemma3GPTQ  # noqa: E402
+from .definitions.gemma3 import Gemma3ForConditionalGenerationGPTQ, Gemma3GPTQ  # noqa: E402
 from .definitions.glm import GLM  # noqa: E402
 from .definitions.gpt2 import GPT2GPTQ  # noqa: E402
 from .definitions.gpt_bigcode import GPTBigCodeGPTQ  # noqa: E402
@@ -168,6 +168,7 @@ MODEL_MAP = {
     "gemma": GemmaGPTQ,
     "gemma2": Gemma2GPTQ,
     "gemma3_text": Gemma3GPTQ,
+    "gemma3": Gemma3ForConditionalGenerationGPTQ,
     "phi": PhiGPTQ,
     "phi3": Phi3GPTQ,
     "phi4mm": Phi4MMGPTQ,

--- a/gptqmodel/models/definitions/gemma3.py
+++ b/gptqmodel/models/definitions/gemma3.py
@@ -14,8 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ..base import BaseGPTQModel
 from . import LlamaGPTQ
 
 
 class Gemma3GPTQ(LlamaGPTQ):
     layer_type = "Gemma3DecoderLayer"
+
+class Gemma3ForConditionalGenerationGPTQ(BaseGPTQModel):
+    base_modules = ["model.language_model.embed_tokens", "model.language_model.norm"]
+    pre_lm_head_norm_module = "model.language_model.norm"
+
+    layers_node = "model.language_model.layers"
+    layer_type = "Gemma3DecoderLayer"
+    layer_modules = [
+        ["self_attn.k_proj", "self_attn.v_proj", "self_attn.q_proj"],
+        ["self_attn.o_proj"],
+        ["mlp.up_proj", "mlp.gate_proj"],
+        ["mlp.down_proj"],
+    ]
+
+    lm_head_module = "model.lm_head"


### PR DESCRIPTION
This PR add support for Gemma3 models larger than 1B. They have a vision encoder and are wrapped inside the `Gemma3ForConditionalGeneration`.