### PR TITLE
[FIX] model_test

### DIFF
--- a/tests/models/model_test.py
+++ b/tests/models/model_test.py
@@ -949,7 +949,6 @@ class ModelTest(unittest.TestCase):
                     self.clear_directory(path)
 
                     model.save(path)
-                    tokenizer.save_pretrained(path)
                     self._print_post_quant_artifacts(path)
 
                     reuse_candidates = {}


### PR DESCRIPTION
Do not call `tokenizer.save_pretrained()`, to avoid overwriting `tokenizer_config.json`.

`model.save()` has already correctly saved the tokenizer.