### PR TITLE
[CI] torch-2.6.0+cu128-python-3.9 does not exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,9 +152,9 @@ jobs:
           # - cuda: 128
           #   torch: 2.7.0
           #   python: 39
-          - cuda: 128
-            torch: 2.6.0
-            python: 39
+          # - cuda: 128
+          #   torch: 2.6.0
+          #   python: 39
           # - cuda: 126
           #   torch: 2.8.0
           #   python: 39


### PR DESCRIPTION
@Qubitium 