### PR TITLE
Fix for #2116 When all modules of a layer excluded there is an error in forward replay

### DIFF
--- a/gptqmodel/looper/module_looper.py
+++ b/gptqmodel/looper/module_looper.py
@@ -1731,7 +1731,7 @@ class ModuleLooper():
                             time.perf_counter() - replay_start,
                             source=replay_source,
                         )
-                
+
                 # Finalize module after last processor
                 if p_index == len(self.processors) - 1:
                     torch_sync()


### PR DESCRIPTION
@Qubitium please review the fix for #2116