### PR TITLE
correctly report the actual kernel names

### DIFF
--- a/gptqmodel/nn_modules/qlinear/awq_gemv.py
+++ b/gptqmodel/nn_modules/qlinear/awq_gemv.py
@@ -37,7 +37,7 @@ class AwqGEMVQuantLinear(AWQuantLinear):
     SUPPORTS_DTYPES = [torch.float16, torch.bfloat16]
 
     # for transformers/optimum tests compat
-    QUANT_TYPE = "awq_gemm"
+    QUANT_TYPE = "awq_gemv"
 
     def __init__(
         self,

--- a/gptqmodel/nn_modules/qlinear/awq_gemv_fast.py
+++ b/gptqmodel/nn_modules/qlinear/awq_gemv_fast.py
@@ -37,7 +37,7 @@ class AwqGEMVFastQuantLinear(AWQuantLinear):
     SUPPORTS_DTYPES = [torch.float16]
 
     # for transformers/optimum tests compat
-    QUANT_TYPE = "awq_gemm"
+    QUANT_TYPE = "awq_gemv_fast"
 
     def __init__(
         self,

--- a/gptqmodel/nn_modules/qlinear/awq_marlin.py
+++ b/gptqmodel/nn_modules/qlinear/awq_marlin.py
@@ -58,7 +58,7 @@ class AwqMarlinQuantLinear(AWQuantLinear):
     REQUIRES_FORMAT_V2 = False
 
     # for transformers/optimum tests compat
-    QUANT_TYPE = "marlin"
+    QUANT_TYPE = "awq_marlin"
 
     # num_bits -> type
     TYPE_MAP = {

--- a/gptqmodel/nn_modules/qlinear/torch_fused.py
+++ b/gptqmodel/nn_modules/qlinear/torch_fused.py
@@ -54,7 +54,7 @@ class TorchFusedQuantLinear(PackableQuantLinear):
     REQUIRES_FORMAT_V2 = True
 
     # for transformers/optimum tests compat
-    QUANT_TYPE = "torch"
+    QUANT_TYPE = "torch_fused"
 
     def __init__(
         self,


### PR DESCRIPTION
@jiqing-feng  This PR will make the kernels report the `correct` names and remove the fakes name previously reported so we can pass `transformer`, `peft`, `optimum` ci tests. I will be submitting parallel PRs to them due to large changes in GPT-QModel v5.0.0 which will remove all legacy autogptq code and bad ci check for QUANT-TYPE as `torch`. They should never check what kernel is returned, unless they directly asked for a specific kernel, and just use whatever we give them. 