### PR TITLE
reduce pkg depend

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ huggingface_hub>=0.34.4
 random_word==1.0.13
 tokenicer==0.0.4
 logbar==0.0.4
-# for Qwen-Omni model
-soundfile==0.13.1
+# req for Qwen-Omni model
+# soundfile==0.13.1
 # try to resolve some pip install issues
 wheel>=0.45.1
 # python 3.l3t may need this package


### PR DESCRIPTION
soundfile is only used for Qwen-Omni, those who need it should install the pkg manually.