### PR TITLE
fix compiler warning: project.license is deprecated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]
 description = "Production ready LLM model compression/quantization toolkit with hw accelerated inference support for both cpu/gpu via HF, vLLM, and SGLang."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 license-files = [ "LICENSE", "licenses/LICENSE.apache" ]
 authors = [{ name = "ModelCloud", email = "qubitium@modelcloud.ai" }]
 keywords = ["gptq", "awq", "qqq", "autogptq", "autoawq", "eora", "gar", "quantization", "large-language-models", "transformers", "llm", "moe", "compression"]


### PR DESCRIPTION
@Qubitium 