### PR TITLE
[FIX] use AutoModelForImageTextToText instead of AutoModelForVision2Seq

### DIFF
--- a/gptqmodel/models/definitions/base_qwen2_vl.py
+++ b/gptqmodel/models/definitions/base_qwen2_vl.py
@@ -17,7 +17,7 @@
 from typing import Dict, Optional
 
 from PIL import Image
-from transformers import AutoModelForVision2Seq, AutoProcessor, ProcessorMixin
+from transformers import AutoModelForImageTextToText, AutoProcessor, ProcessorMixin
 
 from ...utils.calibration import batched
 from ...utils.image import extract_vision_info, fetch_image
@@ -27,7 +27,7 @@ from ..base import BaseGPTQModel
 
 
 class BaseQwen2VLGPTQ(BaseGPTQModel):
-    loader = AutoModelForVision2Seq
+    loader = AutoModelForImageTextToText
 
     base_modules = ["model.embed_tokens", "model.norm"]
     pre_lm_head_norm_module = "model.norm"


### PR DESCRIPTION
Fix Qwen 2.5-VL compat with latest transformers. 