### PR TITLE
[CI] uninstall pynvml

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -521,8 +521,8 @@ jobs:
           # deps may reinstalled torch
           uv pip install torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0 --index-url https://download.pytorch.org/whl/cu128
           
-          echo "===== uninstall torchao ====="
-          uv pip uninstall torchao
+          echo "===== uninstall torchao pynvml ====="
+          uv pip uninstall torchao pynvml
 
           echo "::group::pip list"
           pip list


### PR DESCRIPTION
@Qubitium 

both pynvml and nvidia-ml-py are installed on CI, maybe old dependencies added a long time ago