### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,6 +351,8 @@ jobs:
           overwrite: true
 
   release-source:
+    permissions:
+      contents: write
     runs-on: [ self-hosted, xeon5 ]
     needs:
       - check-vm


### PR DESCRIPTION
Potential fix for [https://github.com/ModelCloud/GPTQModel/security/code-scanning/17](https://github.com/ModelCloud/GPTQModel/security/code-scanning/17)

To fix the problem, an explicit `permissions` block should be added to the workflow, targeting at least the `release-source` job (or higher up, if appropriate), specifying the minimal permissions required for that job to execute correctly. For starters, CodeQL recommends `contents: read`, but any additional requirements (such as `contents: write` for uploading to releases, or `packages: write` for publishing packages to the registry) should be added based on the workflow's actual needs. The most effective fix is to add a `permissions` key under the affected job (`release-source`), before the `runs-on` line, with the minimal required values, e.g.:

```yaml
permissions:
  contents: read
```

If uploading release assets is needed, you may need `contents: write` instead of `read`. Since the job uses both local uploading and a release upload step, it likely requires `contents: write`. The block should be inserted immediately before or after the `needs:` block in the `release-source` job, on line 354.

No additional imports or helpers are needed; this is a workflow syntax change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
