### PR TITLE
Retry partial.to to fix accelerate invalid argument error for first moe layer for >4 GPU setups

### DIFF
--- a/gptqmodel/quantization/gptq.py
+++ b/gptqmodel/quantization/gptq.py
@@ -500,23 +500,19 @@ class GPTQ:
 
             for partial_device, partial in self._device_hessian_partials.items():
                 if partial.device != result_accum.device or partial.dtype != torch.float32:
+                    # TODO FIXME multi-3090 using P2P is revaling an issue where result_accum and/or partial is not ready for consolidation on the main thread
+                    # when parials are calculated on the individual 
                     try:
                         tmp = partial.to(device=result_accum.device, dtype=torch.float32)
                         result_accum.add_(tmp)
                         del tmp
                     except:
                         log.warn(f"Quantization: Module `{self.name}` -> Retry 1/2 partial.to in 0.5s")
-                        time.sleep(0.5)
-                        try:
-                            tmp = partial.to(device=result_accum.device, dtype=torch.float32)
-                            result_accum.add_(tmp)
-                            del tmp
-                        except:
-                            log.warn(f"Quantization: Module `{self.name}` -> Retry 2/2 partial.to in 0.5s")
-                            time.sleep(0.5)
-                            tmp = partial.to(device=result_accum.device, dtype=torch.float32)
-                            result_accum.add_(tmp)
-                            del tmp
+                        time.sleep(0.25)
+                        tmp = partial.to(device=result_accum.device, dtype=torch.float32)
+                        result_accum.add_(tmp)
+                        del tmp
+                       
                 else:
                     result_accum.add_(partial)
 


### PR DESCRIPTION
It works for me with 8x3090 from the first attempt.
<img width="1707" height="685" alt="image" src="https://github.com/user-attachments/assets/de10673c-8e58-4cff-9390-fa7f34df7755" />

I had the issue on the first layer with experts similar to one we overcome in early version with lock, for me retry works well, as it thrown only on first layer, do not see much reason in a lock there.

The original error trace that is fixed by PR:
```
Traceback (most recent call last):j in layer      [1 of 45] ████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░| 0:01:02 / 0:23:46 [2/46] 4.3%
  File "/home/ubuntu/venvs/gptqmodelt/lib/python3.13t/site-packages/gptqmodel/utils/threadx.py", line 484, in _run
    result = fn(*args, **kwargs)
  File "/home/ubuntu/venvs/gptqmodelt/lib/python3.13t/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
  File "/home/ubuntu/venvs/gptqmodelt/lib/python3.13t/site-packages/gptqmodel/looper/module_looper.py", line 1608, in _process_on_worker
    proc.process(module=nm)
    ~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/ubuntu/venvs/gptqmodelt/lib/python3.13t/site-packages/gptqmodel/looper/gptq_processor.py", line 162, in process
    wq, q_scales, q_zeros, q_g_idx, duration, avg_loss, damp_percent, nsamples = g.quantize()
                                                                                 ~~~~~~~~~~^^
  File "/home/ubuntu/venvs/gptqmodelt/lib/python3.13t/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
  File "/home/ubuntu/venvs/gptqmodelt/lib/python3.13t/site-packages/gptqmodel/quantization/gptq.py", line 602, in quantize
    self.finalize_hessian(target_device=target_device)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/venvs/gptqmodelt/lib/python3.13t/site-packages/gptqmodel/quantization/gptq.py", line 520, in finalize_hessian
    self._materialize_global_hessian(target_device=target_device)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/venvs/gptqmodelt/lib/python3.13t/site-packages/gptqmodel/quantization/gptq.py", line 503, in _materialize_global_hessian
    tmp = partial.to(device=result_accum.device, dtype=torch.float32)
torch.AcceleratorError: CUDA error: invalid argument
```