### PR TITLE
avoid building experimental extensions to reduce wheel size

### DIFF
--- a/gptqmodel/nn_modules/qlinear/exllama_eora.py
+++ b/gptqmodel/nn_modules/qlinear/exllama_eora.py
@@ -89,7 +89,7 @@ class ExllamaEoraQuantLinear(BaseQuantLinear):
     ):
         if exllama_eora_import_exception is not None:
             raise ValueError(
-                f"Trying to use the exllama v2 backend, but could not import the C++/CUDA dependencies with the following error: {exllama_eora_import_exception}"
+                f"Trying to use the Exllama EoRA v2 backend, but could not import the C++/CUDA dependencies with the following error: {exllama_eora_import_exception}"
             )
 
         # # backup original values

--- a/setup.py
+++ b/setup.py
@@ -287,15 +287,16 @@ if BUILD_CUDA_EXT == "1":
                         extra_link_args=extra_link_args,
                         extra_compile_args=extra_compile_args,
                     ),
-                    cpp_ext.CUDAExtension(
-                        'gptqmodel_exllama_eora',
-                        [
-                            "gptqmodel_ext/exllama_eora/eora/q_gemm.cu",
-                            "gptqmodel_ext/exllama_eora/eora/pybind.cu",
-                        ],
-                        extra_link_args=extra_link_args,
-                        extra_compile_args=extra_compile_args,
-                    ),
+                    # TODO re-enable after Nvidia readies fixed fused kernel for EoRA
+                    # cpp_ext.CUDAExtension(
+                    #     'gptqmodel_exllama_eora',
+                    #     [
+                    #         "gptqmodel_ext/exllama_eora/eora/q_gemm.cu",
+                    #         "gptqmodel_ext/exllama_eora/eora/pybind.cu",
+                    #     ],
+                    #     extra_link_args=extra_link_args,
+                    #     extra_compile_args=extra_compile_args,
+                    # ),
                     # TODO: VC++: error lnk2001 unresolved external symbol cublasHgemm
                     cpp_ext.CUDAExtension(
                         "gptqmodel_exllamav2_kernels",


### PR DESCRIPTION
@nbasyl  I am doing to disable the compilation of the eora kernel by default to reduce wheel size until the updated kernel with fixed precision for fused ops is ready. 