### PR TITLE
eora: always diff in fp32 + cleanup

### DIFF
--- a/gptqmodel/eora/eora.py
+++ b/gptqmodel/eora/eora.py
@@ -19,7 +19,6 @@ from typing import Dict, Tuple
 import torch
 from torch import Tensor
 
-from ..looper.named_module import NamedModule
 from ..utils.logger import setup_logger
 from ..utils.rocm import IS_ROCM
 
@@ -42,7 +41,7 @@ def eora_process_input(input: Tensor, name: str, eigen_scaling_diag_matrix: Dict
 
 def eora_compute_lora(
         w_wq_delta: Tensor, # need the w (original weight) and wq (quantized qweight) delta in float32
-        module: NamedModule,
+        name: str,
         eigen_scaling_diag_matrix: torch.dtype,
         rank: int,
         dtype: torch.dtype,
@@ -63,7 +62,7 @@ def eora_compute_lora(
 
     if (L < 0).any():
         ## When expanding the calibration data size for EoRA, I suggest maintaining the balance by allocating 50% to general input (C4) and the remaining 50% to downstream task data.
-        log.warn(f"Found negative eigenvalues in `{module.name}`. Please increase your calibration data set for EoRA.")
+        log.warn(f"Found negative eigenvalues in `{name}`. Please increase your calibration data set for EoRA.")
         minimum = torch.min(L[L > 0])
         L[L < 0] = minimum
 

--- a/gptqmodel/looper/dequantize_processor.py
+++ b/gptqmodel/looper/dequantize_processor.py
@@ -29,23 +29,18 @@ class DequantizeProcessor(LoopProcessor):
     # de-quantize weights
     def process(self, module: NamedModule, auto_gc: bool = True):
         device = module.weight.device
-        w = module.weight.data
 
         # TODO fix num_itr param..need to calculate this before dequant
         with self.lock:
             m = self.quantized_modules.pop(module.full_name)
             m.optimize()
-        log.info(f"Dequantize: `{m.name}`")
+        # log.info(f"Dequantize: `{m.name}`")
 
         # TODO: we can optimize this and dequant + w - wq on cpu
         wq = m.dequantize_weight().T.to(device=device)
 
-        if module.weight.data.dtype == torch.float16:
-            # diff in float16
-            w_wq_diff = w - wq
-        else:
-            # diff in float32
-            w_wq_diff = module.weight.data.to(dtype=torch.float32) - wq.to(dtype=torch.float32)
+        # diff in float32
+        w_wq_diff = module.weight.data.to(dtype=torch.float32) - wq.to(dtype=torch.float32)
 
         module.state.update({
             "w_wq_diff": w_wq_diff,

--- a/gptqmodel/looper/eora_processor.py
+++ b/gptqmodel/looper/eora_processor.py
@@ -132,7 +132,7 @@ class EoraProcessor(LoopProcessor):
         # log.info(f"EoRA: module native dtype = `{module_native_dtype}")
         A, B = self.eora_compute_lora(
             w_wq_delta=w_wq_delta,
-            module=module,
+            name=module.name,
             eigen_scaling_diag_matrix=eigen_scaling_diag_matrix,
             rank=module.adapter_cfg.rank,
             dtype=module.module_dtype,

--- a/gptqmodel/looper/gptq_processor.py
+++ b/gptqmodel/looper/gptq_processor.py
@@ -188,12 +188,8 @@ class GPTQProcessor(LoopProcessor):
         self.log_new_row(stat)
 
         if self.calculate_w_wq_diff:
-            if module.weight.data.dtype == torch.float16:
-                # diff in float16
-                w_wq_diff = module.weight.data - wq
-            else:
-                # diff in float32
-                w_wq_diff = module.weight.data.to(dtype=torch.float32) - wq.to(dtype=torch.float32)
+            # diff in float32
+            w_wq_diff = module.weight.data.to(dtype=torch.float32) - wq.to(dtype=torch.float32)
 
             module.state.update({
                 "w_wq_diff": w_wq_diff,

--- a/tests/test_post_quant_eora.py
+++ b/tests/test_post_quant_eora.py
@@ -27,7 +27,6 @@ from gptqmodel import BACKEND, GPTQModel  # noqa: E402
 from gptqmodel.adapter.adapter import Lora  # noqa: E402
 from gptqmodel.utils.eval import EVAL  # noqa: E402
 from gptqmodel.utils.torch import torch_empty_cache  # noqa: E402
-from lm_eval.utils import make_table  # noqa: E402
 from models.model_test import ModelTest  # noqa: E402
 
 
@@ -101,22 +100,22 @@ class TestEoraPostQuant(ModelTest):
                 auto_gc=auto_gc)
 
             # BACKEND.EXLLAMA_V2, BACKEND.EXLLAMA_V1, BACKEND.TRITON, BACKEND.CUDA,
-            for backend in [BACKEND.MARLIN]:  # BACKEND.IPEX, BACKEND.BITBLAS, BACKEND.EXLLAMA_V2V BACKEND.MARLIN
-                base_bench = bench(path=self.QUANTIZED_MODEL_PATH, backend=backend, adapter=None)  # inference using qweights only
-                eora_bench = bench(path=self.QUANTIZED_MODEL_PATH, backend=backend, adapter=eora)  # inference using eora (lora)
-
-                print('--------Quant/EoRA Config ---------')
-
-                # Convert the dictionary to a list of lists for tabulate
-                table_data = [[key, value] for key, value in config_dict.items()]
-                print(tabulate(table_data, headers=["Key", "Value"], tablefmt="grid"))
-
-                print('--------Eval Base Result---------')
-                print(make_table(base_bench))
-                if "groups" in base_bench:
-                    print(make_table(base_bench, "groups"))
-
-                print('--------Eval EoRA Result---------')
-                print(make_table(eora_bench))
-                if "groups" in eora_bench:
-                    print(make_table(eora_bench, "groups"))
+            # for backend in [BACKEND.MARLIN]:  # BACKEND.IPEX, BACKEND.BITBLAS, BACKEND.EXLLAMA_V2V BACKEND.MARLIN
+            #     base_bench = bench(path=self.QUANTIZED_MODEL_PATH, backend=backend, adapter=None)  # inference using qweights only
+            #     eora_bench = bench(path=self.QUANTIZED_MODEL_PATH, backend=backend, adapter=eora)  # inference using eora (lora)
+            #
+            #     print('--------Quant/EoRA Config ---------')
+            #
+            #     # Convert the dictionary to a list of lists for tabulate
+            #     table_data = [[key, value] for key, value in config_dict.items()]
+            #     print(tabulate(table_data, headers=["Key", "Value"], tablefmt="grid"))
+            #
+            #     print('--------Eval Base Result---------')
+            #     print(make_table(base_bench))
+            #     if "groups" in base_bench:
+            #         print(make_table(base_bench, "groups"))
+            #
+            #     print('--------Eval EoRA Result---------')
+            #     print(make_table(eora_bench))
+            #     if "groups" in eora_bench:
+            #         print(make_table(eora_bench, "groups"))

--- a/tests/test_post_quant_eora.py
+++ b/tests/test_post_quant_eora.py
@@ -19,16 +19,15 @@ import os
 os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
 # -- end do not touch
 
-import gzip  # noqa: E402
-import json
 import tempfile  # noqa: E402
 from typing import Optional  # noqa: E402
 
+from datasets import load_dataset
 from gptqmodel import BACKEND, GPTQModel  # noqa: E402
 from gptqmodel.adapter.adapter import Lora  # noqa: E402
 from gptqmodel.utils.eval import EVAL  # noqa: E402
 from gptqmodel.utils.torch import torch_empty_cache  # noqa: E402
-# from lm_eval.utils import make_table  # noqa: E402
+from lm_eval.utils import make_table  # noqa: E402
 from models.model_test import ModelTest  # noqa: E402
 
 
@@ -76,12 +75,14 @@ class TestEoraPostQuant(ModelTest):
         calibration_dataset_concat_size = 0  # disable
         auto_gc = False
 
+        dataset_id = "allenai/c4"
+        dataset_files = "en/c4-train.00001-of-01024.json.gz"
 
-        with gzip.open("/monster/data/model/dataset/c4-train.00000-of-01024.json.gz", 'rt', encoding='utf-8') as f:
-            data = [json.loads(line)["text"] for line in f]
-            calibration_dataset = data[:calibration_dataset_rows]
-
-        # calibration_dataset = self.load_dataset(rows=calibration_dataset_rows)["text"]
+        calibration_dataset = load_dataset(
+            dataset_id,
+            data_files=dataset_files,
+            split="train"
+        ).select(range(calibration_dataset_rows))["text"]
 
         with tempfile.TemporaryDirectory() as tmpdir:
             eora = Lora(
@@ -100,22 +101,22 @@ class TestEoraPostQuant(ModelTest):
                 auto_gc=auto_gc)
 
             # BACKEND.EXLLAMA_V2, BACKEND.EXLLAMA_V1, BACKEND.TRITON, BACKEND.CUDA,
-            # for backend in [BACKEND.TORCH]:  # BACKEND.IPEX, BACKEND.BITBLAS, BACKEND.EXLLAMA_V2V BACKEND.MARLIN
-            #     base_bench = bench(path=self.QUANTIZED_MODEL_PATH, backend=backend, adapter=None)  # inference using qweights only
-            #     eora_bench = bench(path=self.QUANTIZED_MODEL_PATH, backend=backend, adapter=eora)  # inference using eora (lora)
-            #
-            #     print('--------Quant/EoRA Config ---------')
-            #
-            #     # Convert the dictionary to a list of lists for tabulate
-            #     table_data = [[key, value] for key, value in config_dict.items()]
-            #     print(tabulate(table_data, headers=["Key", "Value"], tablefmt="grid"))
-            #
-            #     print('--------Eval Base Result---------')
-            #     print(make_table(base_bench))
-            #     if "groups" in base_bench:
-            #         print(make_table(base_bench, "groups"))
-            #
-            #     print('--------Eval EoRA Result---------')
-            #     print(make_table(eora_bench))
-            #     if "groups" in eora_bench:
-            #         print(make_table(eora_bench, "groups"))
+            for backend in [BACKEND.MARLIN]:  # BACKEND.IPEX, BACKEND.BITBLAS, BACKEND.EXLLAMA_V2V BACKEND.MARLIN
+                base_bench = bench(path=self.QUANTIZED_MODEL_PATH, backend=backend, adapter=None)  # inference using qweights only
+                eora_bench = bench(path=self.QUANTIZED_MODEL_PATH, backend=backend, adapter=eora)  # inference using eora (lora)
+
+                print('--------Quant/EoRA Config ---------')
+
+                # Convert the dictionary to a list of lists for tabulate
+                table_data = [[key, value] for key, value in config_dict.items()]
+                print(tabulate(table_data, headers=["Key", "Value"], tablefmt="grid"))
+
+                print('--------Eval Base Result---------')
+                print(make_table(base_bench))
+                if "groups" in base_bench:
+                    print(make_table(base_bench, "groups"))
+
+                print('--------Eval EoRA Result---------')
+                print(make_table(eora_bench))
+                if "groups" in eora_bench:
+                    print(make_table(eora_bench, "groups"))


### PR DESCRIPTION
@nbasyl  We just did a major refractor of internals to add AWQ. Just a little cleanup in the `EoRA` paths. The biggest change is doing all diff in fp32. It appears if the diff in fp16 is very small, it can actually result in 0.0 if we don't upcast to fp32. 

We have not tested awq and eora execution paths but I believe `eora` may also work with `awq`?