### PR TITLE
fix hf kernel

### DIFF
--- a/gptqmodel/nn_modules/qlinear/gemm_hf_kernel.py
+++ b/gptqmodel/nn_modules/qlinear/gemm_hf_kernel.py
@@ -79,7 +79,7 @@ class HFKernelLinear(PackableQuantLinear):
         try:
             from kernels import get_kernel
 
-            cls.gemm_int4_forward_kernel = get_kernel("kernels-community/quantization_gptq").gemm_int4_forward
+            cls.gemm_int4_forward_kernel = staticmethod(get_kernel("kernels-community/quantization_gptq").gemm_int4_forward)
             return True, None
         except Exception as exc:  # pragma: no cover - best effort fallback
             log.warning("Failed to load CPU gemm_4bit kernel: %s. Use fallback path. \


### PR DESCRIPTION
Without static method, this function will treat self as the 1st input args and raise error like:
`*** TypeError: gemm_int4_forward() takes 5 positional arguments but 6 were given`