### PR TITLE
Separate config options: mock_hessian_inverse and fast_loop instead of mock_quantization

### DIFF
--- a/gptqmodel/quantization/config.py
+++ b/gptqmodel/quantization/config.py
@@ -216,8 +216,10 @@ class QuantizeConfig():
     v2_alpha: float = 0.25
     v2_memory_device: str = "auto" #
 
-    # Skip all heavy computations for testing model loading
-    mock_quantization: bool = field(default=False, metadata={"help": "Skip heavy computations for fast model loading validation"})
+    # Intended to skip complex computational code paths during quantization to accelerate model quant testing
+    # can produce quants of slighlty less quality but much faster (at least in 8 bit)
+    mock_hessian_inverse: bool = field(default=False, metadata={"help": "Use simplified hessian inverse (identity matrix), v1, experimental, use with fast_loop for MoE models in case of skipped expert modules"})
+    fast_loop: bool = field(default=False, metadata={"help": "Fast version of quantization loop with different losses propogation and outcome, v1, experimental"})
 
     def __post_init__(self):
         fields_info = fields(self)


### PR DESCRIPTION
Note:
- for MoE models using `fast_loop` with small number of samples (10) or even large number of samples (1024) could lead to skipped quantization of expert modules, in such a case use `mock_hessian_inverse` as well

Several observations.
1. Here are few evals for Qwen3-0.6B with different options enabled, number of samples 10, batch size 10, number of samples shown for each module was 9790:
```
# original FP16
auto-round --model="/home/ubuntu/.cache/huggingface/hub/models--Qwen--Qwen3-0.6B/snapshots/c1899de289a04d12100db370d81485cdf75e47ca" --eval --device 0 --tasks lambada_openai --eval_bs 16
|    Tasks     |Version|Filter|n-shot|  Metric  |   | Value |   |Stderr|
|--------------|------:|------|-----:|----------|---|------:|---|-----:|
|lambada_openai|      1|none  |     0|acc       |↑  | 0.3996|±  |0.0068|
|              |       |none  |     0|perplexity|↓  |24.7832|±  |1.0502|

# mock_hessian_inverse=False, fast_loop=False
auto-round --model="/home/ubuntu/models/GPTQModel/Qwen3-0.6B-gptqmodel-w8g128-mock-inv-0-fast-0-bs10-s10" --eval --device 0 --tasks lambada_openai --eval_bs 16
|    Tasks     |Version|Filter|n-shot|  Metric  |   | Value |   |Stderr|
|--------------|------:|------|-----:|----------|---|------:|---|-----:|
|lambada_openai|      1|none  |     0|acc       |↑  | 0.3984|±  |0.0068|
|              |       |none  |     0|perplexity|↓  |24.8850|±  |1.0531|

# mock_hessian_inverse=False, fast_loop=True
auto-round --model="/home/ubuntu/models/GPTQModel/Qwen3-0.6B-gptqmodel-w8g128-mock-inv-0-fast-1-bs10-s10" --eval --device 0 --tasks lambada_openai --eval_bs 16
|    Tasks     |Version|Filter|n-shot|  Metric  |   | Value |   |Stderr|
|--------------|------:|------|-----:|----------|---|------:|---|-----:|
|lambada_openai|      1|none  |     0|acc       |↑  | 0.4011|±  |0.0068|
|              |       |none  |     0|perplexity|↓  |24.4086|±  |1.0299|

# mock_hessian_inverse=True, fast_loop=True
auto-round --model="/home/ubuntu/models/GPTQModel/Qwen3-0.6B-gptqmodel-w8g128-mock-inv-1-fast-1-bs10-s10" --eval --device 0 --tasks lambada_openai --eval_bs 16
|    Tasks     |Version|Filter|n-shot|  Metric  |   | Value |   |Stderr|
|--------------|------:|------|-----:|----------|---|------:|---|-----:|
|lambada_openai|      1|none  |     0|acc       |↑  | 0.3972|±  |0.0068|
|              |       |none  |     0|perplexity|↓  |25.0656|±  |1.0616|
```

2. The quant_log for losses comparison of Qwen3-0.6B:
[quant_log-mock-inv-0-fast-0.csv](https://github.com/user-attachments/files/21994897/quant_log-mock-inv-0-fast-0.csv)
[quant_log-mock-inv-0-fast-1.csv](https://github.com/user-attachments/files/21995427/quant_log-mock-inv-0-fast-1.csv)
[quant_log-mock-inv-1-fast-1.csv](https://github.com/user-attachments/files/21994899/quant_log-mock-inv-1-fast-1.csv)

The script used for quantization:
[quantize-qwen3-0.6B-gptqmodel-example.py](https://github.com/user-attachments/files/21994784/quantize-qwen3-0.6B-gptqmodel-example.py)
