### PR TITLE
fix problems in the FOEM data processing pipeline

### DIFF
--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -966,14 +966,15 @@ class BaseQModel(nn.Module):
             quantize_processor.insert(0, NativeProcessor(**args_clone))
 
         if getattr(self.quantize_config, "foem", None) is not None:
-            from ..looper.native_processor import NativeProcessor
+            if self.quantize_config.foem.alpha > 0:
+                from ..looper.native_processor import NativeProcessor
 
-            args_to_copy = {k: v for k, v in args.items() if k != "prepare_dataset_func"}
-            args_clone = copy.deepcopy(args_to_copy)
-            args_clone["prepare_dataset_func"] = args["prepare_dataset_func"]
+                args_to_copy = {k: v for k, v in args.items() if k != "prepare_dataset_func"}
+                args_clone = copy.deepcopy(args_to_copy)
+                args_clone["prepare_dataset_func"] = args["prepare_dataset_func"]
 
-            args_clone.pop("calculate_w_wq_diff", None)
-            quantize_processor.insert(0, NativeProcessor(**args_clone))
+                args_clone.pop("calculate_w_wq_diff", None)
+                quantize_processor.insert(0, NativeProcessor(**args_clone))
 
         processors = quantize_processor
         if needs_lora:

--- a/gptqmodel/quantization/config.py
+++ b/gptqmodel/quantization/config.py
@@ -1166,12 +1166,6 @@ class FOEMConfig:
             (alpha = 0.25, beta = 0.2) generally produces strong results,
             although it is not consistently superior to using FOEM alone.
 
-    Note:
-        FOEM currently follows the same data processing pipeline as GPTAQ.
-        Specifically, `native_inp` is pre-cached regardless of the value of `alpha`.
-        However, when `alpha = 0`, the additional terms (dXXT and P) are not computed
-        during the compensation step.
-
     Args:
         alpha (float, optional): Default is 0.
         beta (float, optional): Default is 0.2.


### PR DESCRIPTION
When testing FOEM on Qwen3.5-35B-A3B, the error caused by reusing GPTAQ’s data processing pipeline occurs even earlier than the previous issue I encountered in `gptqmodel/quantization/foem.py`. In this case, simply setting `alpha = 0` does not resolve the problem.

To address this, I added a special handling of `alpha` in the processor to ensure that FOEM, when used alone, achieves better generalization consistent with GPTQ.