### PR TITLE
fix exception to avoid memory issue

### DIFF
--- a/gptqmodel/nn_modules/qlinear/exllama.py
+++ b/gptqmodel/nn_modules/qlinear/exllama.py
@@ -30,7 +30,7 @@ exllama_import_exception = None
 try:
     from gptqmodel_exllama_kernels import make_q4, q4_matmul
 except ImportError as e:
-    exllama_import_exception = e
+    exllama_import_exception = str(e)
 
 log = setup_logger()
 
@@ -112,7 +112,7 @@ class ExllamaQuantLinear(BaseQuantLinear):
     @classmethod
     def validate(cls, **args) -> Tuple[bool, Optional[Exception]]:
         if exllama_import_exception is not None:
-            return False, exllama_import_exception
+            return False, ImportError(exllama_import_exception)
         return cls._validate(**args)
 
     def post_init(self):

--- a/gptqmodel/nn_modules/qlinear/exllama_eora.py
+++ b/gptqmodel/nn_modules/qlinear/exllama_eora.py
@@ -30,7 +30,7 @@ exllama_eora_import_exception = None
 try:
     import gptqmodel_exllama_eora
 except ImportError as e:
-    exllama_eora_import_exception = e
+    exllama_eora_import_exception = str(e)
 
 log = setup_logger()
 
@@ -122,7 +122,7 @@ class ExllamaEoraQuantLinear(BaseQuantLinear):
     @classmethod
     def validate(cls, **args) -> Tuple[bool, Optional[Exception]]:
         if exllama_eora_import_exception is not None:
-            return False, exllama_eora_import_exception
+            return False, ImportError(exllama_eora_import_exception)
         return cls._validate(**args)
 
     def post_init(self):

--- a/gptqmodel/nn_modules/qlinear/exllamav2.py
+++ b/gptqmodel/nn_modules/qlinear/exllamav2.py
@@ -30,7 +30,7 @@ exllama_v2_import_exception = None
 try:
     from gptqmodel_exllamav2_kernels import gemm_half_q_half, make_q_matrix
 except ImportError as e:
-    exllama_v2_import_exception = e
+    exllama_v2_import_exception = str(e)
 
 log = setup_logger()
 
@@ -195,7 +195,7 @@ class ExllamaV2QuantLinear(BaseQuantLinear):
     @classmethod
     def validate(cls, **args) -> Tuple[bool, Optional[Exception]]:
         if exllama_v2_import_exception is not None:
-            return False, exllama_v2_import_exception
+            return False, ImportError(exllama_v2_import_exception)
         return cls._validate(**args)
 
     def post_init(self, temp_dq):

--- a/gptqmodel/nn_modules/qlinear/marlin.py
+++ b/gptqmodel/nn_modules/qlinear/marlin.py
@@ -33,7 +33,7 @@ marlin_import_exception = None
 try:
     import gptqmodel_marlin_kernels
 except ImportError as e:
-    marlin_import_exception = e
+    marlin_import_exception = str(e)
 
 log = setup_logger()
 
@@ -345,7 +345,7 @@ class MarlinQuantLinear(BaseQuantLinear):
     @classmethod
     def validate(cls, **args) -> Tuple[bool, Optional[Exception]]:
         if marlin_import_exception is not None:
-            return False, marlin_import_exception
+            return False, ImportError(marlin_import_exception)
         return cls._validate(**args)
 
     @classmethod

--- a/gptqmodel/nn_modules/qlinear/qqq.py
+++ b/gptqmodel/nn_modules/qlinear/qqq.py
@@ -22,13 +22,6 @@ from typing import List, Optional, Tuple
 import numpy as np
 import torch
 
-qqq_import_exception = None
-try:
-    import gptqmodel_qqq_kernels
-except ImportError as e:
-    qqq_import_exception = e
-
-
 from ...adapter.adapter import Adapter, Lora
 from ...models._const import DEVICE, PLATFORM
 from ...nn_modules.qlinear import BaseQuantLinear
@@ -40,7 +33,7 @@ qqq_import_exception = None
 try:
     import gptqmodel_qqq_kernels
 except ImportError as e:
-    qqq_import_exception = e
+    qqq_import_exception = str(e)
 
 log = setup_logger()
 
@@ -218,7 +211,7 @@ class QQQQuantLinear(BaseQuantLinear):
     @classmethod
     def validate(cls, **args) -> Tuple[bool, Optional[Exception]]:
         if qqq_import_exception is not None:
-            return False, qqq_import_exception
+            return False, ImportError(qqq_import_exception)
 
         in_features = args.get("in_features")
         out_features = args.get("out_features")


### PR DESCRIPTION
The exception `e` is not just an ImportError instance — it also stores a reference to a traceback object.
The traceback contains the entire call stack at the time of the error.
Keeping the exception as a global value will lead to the object not being released, for example:
```python
import sys
import torch
import gc
from diffusers import (
    FluxControlPipeline,
    FluxTransformer2DModel,
    GGUFQuantizationConfig,
)


torch_device = 0
accelerator_module = None
if torch.cuda.is_available():
    accelerator_module = torch.cuda
elif torch.xpu.is_available():
    accelerator_module = torch.xpu


def test_lora_loading():
    ckpt_path = "https://huggingface.co/city96/FLUX.1-dev-gguf/blob/main/flux1-dev-Q2_K.gguf"
    transformer = FluxTransformer2DModel.from_single_file(
        ckpt_path,
        quantization_config=GGUFQuantizationConfig(compute_dtype=torch.bfloat16),
        torch_dtype=torch.bfloat16,
    ).to(torch_device)
    pipe = FluxControlPipeline.from_pretrained(
        "black-forest-labs/FLUX.1-dev",
        transformer=transformer,
        torch_dtype=torch.bfloat16,
    ).to(torch_device)
    print(f"transformer ref before lora loading: {sys.getrefcount(transformer)}")
    pipe.load_lora_weights("black-forest-labs/FLUX.1-Canny-dev-lora")
    print(f"transformer ref after lora loading: {sys.getrefcount(transformer)}")

    del transformer
    del pipe
    gc.collect()
    accelerator_module.empty_cache()

print(f"memory before running: {accelerator_module.max_memory_allocated()}")
test_lora_loading()
print(f"memory after running: {accelerator_module.max_memory_allocated()}")
accelerator_module.reset_peak_memory_stats()
print(f"memory after reset_peak_memory_stats: {accelerator_module.max_memory_allocated()}")
```
Output before this PR:
```
memory before running: 0
transformer ref before lora loading: 3
transformer ref after lora loading: 12
memory after running: 15408069632
memory after reset_peak_memory_stats: 15408069632
```

We can keep the string of the exception instead of the exception object. In this case, we only store a string instead of the full traceback as the global value.

Output after this PR:
```
memory before running: 0
transformer ref before lora loading: 3
transformer ref after lora loading: 3
memory after running: 15408069632
memory after reset_peak_memory_stats: 0
```