### PR TITLE
gate hf kernel to non-nogil builds of python until upsteram fix wheels

### DIFF
--- a/gptqmodel/nn_modules/qlinear/gemm_hf_kernel.py
+++ b/gptqmodel/nn_modules/qlinear/gemm_hf_kernel.py
@@ -18,6 +18,7 @@ from ...nn_modules.qlinear import BaseQuantLinear, PackableQuantLinear
 from ...quantization import FORMAT, METHOD
 from ...utils.backend import BACKEND
 from ...utils.logger import setup_logger
+from ...utils.python import is_free_threading_build
 
 
 log = setup_logger()
@@ -51,12 +52,31 @@ class HFKernelLinear(PackableQuantLinear):
     KERNEL_REPO_ID = "kernels-community/quantization-gptq"
 
     @classmethod
+    def _hf_kernels_import_guard(cls, kernel_name: Optional[str] = None) -> Optional[RuntimeError]:
+        if not is_free_threading_build():
+            return None
+
+        kernel_name = kernel_name or cls.__name__
+        # FIXME: Remove this guard once https://github.com/huggingface/kernels/issues/312 is fixed.
+        msg = (
+            f"{kernel_name} is disabled on free-threaded Python builds "
+            "(Py_GIL_DISABLED=1) because importing `kernels` can segfault "
+            "even when the runtime GIL is enabled. Please use a standard "
+            "GIL-enabled Python build."
+        )
+        return RuntimeError(msg)
+
+    @classmethod
     def _load_cpu_kernel_variant(cls, repo_id: str):
         """
         kernels.get_kernel() picks variants from the local torch build. On CUDA-enabled torch
         wheels running CPU-only inference, that can miss CPU-only kernel repos. Fall back to an
         explicit CPU variant selection from repo build artifacts.
         """
+        build_error = cls._hf_kernels_import_guard()
+        if build_error is not None:
+            raise build_error
+
         from kernels.utils import _import_from_path, install_kernel_all_variants, package_name_from_repo_id
 
         build_dir = install_kernel_all_variants(repo_id, revision="main")
@@ -138,6 +158,11 @@ class HFKernelLinear(PackableQuantLinear):
 
     @classmethod
     def validate_once(cls) -> Tuple[bool, Optional[Exception]]:
+        build_error = cls._hf_kernels_import_guard()
+        if build_error is not None:
+            log.warning(str(build_error))
+            return False, build_error
+
         if not cls._is_torch_release():
             msg = (
                 f"HFKernelLinear requires a release version of torch, "

--- a/gptqmodel/nn_modules/qlinear/gemm_hf_kernel_awq.py
+++ b/gptqmodel/nn_modules/qlinear/gemm_hf_kernel_awq.py
@@ -115,6 +115,11 @@ class HFKernelAwqLinear(AWQuantLinear):
 
     @classmethod
     def validate_once(cls) -> Tuple[bool, Optional[Exception]]:
+        build_error = HFKernelLinear._hf_kernels_import_guard(cls.__name__)
+        if build_error is not None:
+            log.warning(str(build_error))
+            return False, build_error
+
         if not HFKernelLinear._is_torch_release():
             msg = (
                 f"HFKernelAwqLinear requires a release version of torch, "

--- a/gptqmodel/utils/python.py
+++ b/gptqmodel/utils/python.py
@@ -5,6 +5,7 @@
 
 import platform
 import sys
+import sysconfig
 
 from packaging.version import Version
 
@@ -13,15 +14,27 @@ from gptqmodel.utils.logger import setup_logger
 
 log = setup_logger()
 
-# Check if GIL (global interpreter lock) is controllable in this Python build.
-# Starting from python 3.13 it is possible to disable GIL
-def has_gil_control():
-    return hasattr(sys, '_is_gil_enabled')
+# Check if this Python build supports free-threading / GIL control.
+# Starting from python 3.13 it is possible to disable GIL at build time.
+def is_free_threading_build():
+    """Return True when Python was built with free-threading support."""
+    py_gil_disabled = sysconfig.get_config_var("Py_GIL_DISABLED")
+    try:
+        return int(py_gil_disabled or 0) == 1
+    except (TypeError, ValueError):
+        return False
 
-# Check if GIL (global interpreter lock) is enabled.
-# Starting from python 3.13 it is possible to disable GIL
+
+# Check if GIL (global interpreter lock) is controllable in this Python build.
+# Starting from python 3.13 it is possible to disable GIL.
+def has_gil_control():
+    return is_free_threading_build()
+
+# Check if GIL (global interpreter lock) is enabled at runtime.
+# Starting from python 3.13 it is possible to disable GIL.
 def has_gil_disabled():
-    return has_gil_control() and not sys._is_gil_enabled()
+    gil_enabled = getattr(sys, "_is_gil_enabled", None)
+    return has_gil_control() and callable(gil_enabled) and not gil_enabled()
 
 # Check For Python >= 3.13.3
 def gte_python_3_13_3():


### PR DESCRIPTION
@avtc This will fix your `hf kernels` segfaults on your `t` or `nogil` version of python