### PR TITLE
cleanup checks for GIL control, GIL=0, and python >= 3.13.3t

### DIFF
--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -90,6 +90,7 @@ from .definitions.gpt2 import GPT2GPTQ  # noqa: E402
 from .definitions.gpt_bigcode import GPTBigCodeGPTQ  # noqa: E402
 from .definitions.gpt_neo import GPTNeoGPTQ  # noqa: E402
 from .definitions.gpt_neox import GPTNeoXGPTQ  # noqa: E402
+from .definitions.gpt_oss import GPTOSSGPTQ  # noqa: E402
 from .definitions.gptj import GPTJGPTQ  # noqa: E402
 from .definitions.granite import GraniteGPTQ  # noqa: E402
 from .definitions.grinmoe import GrinMOEGPTQ  # noqa: E402
@@ -130,7 +131,6 @@ from .definitions.starcoder2 import Starcoder2GPTQ  # noqa: E402
 from .definitions.telechat2 import TeleChat2GPTQ
 from .definitions.xverse import XverseGPTQ  # noqa: E402
 from .definitions.yi import YiGPTQ  # noqa: E402
-from .definitions.gpt_oss import GPTOSSGPTQ  # noqa: E402
 
 # make quants and inference more determinisitc
 torch.manual_seed(787)

--- a/gptqmodel/nn_modules/qlinear/tritonv2.py
+++ b/gptqmodel/nn_modules/qlinear/tritonv2.py
@@ -23,7 +23,7 @@ from ...adapter.adapter import Adapter, Lora
 from ...models._const import DEVICE, PLATFORM
 from ...utils.backend import BACKEND
 from ...utils.logger import setup_logger
-from ...utils.python import has_gil_control, has_gil_disabled
+from ...utils.python import has_gil_disabled
 from .torch import TorchQuantLinear
 
 try:

--- a/gptqmodel/nn_modules/qlinear/tritonv2.py
+++ b/gptqmodel/nn_modules/qlinear/tritonv2.py
@@ -23,12 +23,12 @@ from ...adapter.adapter import Adapter, Lora
 from ...models._const import DEVICE, PLATFORM
 from ...utils.backend import BACKEND
 from ...utils.logger import setup_logger
-from ...utils.python import has_gil
+from ...utils.python import has_gil_control, has_gil_disabled
 from .torch import TorchQuantLinear
 
 try:
     # TODO: triton is not compatible with free threading
-    if not has_gil():
+    if not has_gil_disabled():
         raise Exception("GIL is disabled so Triton is not (yet) compatible.")
 
     import triton

--- a/gptqmodel/utils/__init__.py
+++ b/gptqmodel/utils/__init__.py
@@ -22,15 +22,15 @@ log = setup_logger()
 
 # TODO: datasets is not compatible with free threading
 if has_gil_disabled():
-    log.info("Python GIL is disabled and GPTQModel will auto enable multi-gpu quant acceleration for some MoE models.")
+    log.info("Python GIL is disabled and GPTQModel will auto enable multi-gpu quant acceleration for MoE models plus multi-cpu accelerated packing.")
     from .perplexity import Perplexity
 else:
     if has_gil_control():
         log.warn(
             "Python >= 3.13T (free-threading) version detected but GIL is not disabled due to manual override or `regex` package compatibility which can be ignored. Please disable GIL via env `PYTHON_GIL=0`.")
 
-    log.info(
-        "Python GIL is enabled and multi-gpu quant acceleration for some MoE models is sub-optimal. Install Python >= 3.13.3t with Pytorch > 2.8 for mult-gpu quantization enable enable env `PYTHON_GIL=0`.")
+    log.warn(
+        "Python GIL is enabled: Multi-gpu quant acceleration for MoE models is sub-optimal and multi-core accelerated cpu packing is also disabled. We recommend Python >= 3.13.3t with Pytorch > 2.8 for mult-gpu quantization and multi-cpu packing with env `PYTHON_GIL=0`.")
 
     log_gil_requirements_for("utils/Perplexity")
 

--- a/gptqmodel/utils/__init__.py
+++ b/gptqmodel/utils/__init__.py
@@ -16,7 +16,7 @@
 
 from .backend import BACKEND
 from .logger import setup_logger
-from .python import has_gil_control, has_gil_disabled, log_gil_requirements_for, gt_python_3_13_3
+from .python import gt_python_3_13_3, has_gil_control, has_gil_disabled, log_gil_requirements_for
 
 log = setup_logger()
 

--- a/gptqmodel/utils/__init__.py
+++ b/gptqmodel/utils/__init__.py
@@ -16,7 +16,7 @@
 
 from .backend import BACKEND
 from .logger import setup_logger
-from .python import gt_python_3_13_3, has_gil_control, has_gil_disabled, log_gil_requirements_for
+from .python import gte_python_3_13_3, has_gil_control, has_gil_disabled, log_gil_requirements_for
 
 log = setup_logger()
 

--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -55,7 +55,7 @@ from ..nn_modules.qlinear.exllamav2 import ExllamaV2QuantLinear
 from ..nn_modules.qlinear.ipex import HAS_IPEX, IPEXQuantLinear
 from ..quantization import FORMAT, QuantizeConfig
 from ..quantization.config import FORMAT_FIELD_JSON, QUANT_METHOD, dynamic_get
-from . import has_gil
+from . import has_gil_control
 from .backend import BACKEND
 from .importer import select_quant_linear
 from .logger import setup_logger
@@ -642,7 +642,7 @@ def pack_model(
     names = list(qModules.keys())
     lock = threading.Lock()
 
-    if not has_gil():
+    if not has_gil_enabled():
         from device_smi import Device
         cpu = Device("cpu")
         max_packers = cpu.count * cpu.cores

--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -55,6 +55,7 @@ from ..nn_modules.qlinear.exllamav2 import ExllamaV2QuantLinear
 from ..nn_modules.qlinear.ipex import HAS_IPEX, IPEXQuantLinear
 from ..quantization import FORMAT, QuantizeConfig
 from ..quantization.config import FORMAT_FIELD_JSON, QUANT_METHOD, dynamic_get
+from . import has_gil_disabled
 from .backend import BACKEND
 from .importer import select_quant_linear
 from .logger import setup_logger
@@ -641,7 +642,7 @@ def pack_model(
     names = list(qModules.keys())
     lock = threading.Lock()
 
-    if not has_gil_enabled():
+    if has_gil_disabled():
         from device_smi import Device
         cpu = Device("cpu")
         max_packers = cpu.count * cpu.cores

--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -55,7 +55,6 @@ from ..nn_modules.qlinear.exllamav2 import ExllamaV2QuantLinear
 from ..nn_modules.qlinear.ipex import HAS_IPEX, IPEXQuantLinear
 from ..quantization import FORMAT, QuantizeConfig
 from ..quantization.config import FORMAT_FIELD_JSON, QUANT_METHOD, dynamic_get
-from . import has_gil_control
 from .backend import BACKEND
 from .importer import select_quant_linear
 from .logger import setup_logger

--- a/gptqmodel/utils/python.py
+++ b/gptqmodel/utils/python.py
@@ -1,3 +1,4 @@
+import platform
 import sys
 
 from gptqmodel.utils.logger import setup_logger

--- a/gptqmodel/utils/python.py
+++ b/gptqmodel/utils/python.py
@@ -1,16 +1,23 @@
 import sys
-
+from packaging.version import Version
 from gptqmodel.utils.logger import setup_logger
 
 log = setup_logger()
 
+# Check if GIL (global interpreter lock) is controllable in this Python build.
+# Starting from python 3.13 it is possible to disable GIL
+def has_gil_control():
+    return hasattr(sys, '_is_gil_enabled')
+
 # Check if GIL (global interpreter lock) is enabled.
 # Starting from python 3.13 it is possible to disable GIL
-def has_gil():
-    if hasattr(sys, '_is_gil_enabled'):
-        return sys._is_gil_enabled()
+def has_gil_disabled():
+    return has_gil_control() and not sys._is_gil_enabled()
 
-    return True
+# Check For Python > 3.13.3
+def gt_python_3_13_3():
+    return Version(platform.python_version()) >= Version("3.13.3")
 
-def log_gil_required(feature: str):
-    log.warn.once(f"Feature `{feature}` requires python GIL. Feature is currently skipped/disabled.")
+# torch compile requires GIL=1 or python 3.13.3t with GIL=0
+def log_gil_requirements_for(feature: str):
+    log.warn.once(f"Feature `{feature}` requires python GIL or Python > 3.13.3T (T for Threading-Free edition of Python) plus Torch 2.8. Feature is currently skipped/disabled.")

--- a/gptqmodel/utils/python.py
+++ b/gptqmodel/utils/python.py
@@ -17,7 +17,7 @@ def has_gil_disabled():
     return has_gil_control() and not sys._is_gil_enabled()
 
 # Check For Python > 3.13.3
-def gt_python_3_13_3():
+def gte_python_3_13_3():
     return Version(platform.python_version()) >= Version("3.13.3")
 
 # torch compile requires GIL=1 or python 3.13.3t with GIL=0

--- a/gptqmodel/utils/python.py
+++ b/gptqmodel/utils/python.py
@@ -1,6 +1,7 @@
 import sys
-from packaging.version import Version
+
 from gptqmodel.utils.logger import setup_logger
+from packaging.version import Version
 
 log = setup_logger()
 

--- a/gptqmodel/utils/torch.py
+++ b/gptqmodel/utils/torch.py
@@ -23,7 +23,7 @@ from packaging import version
 from torch.cpu import StreamContext
 
 from ..utils.logger import setup_logger
-from . import gt_python_3_13_3, has_gil_disabled, log_gil_requirements_for
+from . import gte_python_3_13_3, has_gil_disabled, log_gil_requirements_for
 
 # pytorch 2.6.0 fixes many compilation errors
 TORCH_HAS_COMPILE = version.parse(torch.__version__).release >= version.Version('2.6').release
@@ -71,7 +71,7 @@ except BaseException:
 
 def torch_compile(module: Union[torch.nn.Module, Callable], backend:str ="inductor", mode: str = None, fullgraph=False):
     # requires torch >2.8 for proper torch.compile + Python 3.13.3t (freethreading)
-    if has_gil_disabled() and not gt_python_3_13_3():
+    if has_gil_disabled() and not gte_python_3_13_3():
         log_gil_requirements_for("Torch Compile")
         return module
 

--- a/gptqmodel/utils/torch.py
+++ b/gptqmodel/utils/torch.py
@@ -23,7 +23,7 @@ from packaging import version
 from torch.cpu import StreamContext
 
 from ..utils.logger import setup_logger
-from . import gt_python_3_13_3, log_gil_requirements_for
+from . import gt_python_3_13_3, has_gil_disabled, log_gil_requirements_for
 
 # pytorch 2.6.0 fixes many compilation errors
 TORCH_HAS_COMPILE = version.parse(torch.__version__).release >= version.Version('2.6').release
@@ -71,7 +71,7 @@ except BaseException:
 
 def torch_compile(module: Union[torch.nn.Module, Callable], backend:str ="inductor", mode: str = None, fullgraph=False):
     # requires torch >2.8 for proper torch.compile + Python 3.13.3t (freethreading)
-    if not has_gil_enabled() and not gt_python_3_13_3():
+    if has_gil_disabled() and not gt_python_3_13_3():
         log_gil_requirements_for("Torch Compile")
         return module
 

--- a/gptqmodel/utils/torch.py
+++ b/gptqmodel/utils/torch.py
@@ -23,7 +23,7 @@ from packaging import version
 from torch.cpu import StreamContext
 
 from ..utils.logger import setup_logger
-from . import has_gil_control, log_gil_requirements_for, gt_python_3_13_3
+from . import gt_python_3_13_3, log_gil_requirements_for
 
 # pytorch 2.6.0 fixes many compilation errors
 TORCH_HAS_COMPILE = version.parse(torch.__version__).release >= version.Version('2.6').release

--- a/gptqmodel/utils/torch.py
+++ b/gptqmodel/utils/torch.py
@@ -23,7 +23,7 @@ from packaging import version
 from torch.cpu import StreamContext
 
 from ..utils.logger import setup_logger
-from . import has_gil, log_gil_required
+from . import has_gil_control, log_gil_requirements_for, gt_python_3_13_3
 
 # pytorch 2.6.0 fixes many compilation errors
 TORCH_HAS_COMPILE = version.parse(torch.__version__).release >= version.Version('2.6').release
@@ -70,10 +70,9 @@ except BaseException:
     pass
 
 def torch_compile(module: Union[torch.nn.Module, Callable], backend:str ="inductor", mode: str = None, fullgraph=False):
-    # requires torch >2.8 for proper torch.compile
-    # torch compile broken for free threading
-    if not has_gil():
-        log_gil_required("Torch Compile")
+    # requires torch >2.8 for proper torch.compile + Python 3.13.3t (freethreading)
+    if not has_gil_enabled() and not gt_python_3_13_3():
+        log_gil_requirements_for("Torch Compile")
         return module
 
     #from ..models.base import PYTORCH_MIN_VERSION_WITH_COMPILE


### PR DESCRIPTION
Cleanup some code for GIL checks and also add checks for torch compile which is now compatible with  free-threading but must be >= 3.13.3t. 