### PR TITLE
Add gpt-neo model definition

### DIFF
--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -86,6 +86,7 @@ from .definitions.gemma3 import Gemma3ForConditionalGenerationGPTQ, Gemma3GPTQ  
 from .definitions.glm import GLM  # noqa: E402
 from .definitions.gpt2 import GPT2GPTQ  # noqa: E402
 from .definitions.gpt_bigcode import GPTBigCodeGPTQ  # noqa: E402
+from .definitions.gpt_neo import GPTNeoGPTQ  # noqa: E402
 from .definitions.gpt_neox import GPTNeoXGPTQ  # noqa: E402
 from .definitions.gptj import GPTJGPTQ  # noqa: E402
 from .definitions.granite import GraniteGPTQ  # noqa: E402
@@ -136,6 +137,7 @@ numpy.random.seed(787)
 MODEL_MAP = {
     "dream": DreamGPTQ,
     "bloom": BloomGPTQ,
+    "gpt_neo": GPTNeoGPTQ,
     "gpt_neox": GPTNeoXGPTQ,
     "gptj": GPTJGPTQ,
     "gpt2": GPT2GPTQ,

--- a/gptqmodel/models/definitions/__init__.py
+++ b/gptqmodel/models/definitions/__init__.py
@@ -40,6 +40,7 @@ from .gemma3 import Gemma3GPTQ
 from .glm import GLM
 from .gpt2 import GPT2GPTQ
 from .gpt_bigcode import GPTBigCodeGPTQ
+from .gpt_neo import GPTNeoGPTQ
 from .gpt_neox import GPTNeoXGPTQ
 from .gptj import GPTJGPTQ
 from .granite import GraniteGPTQ

--- a/gptqmodel/models/definitions/gpt_neo.py
+++ b/gptqmodel/models/definitions/gpt_neo.py
@@ -1,0 +1,32 @@
+# Copyright 2024-2025 ModelCloud.ai
+# Copyright 2024-2025 qubitium@modelcloud.ai
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..base import BaseGPTQModel
+
+
+class GPTNeoGPTQ(BaseGPTQModel):
+    base_modules = ["transformer.wte", "transformer.wpe", "transformer.ln_f"]
+    pre_lm_head_norm_module = "transformer.ln_f"
+    lm_head = "lm_head"
+
+    layers_node = ["transformer.h"]
+    layer_type = "GPTNeoBlock"
+    layer_modules = [
+        ["attn.attention.k_proj", "attn.attention.v_proj","attn.attention.q_proj"],
+        ["attn.attention.out_proj"],
+        ["mlp.c_fc"],
+        ["mlp.c_proj"],
+    ]


### PR DESCRIPTION
Small model without QKV bias and without RoPE which is an unusual combination.

Tested on MPS:
```sh
❯ PYTORCH_ENABLE_MPS_FALLBACK=1 python examples/quantization/basic_usage_wikitext2.py
[...]
test is a good idea, but I'm not sure that it's a good idea.
I'm not
Perplexity: 38.3164 [400 of 400] ████████████████████████████████████████████████████████████████████████████████| 0:02:13 / 0:02:13 [400/400] 100.0%
Quantized Model EleutherAI/gpt-neo-125m-gptq avg PPL is 39.33393188434296
```