### PR TITLE
Fix typo in setup.py causing wheel build failure (sys.abiflag -> sys.abiflags)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -867,7 +867,7 @@ class CachedWheelsCommand(_bdist_wheel):
         if FORCE_BUILD or xpu_avail:
             return super().run()
 
-        python_version = f"cp{sys.version_info.major}{sys.version_info.minor}{sys.abiflag}"
+        python_version = f"cp{sys.version_info.major}{sys.version_info.minor}{sys.abiflags}"
 
         wheel_filename = f"gptqmodel-{gptqmodel_version}+{get_version_tag()}-{python_version}-{python_version}-linux_x86_64.whl"
 


### PR DESCRIPTION
### Description
When building 'GPTQModel' from source (or when a pre-built wheel is not available), the wheel generation process crashes with the following error:

'AttributeError: module 'sys' has no attribute 'abiflag'. Did you mean: 'abiflags'?'

### Fix
Corrected a minor typo in 'setup.py' (changed 'sys.abiflag' to 'sys.abiflags'). This ensures the ABI flags are correctly fetched when generating the fallback wheel filename, allowing the build process to complete successfully.