### PR TITLE
Add AWQ support for CPU fused kernels (torch_fused & hf_kernel)

### DIFF
--- a/gptqmodel/nn_modules/qlinear/gemm_hf_kernel_awq.py
+++ b/gptqmodel/nn_modules/qlinear/gemm_hf_kernel_awq.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+import math
+
+import torch
+
+from ...adapter.adapter import Adapter
+from ...quantization import FORMAT, METHOD
+from ...quantization.awq.utils.packing_utils import (
+    dequantize_gemm,
+    reverse_awq_order,
+    unpack_awq,
+)
+from ...utils.backend import BACKEND
+from ...utils.logger import setup_logger
+from .gemm_hf_kernel import HFKernelLinear
+
+
+log = setup_logger()
+
+
+class HFKernelAwqLinear(HFKernelLinear):
+    """AWQ variant of HFKernelLinear — uses kernels-community gemm_int4 with AWQ weights."""
+
+    QUANT_TYPE = "hf_kernel_awq"
+
+    SUPPORTS_BACKENDS = [BACKEND.HF_KERNEL_AWQ]
+    SUPPORTS_METHODS = [METHOD.AWQ]
+    SUPPORTS_FORMATS = {FORMAT.GEMM: 60}
+
+    # inherit from HFKernelLinear
+    SUPPORTS_BITS = HFKernelLinear.SUPPORTS_BITS
+    SUPPORTS_GROUP_SIZE = HFKernelLinear.SUPPORTS_GROUP_SIZE
+    SUPPORTS_DESC_ACT = HFKernelLinear.SUPPORTS_DESC_ACT
+    SUPPORTS_SYM = HFKernelLinear.SUPPORTS_SYM
+    SUPPORTS_SHARDS = HFKernelLinear.SUPPORTS_SHARDS
+    SUPPORTS_TRAINING = HFKernelLinear.SUPPORTS_TRAINING
+    SUPPORTS_AUTO_PADDING = HFKernelLinear.SUPPORTS_AUTO_PADDING
+    SUPPORTS_IN_FEATURES_DIVISIBLE_BY = HFKernelLinear.SUPPORTS_IN_FEATURES_DIVISIBLE_BY
+    SUPPORTS_OUT_FEATURES_DIVISIBLE_BY = HFKernelLinear.SUPPORTS_OUT_FEATURES_DIVISIBLE_BY
+    SUPPORTS_DEVICES = HFKernelLinear.SUPPORTS_DEVICES
+    SUPPORTS_PLATFORM = HFKernelLinear.SUPPORTS_PLATFORM
+    SUPPORTS_PACK_DTYPES = HFKernelLinear.SUPPORTS_PACK_DTYPES
+    SUPPORTS_ADAPTERS = HFKernelLinear.SUPPORTS_ADAPTERS
+    REQUIRES_FORMAT_V2 = HFKernelLinear.REQUIRES_FORMAT_V2
+
+    SUPPORTS_DTYPES = [torch.float16, torch.bfloat16]
+
+    def __init__(
+        self,
+        bits: int,
+        group_size: int,
+        sym: bool,
+        desc_act: bool,
+        in_features: int,
+        out_features: int,
+        bias: bool = False,
+        pack_dtype: torch.dtype = torch.int32,
+        adapter: Adapter = None,
+        register_buffers: bool = True,
+        **kwargs,
+    ):
+        kwargs.setdefault("backend", BACKEND.HF_KERNEL_AWQ)
+        super().__init__(
+            bits=bits,
+            group_size=group_size,
+            sym=sym,
+            desc_act=desc_act,
+            in_features=in_features,
+            out_features=out_features,
+            bias=bias,
+            pack_dtype=pack_dtype,
+            adapter=adapter,
+            # Skip base buffer init, we need to manually init buffers for awq
+            register_buffers=False,
+            **kwargs,
+        )
+
+        # Create awq buffers
+        if register_buffers:
+            pack_cols = max(1, self.out_features // self.pack_factor)
+            qweight_shape = (self.in_features, pack_cols)
+            group_size = max(int(self.group_size), 1)
+            group_rows = max(1, math.ceil(self.in_features / group_size))
+
+            self.register_buffer(
+                "qweight",
+                torch.zeros(qweight_shape, dtype=self.pack_dtype),
+            )
+
+            self.register_buffer(
+                "qzeros",
+                torch.zeros((group_rows, pack_cols), dtype=self.pack_dtype),
+            )
+
+            self.register_buffer(
+                "scales",
+                torch.zeros((group_rows, self.out_features), dtype=torch.float16),
+            )
+
+            if bias:
+                self.register_buffer("bias", torch.zeros(self.out_features, dtype=torch.float16))
+            else:
+                self.bias = None
+
+    def post_init(self):
+        # AWQ has no g_idx — create wf buffers using qweight.device instead
+        device = self.qweight.device
+        if self.bits in [2, 4, 8]:
+            wf = torch.tensor(list(range(0, self.pack_dtype_bits, self.bits)), dtype=torch.int32).unsqueeze(0).to(device=device)
+        elif self.bits == 3:
+            wf = torch.tensor(
+                [
+                    [0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 0],
+                    [0, 1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31],
+                    [0, 2, 5, 8, 11, 14, 17, 20, 23, 26, 29, 0],
+                ],
+                dtype=torch.int32,
+            ).reshape(1, 3, 12).to(device=device)
+
+        self.register_buffer("wf_unsqueeze_zero", wf.unsqueeze(0).to(device=device), persistent=False)
+        self.register_buffer("wf_unsqueeze_neg_one", wf.unsqueeze(-1).to(device=device), persistent=False)
+
+        self.linear_mode = None
+        self.dequant_dtype = torch.int8
+        self.optimize()
+
+    def transform_cpu(self):
+        # Unpack AWQ weights directly to integer form
+        iweight, izeros = unpack_awq(self.qweight, self.qzeros, self.bits)
+        iweight, izeros = reverse_awq_order(iweight, izeros, self.bits)
+        max_val = (1 << self.bits) - 1
+        iweight = torch.bitwise_and(iweight, max_val).to(torch.uint8)
+        izeros = torch.bitwise_and(izeros, max_val).to(torch.uint8)
+
+        self.scales = self.scales.to(torch.bfloat16).contiguous()
+
+        # AWQ has no g_idx — weights are already in natural order, just transpose
+        # iweight: (in_features, out_features) -> (out_features, in_features)
+        self.qweight = iweight.t().contiguous()
+        self.qzeros = izeros.contiguous()
+
+    def transform(self, device):
+        if device == "cpu":
+            self.transform_cpu()
+            self.convert_weight_packed_zp()
+        else:
+            raise NotImplementedError(
+                "HFKernelAwqLinear only supports fused transforms on CPU devices."
+            )
+
+    def awq_weight_dequantize(self, device, dtype):
+        return dequantize_gemm(
+            qweight=self.qweight,
+            qzeros=self.qzeros,
+            scales=self.scales,
+            bits=self.bits,
+            group_size=self.group_size,
+            sym=self.sym,
+        ).to(device=device, dtype=dtype)
+
+    @torch.no_grad()
+    def _fused_op_forward(self, x):
+        # AWQ has no g_idx reordering — skip ret_idx
+        if x.device.type == "cpu":
+            out = self.gemm_int4_forward_kernel(x, self.qweight, self.qzeros, self.scales, self.group_size)
+        else:
+            raise NotImplementedError
+        return out
+
+    def forward(self, x: torch.Tensor):
+        out_shape = x.shape[:-1] + (self.out_features,)
+        x = x.reshape(-1, x.shape[-1])
+        if not self.training and not x.requires_grad and self.linear_mode is None and self.gemm_int4_forward_kernel is not None:
+            self.transform(x.device.type)
+            self.linear_mode = "inference"
+        elif self.linear_mode is None:
+            self.linear_mode = "train"
+
+        if self.linear_mode == "inference":
+            out = self._fused_op_forward(x).reshape(out_shape)
+        else:
+            weight = self.awq_weight_dequantize(device=x.device, dtype=x.dtype)
+            out = torch.matmul(x, weight).reshape(out_shape)
+
+        if self.bias is not None:
+            out.add_(self.bias)
+        if self.adapter:
+            out = self.adapter.apply(x=x, out=out)
+
+        return out
+
+
+__all__ = ["HFKernelAwqLinear"]

--- a/gptqmodel/nn_modules/qlinear/torch_fused_awq.py
+++ b/gptqmodel/nn_modules/qlinear/torch_fused_awq.py
@@ -49,8 +49,7 @@ class TorchFusedAwqQuantLinear(TorchFusedQuantLinear):
     SUPPORTS_ADAPTERS = TorchFusedQuantLinear.SUPPORTS_ADAPTERS
     REQUIRES_FORMAT_V2 = TorchFusedQuantLinear.REQUIRES_FORMAT_V2
 
-    # AWQ kernels are only accuracy validate for float16 for now
-    SUPPORTS_DTYPES = [torch.float16]
+    SUPPORTS_DTYPES = [torch.float16, torch.bfloat16]
 
     def __init__(
         self,
@@ -106,12 +105,32 @@ class TorchFusedAwqQuantLinear(TorchFusedQuantLinear):
                 torch.zeros((group_rows, self.out_features), dtype=torch.float16),
             )
 
-            self.register_buffer("g_idx", torch.arange(self.in_features, dtype=torch.int32) // group_size)
-
             if bias:
                 self.register_buffer("bias", torch.zeros(self.out_features, dtype=torch.float16))
             else:
                 self.bias = None
+
+    def post_init(self):
+        # AWQ has no g_idx — create wf buffers using qweight.device instead
+        device = self.qweight.device
+        if self.bits in [2, 4, 8]:
+            wf = torch.tensor(list(range(0, self.pack_dtype_bits, self.bits)), dtype=torch.int32).unsqueeze(0).to(device=device)
+        elif self.bits == 3:
+            wf = torch.tensor(
+                [
+                    [0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 0],
+                    [0, 1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31],
+                    [0, 2, 5, 8, 11, 14, 17, 20, 23, 26, 29, 0],
+                ],
+                dtype=torch.int32,
+            ).reshape(1, 3, 12).to(device=device)
+
+        self.register_buffer("wf_unsqueeze_zero", wf.unsqueeze(0).to(device=device), persistent=False)
+        self.register_buffer("wf_unsqueeze_neg_one", wf.unsqueeze(-1).to(device=device), persistent=False)
+
+        self.linear_mode = None
+        self.dequant_dtype = torch.int16 if self.bits == 8 else torch.int8
+        self.optimize()
 
     def prepare_awq_fused_tensors(self, need_zeros: bool = True):
         self.scales.to(torch.float16).contiguous()
@@ -168,23 +187,62 @@ class TorchFusedAwqQuantLinear(TorchFusedQuantLinear):
         return packed.contiguous()
 
     def transform_cpu_awq(self, dtype):
-        self.qweight, self.qzeros, scales, zeros = self.prepare_awq_fused_tensors()
+        # Unpack AWQ weights directly to integer form
+        iweight, izeros = unpack_awq(self.qweight, self.qzeros, self.bits)
+        iweight, izeros = reverse_awq_order(iweight, izeros, self.bits)
+        max_val = (1 << self.bits) - 1
+        iweight = torch.bitwise_and(iweight, max_val)
+        izeros = torch.bitwise_and(izeros, max_val)
 
-        super().transform_cpu(dtype, do_scales_and_zeros=False)
+        # Compute zeros: (zero_offset - izeros) * scales
+        zero_offset = 1 << (self.bits - 1)
+        zeros = (zero_offset - izeros.reshape_as(self.scales)) * self.scales
 
-        self.scales = scales.to(device=self.qweight.device, dtype=dtype).contiguous()
+        # AWQ has no g_idx — weights are already in natural order, just transpose
+        # iweight: (in_features, out_features) -> (out_features, in_features) for int4pack
+        weight = iweight.t().contiguous()
+        self.qweight = torch.ops.aten._convert_weight_to_int4pack_for_cpu(weight.int(), 1).contiguous()
+
+        self.scales = self.scales.to(dtype=dtype).contiguous()
         self.qzeros = zeros.to(device=self.qweight.device, dtype=dtype).contiguous()
         self.scales_and_zeros = pack_scales_and_zeros(self.scales, self.qzeros)
 
     def transform_xpu_awq(self, dtype):
-        self.qweight, self.qzeros, scales, _ = self.prepare_awq_fused_tensors(need_zeros=False)
+        # Unpack AWQ weights directly to integer form
+        iweight, izeros = unpack_awq(self.qweight, self.qzeros, self.bits)
+        iweight, izeros = reverse_awq_order(iweight, izeros, self.bits)
+        max_val = (1 << self.bits) - 1
+        iweight = torch.bitwise_and(iweight, max_val)
+        izeros = torch.bitwise_and(izeros, max_val)
 
-        super().transform_xpu(dtype)
+        self.scales = self.scales.to(dtype).contiguous()
 
-        self.scales = scales.to(device=self.qweight.device, dtype=dtype).contiguous()
+        # AWQ has no g_idx — pack weight directly for XPU without reordering
+        # iweight: (in_features, out_features) -> transpose for XPU packing
+        weight = iweight.t().contiguous()
+        packed = torch.zeros(weight.shape[0], weight.shape[1] // self.pack_factor, dtype=torch.int32, device=weight.device)
+        for col in range(weight.shape[1] // self.pack_factor):
+            for i in range(self.pack_factor):
+                packed_col = weight[:, col * self.pack_factor + i].to(torch.int32)
+                packed[:, col] |= packed_col << (i * self.bits)
+        self.qweight = packed.contiguous()
+        self.qzeros = izeros.contiguous()
 
     def transform_cpu(self, dtype):
         self.transform_cpu_awq(dtype)
+
+    @torch.no_grad()
+    def _fused_op_forward(self, x):
+        # AWQ has no g_idx reordering — skip ret_idx
+        if x.device.type == "xpu":
+            out = torch.ops.aten._weight_int4pack_mm_with_scales_and_zeros(
+                x, self.qweight, self.group_size, self.scales, self.qzeros
+            )
+        elif x.device.type == "cpu":
+            out = self.torch_fused_op(x)
+        else:
+            raise NotImplementedError
+        return out
 
     def awq_weight_dequantize(self, device, dtype):
         return dequantize_gemm(

--- a/gptqmodel/utils/backend.py
+++ b/gptqmodel/utils/backend.py
@@ -32,6 +32,7 @@ class BACKEND(str, Enum):
     GEMV = "gemv"
     GEMV_FAST = "gemv_fast"
     TORCH_FUSED_AWQ = "torch_fused_awq"  # AWQ variant of torch fused kernel
+    HF_KERNEL_AWQ = "hf_kernel_awq"  # AWQ variant of HF kernel
     TORCH_AWQ = "torch_awq"
 
     # external


### PR DESCRIPTION
AWQ has no g_idx — weights/zeros/scales are in natural order. The existing ·torch_fused_awq.py· was copied from the GPTQ version and incorrectly depended on g_idx, causing AttributeError at runtime.

Fixed torch_fused_awq.py: unpack AWQ weights directly, skip all g_idx/ret_idx logic, added bfloat16 support
New gemm_hf_kernel_awq.py: AWQ variant of HFKernelLinear using kernels-community gemm_int4 kernel, priority 60 (auto-selected over torch_fused_awq at priority 20)
Added HF_KERNEL_AWQ backend enum