### PR TITLE
Fix bitblas support for gptq_v2 format

### DIFF
--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -252,7 +252,7 @@ def make_quant(
     pack_dtype = qcfg.pack_dtype
 
     # Bitblas needs to be loaded as gptq's quant linear first, and then converted to bitblas format.
-    if not pack and format == FORMAT.GPTQ and backend == BACKEND.BITBLAS:
+    if not pack and format in (FORMAT.GPTQ, FORMAT.GPTQ_V2) and backend == BACKEND.BITBLAS:
         backend = BACKEND.TORCH
 
     # returns multiple validated kernels

--- a/tests/test_bitblas_gptq_v2.py
+++ b/tests/test_bitblas_gptq_v2.py
@@ -1,0 +1,24 @@
+import os
+
+import pytest
+import torch
+
+from gptqmodel.nn_modules.qlinear.bitblas import (
+    BITBLAS_AVAILABLE,
+    import_bitblas,
+)
+
+from gptqmodel import GPTQModel, BACKEND
+from gptqmodel.quantization.config import FORMAT
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for BitBLAS")
+@pytest.mark.skipif(not BITBLAS_AVAILABLE, reason="BitBLAS backend is not available")
+def test_bitblas_forward_pass():
+    import_bitblas()
+
+    device_index = int(os.environ.get("BITBLAS_TEST_DEVICE", 0))
+    torch.cuda.set_device(device_index)
+
+    # Load a dummy model (1.0 GB) to test if there are errors while converting to bitblas
+    # Take a few minutes for compiling (1st run) and repacking (each time)
+    GPTQModel.load("XXXXyu/Qwen3-1.7B-w2g64-gptq_v2", trust_remote_code=True, backend=BACKEND('bitblas'))


### PR DESCRIPTION
Fix https://github.com/ModelCloud/GPTQModel/issues/2272.

I've added a test that requires downloading a 1 GB checkpoint (feel free to remove it).