### PR TITLE
Fix: LazyTurtle materialization for non-square fused experts

### DIFF
--- a/gptqmodel/utils/structure.py
+++ b/gptqmodel/utils/structure.py
@@ -831,20 +831,97 @@ class LazyTurtle:
         expert_index: Optional[int],
         split_index: Optional[int],
         split_dim: Optional[int],
+        expected_shape: Optional[tuple[int, ...]] = None,
+        prefer_transposed: Optional[bool] = None,
     ) -> Optional[torch.Tensor]:
         """Slice fused checkpoint tensors into the tensor layout expected by the shell module."""
 
         if expert_index is not None:
             if tensor.shape[0] <= expert_index:
                 return None
+            # Fused expert checkpoints store the expert axis first; peel it off before
+            # reasoning about split dimensions or transpose decisions.
             tensor = tensor[expert_index].contiguous()
 
-        if split_index is not None:
-            if split_dim is None or tensor.shape[split_dim] % 2 != 0:
-                return None
-            tensor = tensor.chunk(2, dim=split_dim)[split_index].contiguous()
+        if expected_shape is None:
+            if split_index is not None:
+                if split_dim is None or tensor.shape[split_dim] % 2 != 0:
+                    return None
+                tensor = tensor.chunk(2, dim=split_dim)[split_index].contiguous()
+            return tensor
 
-        return tensor
+        expected_shape = tuple(expected_shape)
+
+        # Some checkpoints store expert projections as (out, in) while others store
+        # them as (in, out). Keep both candidates and let the defused leaf shape be
+        # the final arbiter instead of hard-coding one model family's layout.
+        candidates: list[tuple[torch.Tensor, bool]] = [(tensor, False)]
+        if tensor.ndim == 2:
+            transposed = tensor.transpose(0, 1).contiguous()
+            if prefer_transposed is True:
+                candidates = [(transposed, True), (tensor, False)]
+            elif prefer_transposed is None and transposed.shape != tensor.shape:
+                candidates.append((transposed, True))
+            elif prefer_transposed is False and transposed.shape != tensor.shape:
+                candidates.append((transposed, True))
+
+        for candidate, used_transpose in candidates:
+            if split_index is None:
+                if tuple(candidate.shape) == expected_shape:
+                    return candidate.contiguous()
+                continue
+
+            preferred_dims: list[int] = []
+            mapped_split_dim = split_dim
+            if (
+                used_transpose
+                and candidate.ndim == 2
+                and split_dim is not None
+                and 0 <= split_dim < 2
+            ):
+                # The resolver hint is expressed in the checkpoint's native layout.
+                # Once we transpose a 2D candidate, the split dimension flips too.
+                mapped_split_dim = 1 - split_dim
+            if mapped_split_dim is not None and 0 <= mapped_split_dim < candidate.ndim:
+                preferred_dims.append(mapped_split_dim)
+            preferred_dims.extend(dim for dim in range(candidate.ndim) if dim not in preferred_dims)
+
+            for dim in preferred_dims:
+                if candidate.shape[dim] % 2 != 0:
+                    continue
+                split_tensor = candidate.chunk(2, dim=dim)[split_index].contiguous()
+                if tuple(split_tensor.shape) == expected_shape:
+                    return split_tensor
+
+        return None
+
+    @staticmethod
+    def _resolve_prefer_transposed_hint(
+        *,
+        target_model: nn.Module,
+        module_path: str,
+        rel_name: str,
+        modules_by_name: Dict[str, nn.Module],
+    ) -> Optional[bool]:
+        rel_parent, _, _leaf = rel_name.rpartition(".")
+        current_path = module_path
+        if rel_parent:
+            current_path = LazyTurtle._join_tensor_name(module_path, rel_parent)
+
+        # Expert containers usually expose `is_transposed`; leaf Linear modules do not.
+        # Walk upward until we find the nearest owner that carries the layout hint.
+        while True:
+            owner = target_model if not current_path else modules_by_name.get(current_path)
+            if owner is not None and hasattr(owner, "is_transposed"):
+                value = getattr(owner, "is_transposed")
+                if isinstance(value, bool):
+                    return value
+
+            if not current_path:
+                break
+            current_path = current_path.rpartition(".")[0]
+
+        return None
 
     def _resolve_checkpoint_tensor_source(
         self,
@@ -861,7 +938,61 @@ class LazyTurtle:
         if resolved[0] is not None:
             return resolved
 
-        return self._resolve_fused_expert_tensor_name(module_path, rel_name)
+        resolved = self._resolve_fused_expert_tensor_name(module_path, rel_name)
+        if resolved[0] is not None:
+            return resolved
+
+        # Direct-meta rematerialization often visits a leaf Linear whose relative name is
+        # just `weight` / `bias`. Retry resolution with the full module path so leaf-only
+        # materialization can still map back to fused expert checkpoint tensors.
+        combined_name = self._join_tensor_name(module_path, rel_name)
+        resolved = self._resolve_split_gate_up_tensor_name("", combined_name)
+        if resolved[0] is not None:
+            return resolved
+
+        return self._resolve_fused_expert_tensor_name("", combined_name)
+
+    @staticmethod
+    def _warn_materialization_skip(
+        *,
+        phase: str,
+        kind: str,
+        module_path: str,
+        rel_name: str,
+        reason: str,
+        full_name: Optional[str] = None,
+        source_shape: Optional[tuple[int, ...]] = None,
+        target_shape: Optional[tuple[int, ...]] = None,
+        expert_index: Optional[int] = None,
+        split_index: Optional[int] = None,
+        split_dim: Optional[int] = None,
+    ) -> None:
+        """Emit a consistent warning when a checkpoint-backed tensor cannot be materialized."""
+
+        details = []
+        if full_name is not None:
+            details.append(f"checkpoint={full_name}")
+        if source_shape is not None:
+            details.append(f"source_shape={source_shape}")
+        if target_shape is not None:
+            details.append(f"target_shape={target_shape}")
+        if expert_index is not None:
+            details.append(f"expert_index={expert_index}")
+        if split_index is not None:
+            details.append(f"split_index={split_index}")
+        if split_dim is not None:
+            details.append(f"split_dim={split_dim}")
+
+        suffix = f" ({', '.join(details)})" if details else ""
+        log.warning(
+            "LazyTurtle: skip %s %s `%s` under `%s`: %s%s",
+            phase,
+            kind,
+            rel_name,
+            module_path or "<root>",
+            reason,
+            suffix,
+        )
 
     def _load_checkpoint_tensors_for_module_path(
         self,
@@ -908,15 +1039,36 @@ class LazyTurtle:
 
         t_params = dict(target_submodule.named_parameters(recurse=recurse))
         t_bufs = dict(target_submodule.named_buffers(recurse=recurse))
+        modules_by_name = dict(target_model.named_modules())
         missing_nonpersistent_buffers: list[tuple[str, str]] = []
 
         grouped_names: Dict[str, list[tuple[str, str, str, Optional[int], Optional[int], Optional[int]]]] = {}
         for rel_name in t_params:
             full_name, expert_index, split_index, split_dim = self._resolve_checkpoint_tensor_source(module_path, rel_name)
             if full_name is None:
+                self._warn_materialization_skip(
+                    phase="submodule materialization",
+                    kind="param",
+                    module_path=module_path,
+                    rel_name=rel_name,
+                    reason="no checkpoint tensor mapping was found",
+                    target_shape=tuple(t_params[rel_name].shape),
+                )
                 continue
             shard = self._weight_map.get(full_name)
             if shard is None:
+                self._warn_materialization_skip(
+                    phase="submodule materialization",
+                    kind="param",
+                    module_path=module_path,
+                    rel_name=rel_name,
+                    reason="checkpoint tensor mapping resolved to a missing shard",
+                    full_name=full_name,
+                    target_shape=tuple(t_params[rel_name].shape),
+                    expert_index=expert_index,
+                    split_index=split_index,
+                    split_dim=split_dim,
+                )
                 continue
             grouped_names.setdefault(shard, []).append(("param", rel_name, full_name, expert_index, split_index, split_dim))
 
@@ -950,18 +1102,68 @@ class LazyTurtle:
                 shard_path = os.path.join(self.model_local_path, shard)
                 with safe_open(shard_path, framework="pt", device="cpu") as handler:
                     for kind, rel_name, full_name, expert_index, split_index, split_dim in entries:
-                        tensor = handler.get_tensor(full_name)
+                        target_tensor = t_params.get(rel_name) if kind == "param" else t_bufs.get(rel_name)
+                        expected_shape = tuple(target_tensor.shape) if target_tensor is not None else None
+                        prefer_transposed = self._resolve_prefer_transposed_hint(
+                            target_model=target_model,
+                            module_path=module_path,
+                            rel_name=rel_name,
+                            modules_by_name=modules_by_name,
+                        )
+                        checkpoint_tensor = handler.get_tensor(full_name)
                         tensor = self._transform_checkpoint_tensor(
-                            tensor,
+                            checkpoint_tensor,
                             expert_index=expert_index,
                             split_index=split_index,
                             split_dim=split_dim,
+                            expected_shape=expected_shape,
+                            prefer_transposed=prefer_transposed,
                         )
                         if tensor is None:
+                            self._warn_materialization_skip(
+                                phase="submodule materialization",
+                                kind=kind,
+                                module_path=module_path,
+                                rel_name=rel_name,
+                                reason="checkpoint tensor could not be reshaped into the target layout",
+                                full_name=full_name,
+                                source_shape=tuple(checkpoint_tensor.shape),
+                                target_shape=expected_shape,
+                                expert_index=expert_index,
+                                split_index=split_index,
+                                split_dim=split_dim,
+                            )
                             continue
                         if kind == "param":
                             target_param = t_params.get(rel_name)
-                            if target_param is None or target_param.shape != tensor.shape:
+                            if target_param is None:
+                                self._warn_materialization_skip(
+                                    phase="submodule materialization",
+                                    kind=kind,
+                                    module_path=module_path,
+                                    rel_name=rel_name,
+                                    reason="target tensor disappeared before materialization",
+                                    full_name=full_name,
+                                    source_shape=tuple(tensor.shape),
+                                    expert_index=expert_index,
+                                    split_index=split_index,
+                                    split_dim=split_dim,
+                                )
+                                continue
+                            if target_param.shape != tensor.shape:
+                                self._warn_materialization_skip(
+                                    phase="submodule materialization",
+                                    kind=kind,
+                                    module_path=module_path,
+                                    rel_name=rel_name,
+                                    reason="target tensor shape does not match the transformed checkpoint tensor",
+                                    full_name=full_name,
+                                    source_shape=tuple(tensor.shape),
+                                    target_shape=tuple(target_param.shape),
+                                    expert_index=expert_index,
+                                    split_index=split_index,
+                                    split_dim=split_dim,
+                                )
                                 continue
                             target_param_new = _ensure_target_storage_on_device_(target_param, device)
                             if target_param_new is not target_param:
@@ -983,6 +1185,22 @@ class LazyTurtle:
                             new_buffer = source.to(device=device)
                             t_parent.register_buffer(leaf, new_buffer, persistent=persistent)
                             t_bufs[rel_name] = new_buffer
+                            continue
+
+                        if tuple(target_buffer.shape) != tuple(source.shape):
+                            self._warn_materialization_skip(
+                                phase="submodule materialization",
+                                kind=kind,
+                                module_path=module_path,
+                                rel_name=rel_name,
+                                reason="target tensor shape does not match the transformed checkpoint tensor",
+                                full_name=full_name,
+                                source_shape=tuple(source.shape),
+                                target_shape=tuple(target_buffer.shape),
+                                expert_index=expert_index,
+                                split_index=split_index,
+                                split_dim=split_dim,
+                            )
                             continue
 
                         if getattr(target_buffer, "is_meta", False) or target_buffer.device.type == "meta":
@@ -1140,24 +1358,72 @@ class LazyTurtle:
 
                 full_name, expert_index, split_index, split_dim = self._resolve_checkpoint_tensor_source(module_path, name)
                 if full_name is None:
+                    self._warn_materialization_skip(
+                        phase="direct-meta sync",
+                        kind="param",
+                        module_path=module_path,
+                        rel_name=name,
+                        reason="no checkpoint tensor mapping was found",
+                        target_shape=tuple(shell_param.shape),
+                    )
                     continue
                 shard = self._weight_map.get(full_name)
                 if shard is None:
+                    self._warn_materialization_skip(
+                        phase="direct-meta sync",
+                        kind="param",
+                        module_path=module_path,
+                        rel_name=name,
+                        reason="checkpoint tensor mapping resolved to a missing shard",
+                        full_name=full_name,
+                        target_shape=tuple(shell_param.shape),
+                        expert_index=expert_index,
+                        split_index=split_index,
+                        split_dim=split_dim,
+                    )
                     continue
 
                 source_path = os.path.join(self.model_local_path, shard)
                 with safe_open(source_path, framework="pt", device="cpu") as handler:
-                    source_param = handler.get_tensor(full_name)
+                    checkpoint_param = handler.get_tensor(full_name)
                 source_param = self._transform_checkpoint_tensor(
-                    source_param,
+                    checkpoint_param,
                     expert_index=expert_index,
                     split_index=split_index,
                     split_dim=split_dim,
+                    expected_shape=tuple(shell_param.shape),
+                    prefer_transposed=getattr(shell_sub, "is_transposed", None),
                 )
                 if source_param is None:
+                    self._warn_materialization_skip(
+                        phase="direct-meta sync",
+                        kind="param",
+                        module_path=module_path,
+                        rel_name=name,
+                        reason="checkpoint tensor could not be reshaped into the target layout",
+                        full_name=full_name,
+                        source_shape=tuple(checkpoint_param.shape),
+                        target_shape=tuple(shell_param.shape),
+                        expert_index=expert_index,
+                        split_index=split_index,
+                        split_dim=split_dim,
+                    )
                     continue
 
                 if shell_param.shape != source_param.shape:
+                    self._warn_materialization_skip(
+                        phase="direct-meta sync",
+                        kind="param",
+                        module_path=module_path,
+                        rel_name=name,
+                        reason="target tensor shape does not match the transformed checkpoint tensor",
+                        full_name=full_name,
+                        source_shape=tuple(source_param.shape),
+                        target_shape=tuple(shell_param.shape),
+                        expert_index=expert_index,
+                        split_index=split_index,
+                        split_dim=split_dim,
+                    )
                     continue
 
                 cache_key = (full_name, expert_index, split_index, split_dim, shell_param.dtype, shell_param.requires_grad)
@@ -1180,24 +1446,72 @@ class LazyTurtle:
 
                 full_name, expert_index, split_index, split_dim = self._resolve_checkpoint_tensor_source(module_path, name)
                 if full_name is None:
+                    self._warn_materialization_skip(
+                        phase="direct-meta sync",
+                        kind="buffer",
+                        module_path=module_path,
+                        rel_name=name,
+                        reason="no checkpoint tensor mapping was found",
+                        target_shape=tuple(shell_buffer.shape),
+                    )
                     continue
                 shard = self._weight_map.get(full_name)
                 if shard is None:
+                    self._warn_materialization_skip(
+                        phase="direct-meta sync",
+                        kind="buffer",
+                        module_path=module_path,
+                        rel_name=name,
+                        reason="checkpoint tensor mapping resolved to a missing shard",
+                        full_name=full_name,
+                        target_shape=tuple(shell_buffer.shape),
+                        expert_index=expert_index,
+                        split_index=split_index,
+                        split_dim=split_dim,
+                    )
                     continue
 
                 source_path = os.path.join(self.model_local_path, shard)
                 with safe_open(source_path, framework="pt", device="cpu") as handler:
-                    source_buffer = handler.get_tensor(full_name)
+                    checkpoint_buffer = handler.get_tensor(full_name)
                 source_buffer = self._transform_checkpoint_tensor(
-                    source_buffer,
+                    checkpoint_buffer,
                     expert_index=expert_index,
                     split_index=split_index,
                     split_dim=split_dim,
+                    expected_shape=tuple(shell_buffer.shape),
+                    prefer_transposed=getattr(shell_sub, "is_transposed", None),
                 )
                 if source_buffer is None:
+                    self._warn_materialization_skip(
+                        phase="direct-meta sync",
+                        kind="buffer",
+                        module_path=module_path,
+                        rel_name=name,
+                        reason="checkpoint tensor could not be reshaped into the target layout",
+                        full_name=full_name,
+                        source_shape=tuple(checkpoint_buffer.shape),
+                        target_shape=tuple(shell_buffer.shape),
+                        expert_index=expert_index,
+                        split_index=split_index,
+                        split_dim=split_dim,
+                    )
                     continue
 
                 if shell_buffer.shape != source_buffer.shape:
+                    self._warn_materialization_skip(
+                        phase="direct-meta sync",
+                        kind="buffer",
+                        module_path=module_path,
+                        rel_name=name,
+                        reason="target tensor shape does not match the transformed checkpoint tensor",
+                        full_name=full_name,
+                        source_shape=tuple(source_buffer.shape),
+                        target_shape=tuple(shell_buffer.shape),
+                        expert_index=expert_index,
+                        split_index=split_index,
+                        split_dim=split_dim,
+                    )
                     continue
 
                 persistent = name not in getattr(shell_sub, "_non_persistent_buffers_set", set())

--- a/tests/models/awq/test_qwen3_5_moe.py
+++ b/tests/models/awq/test_qwen3_5_moe.py
@@ -36,7 +36,6 @@ class TestQwen3_5Moe(ModelTest):
     EVAL_TASKS_FAST = ModelTest.derive_fast_eval_tasks(EVAL_TASKS_SLOW)
 
     VRAM_STRATEGY = VramStrategy.BALANCED
-    OFFLOAD_TO_DISK = False  # FIXME Currently, after defuser transforms the model, OFFLOAD_TO_DISK must be False for quantization.
 
     def test_qwen3_5_moe(self):
         self.quant_lm_eval()

--- a/tests/models/test_mixtral.py
+++ b/tests/models/test_mixtral.py
@@ -23,7 +23,6 @@ class TestMixtral(ModelTest):
         },
     }
     EVAL_TASKS_FAST = ModelTest.derive_fast_eval_tasks(EVAL_TASKS_SLOW)
-    OFFLOAD_TO_DISK = False  # FIXME Currently, after defuser converted the model, OFFLOAD_TO_DISK must be False for quantization.
 
     def test_mixtral(self):
         self.quant_lm_eval()

--- a/tests/models/test_mixtral.py
+++ b/tests/models/test_mixtral.py
@@ -23,6 +23,7 @@ class TestMixtral(ModelTest):
         },
     }
     EVAL_TASKS_FAST = ModelTest.derive_fast_eval_tasks(EVAL_TASKS_SLOW)
+    OFFLOAD_TO_DISK = False  # FIXME Currently, after defuser converted the model, OFFLOAD_TO_DISK must be False for quantization.
 
     def test_mixtral(self):
         self.quant_lm_eval()

--- a/tests/models/test_qwen3_5_moe.py
+++ b/tests/models/test_qwen3_5_moe.py
@@ -29,7 +29,6 @@ class TestQwen3_5Moe(ModelTest):
     EVAL_TASKS_FAST = ModelTest.derive_fast_eval_tasks(EVAL_TASKS_SLOW)
 
     VRAM_STRATEGY = VramStrategy.BALANCED
-    OFFLOAD_TO_DISK = False  # FIXME Currently, after defuser transforms the model, OFFLOAD_TO_DISK must be False for quantization.
 
     def test_qwen3_5_moe(self):
         self.quant_lm_eval()

--- a/tests/test_offload_files.py
+++ b/tests/test_offload_files.py
@@ -17,6 +17,7 @@ from torch import nn
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding
 
+import gptqmodel.utils.structure as structure_utils
 from gptqmodel.utils.model import get_state_dict_for_save, move_to, streaming_state_dict_to_shards
 from gptqmodel.utils.offload import offload_to_disk, undo_offload_to_disk
 from gptqmodel.utils.structure import (
@@ -189,6 +190,16 @@ class _TinyExpert(nn.Module):
         self.down_proj = nn.Linear(width, width, bias=True)
 
 
+class _RectExpert(nn.Module):
+    """Expert with distinct hidden/intermediate sizes to catch wrong split/transpose rules."""
+
+    def __init__(self, width: int, intermediate: int, *, bias: bool = True):
+        super().__init__()
+        self.gate_proj = nn.Linear(width, intermediate, bias=bias)
+        self.up_proj = nn.Linear(width, intermediate, bias=bias)
+        self.down_proj = nn.Linear(intermediate, width, bias=bias)
+
+
 class _FusedExpertsWrapper(nn.Module):
     """Wrapper used to exercise fused expert checkpoint slicing during lazy-turtle rematerialization."""
 
@@ -200,6 +211,18 @@ class _FusedExpertsWrapper(nn.Module):
             self.block.experts.add_module(str(expert_idx), _TinyExpert(width))
 
 
+class _RectFusedExpertsWrapper(nn.Module):
+    """Wrapper used to validate real rectangular expert layouts, including transposed storage."""
+
+    def __init__(self, width: int, intermediate: int, expert_count: int, *, is_transposed: bool):
+        super().__init__()
+        self.block = nn.Module()
+        self.block.experts = nn.Module()
+        self.block.experts.is_transposed = is_transposed
+        for expert_idx in range(expert_count):
+            self.block.experts.add_module(str(expert_idx), _RectExpert(width, intermediate))
+
+
 def _write_checkpoint_index(path: Path, shard_name: str, state_dict: dict[str, torch.Tensor]) -> None:
     weight_map = dict.fromkeys(state_dict, shard_name)
     (path / "model.safetensors.index.json").write_text(json.dumps({"weight_map": weight_map}))
@@ -208,13 +231,18 @@ def _write_checkpoint_index(path: Path, shard_name: str, state_dict: dict[str, t
 def _build_lazy_turtle_from_module(tmp_path: Path, model: nn.Module) -> LazyTurtle:
     """Persist cloned checkpoint values and reopen them through the lazy turtle source."""
 
+    state_dict = {name: tensor.detach().clone() for name, tensor in model.state_dict().items()}
+    return _build_lazy_turtle_from_checkpoint_tensors(tmp_path, state_dict)
+
+
+def _build_lazy_turtle_from_checkpoint_tensors(tmp_path: Path, checkpoint_tensors: dict[str, torch.Tensor]) -> LazyTurtle:
+    """Persist an arbitrary safetensors checkpoint and reopen it through LazyTurtle."""
+
     model_dir = tmp_path / "source_model"
     model_dir.mkdir()
     shard_name = "model.safetensors"
-    # Checkpoint-backed lazy turtle reconstructs tensor values, not Python-side alias identity.
-    state_dict = {name: tensor.detach().clone() for name, tensor in model.state_dict().items()}
-    save_file(state_dict, str(model_dir / shard_name))
-    _write_checkpoint_index(model_dir, shard_name, state_dict)
+    save_file(checkpoint_tensors, str(model_dir / shard_name))
+    _write_checkpoint_index(model_dir, shard_name, checkpoint_tensors)
     source = LazyTurtle.maybe_create(
         model_local_path=str(model_dir),
         config=SimpleNamespace(_experts_implementation=None),
@@ -222,6 +250,74 @@ def _build_lazy_turtle_from_module(tmp_path: Path, model: nn.Module) -> LazyTurt
     )
     assert source is not None
     return source
+
+
+def _build_rect_fused_expert_checkpoint_tensors(
+    source_model: _RectFusedExpertsWrapper,
+    *,
+    include_down_proj: bool = True,
+) -> dict[str, torch.Tensor]:
+    """Build fused expert checkpoint tensors that mimic the HF/Defuser expert storage layouts."""
+
+    experts = [expert for _, expert in source_model.block.experts.named_children()]
+    is_transposed = bool(getattr(source_model.block.experts, "is_transposed", False))
+    gate_split_dim = 1 if is_transposed else 0
+
+    checkpoint_tensors = {
+        "block.experts.gate_up_proj": torch.stack(
+            [
+                torch.cat(
+                    [
+                        expert.gate_proj.weight.detach().clone().transpose(0, 1) if is_transposed else expert.gate_proj.weight.detach().clone(),
+                        expert.up_proj.weight.detach().clone().transpose(0, 1) if is_transposed else expert.up_proj.weight.detach().clone(),
+                    ],
+                    dim=gate_split_dim,
+                )
+                for expert in experts
+            ],
+            dim=0,
+        ),
+        "block.experts.gate_up_proj_bias": torch.stack(
+            [
+                torch.cat(
+                    [
+                        expert.gate_proj.bias.detach().clone(),
+                        expert.up_proj.bias.detach().clone(),
+                    ],
+                    dim=0,
+                )
+                for expert in experts
+            ],
+            dim=0,
+        ),
+    }
+
+    if include_down_proj:
+        checkpoint_tensors["block.experts.down_proj"] = torch.stack(
+            [
+                expert.down_proj.weight.detach().clone().transpose(0, 1) if is_transposed else expert.down_proj.weight.detach().clone()
+                for expert in experts
+            ],
+            dim=0,
+        )
+        checkpoint_tensors["block.experts.down_proj_bias"] = torch.stack(
+            [expert.down_proj.bias.detach().clone() for expert in experts],
+            dim=0,
+        )
+
+    return checkpoint_tensors
+
+
+def _capture_structure_warnings(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Capture LazyTurtle warnings without depending on the logging backend implementation."""
+
+    warnings: list[str] = []
+
+    def _record_warning(message: str, *args):
+        warnings.append(message % args if args else message)
+
+    monkeypatch.setattr(structure_utils.log, "warning", _record_warning, raising=False)
+    return warnings
 
 
 def test_offload_to_disk_writes_single_dat_file(tmp_path):
@@ -758,6 +854,458 @@ def test_lazy_turtle_materializes_split_experts_from_fused_checkpoint_tensors(tm
         torch.testing.assert_close(actual.up_proj.bias, expected.up_proj.bias)
         torch.testing.assert_close(actual.down_proj.weight, expected.down_proj.weight)
         torch.testing.assert_close(actual.down_proj.bias, expected.down_proj.bias)
+
+
+def test_lazy_turtle_materializes_rectangular_qwen_style_experts_from_fused_checkpoint_tensors(tmp_path):
+    """Non-transposed expert checkpoints should split gate/up along the output dimension."""
+
+    source_model = _RectFusedExpertsWrapper(width=8, intermediate=6, expert_count=2, is_transposed=False)
+    shell_model = _RectFusedExpertsWrapper(width=8, intermediate=6, expert_count=2, is_transposed=False)
+    shell_model.load_state_dict(source_model.state_dict())
+
+    model_dir = tmp_path / "source_model"
+    model_dir.mkdir()
+    shard_name = "model.safetensors"
+    checkpoint_tensors = {
+        "block.experts.gate_up_proj": torch.stack(
+            [
+                torch.cat(
+                    [
+                        source_model.block.experts.get_submodule(str(expert_idx)).gate_proj.weight.detach().clone(),
+                        source_model.block.experts.get_submodule(str(expert_idx)).up_proj.weight.detach().clone(),
+                    ],
+                    dim=0,
+                )
+                for expert_idx in range(2)
+            ],
+            dim=0,
+        ),
+        "block.experts.gate_up_proj_bias": torch.stack(
+            [
+                torch.cat(
+                    [
+                        source_model.block.experts.get_submodule(str(expert_idx)).gate_proj.bias.detach().clone(),
+                        source_model.block.experts.get_submodule(str(expert_idx)).up_proj.bias.detach().clone(),
+                    ],
+                    dim=0,
+                )
+                for expert_idx in range(2)
+            ],
+            dim=0,
+        ),
+        "block.experts.down_proj": torch.stack(
+            [
+                source_model.block.experts.get_submodule(str(expert_idx)).down_proj.weight.detach().clone()
+                for expert_idx in range(2)
+            ],
+            dim=0,
+        ),
+        "block.experts.down_proj_bias": torch.stack(
+            [
+                source_model.block.experts.get_submodule(str(expert_idx)).down_proj.bias.detach().clone()
+                for expert_idx in range(2)
+            ],
+            dim=0,
+        ),
+    }
+    save_file(checkpoint_tensors, str(model_dir / shard_name))
+    _write_checkpoint_index(model_dir, shard_name, checkpoint_tensors)
+
+    for expert_idx in range(2):
+        expert = shell_model.block.experts.get_submodule(str(expert_idx))
+        expert.gate_proj.weight = nn.Parameter(
+            torch.empty_like(expert.gate_proj.weight, device="meta"),
+            requires_grad=expert.gate_proj.weight.requires_grad,
+        )
+        expert.gate_proj.bias = nn.Parameter(
+            torch.empty_like(expert.gate_proj.bias, device="meta"),
+            requires_grad=expert.gate_proj.bias.requires_grad,
+        )
+        expert.up_proj.weight = nn.Parameter(
+            torch.empty_like(expert.up_proj.weight, device="meta"),
+            requires_grad=expert.up_proj.weight.requires_grad,
+        )
+        expert.up_proj.bias = nn.Parameter(
+            torch.empty_like(expert.up_proj.bias, device="meta"),
+            requires_grad=expert.up_proj.bias.requires_grad,
+        )
+        expert.down_proj.weight = nn.Parameter(
+            torch.empty_like(expert.down_proj.weight, device="meta"),
+            requires_grad=expert.down_proj.weight.requires_grad,
+        )
+        expert.down_proj.bias = nn.Parameter(
+            torch.empty_like(expert.down_proj.bias, device="meta"),
+            requires_grad=expert.down_proj.bias.requires_grad,
+        )
+
+    source = LazyTurtle.maybe_create(
+        model_local_path=str(model_dir),
+        config=SimpleNamespace(_experts_implementation=None),
+        model_init_kwargs={"device_map": {"": "cpu"}},
+    )
+    assert source is not None
+
+    alias_from_turtle_for_submodule(
+        target_model=shell_model,
+        turtle_model=source,
+        target_submodule=shell_model.block,
+        device=torch.device("cpu"),
+    )
+
+    for expert_idx in range(2):
+        expected = source_model.block.experts.get_submodule(str(expert_idx))
+        actual = shell_model.block.experts.get_submodule(str(expert_idx))
+        torch.testing.assert_close(actual.gate_proj.weight, expected.gate_proj.weight)
+        torch.testing.assert_close(actual.gate_proj.bias, expected.gate_proj.bias)
+        torch.testing.assert_close(actual.up_proj.weight, expected.up_proj.weight)
+        torch.testing.assert_close(actual.up_proj.bias, expected.up_proj.bias)
+        torch.testing.assert_close(actual.down_proj.weight, expected.down_proj.weight)
+        torch.testing.assert_close(actual.down_proj.bias, expected.down_proj.bias)
+
+
+def test_lazy_turtle_materializes_leaf_qwen_style_expert_gate_proj_from_fused_checkpoint_tensor(tmp_path):
+    """Leaf expert gate_proj modules should resolve fused expert sources from module_path alone."""
+
+    source_model = _RectFusedExpertsWrapper(width=8, intermediate=6, expert_count=2, is_transposed=False)
+    shell_model = _RectFusedExpertsWrapper(width=8, intermediate=6, expert_count=2, is_transposed=False)
+    shell_model.load_state_dict(source_model.state_dict())
+
+    model_dir = tmp_path / "source_model"
+    model_dir.mkdir()
+    shard_name = "model.safetensors"
+    checkpoint_tensors = {
+        "block.experts.gate_up_proj": torch.stack(
+            [
+                torch.cat(
+                    [
+                        source_model.block.experts.get_submodule(str(expert_idx)).gate_proj.weight.detach().clone(),
+                        source_model.block.experts.get_submodule(str(expert_idx)).up_proj.weight.detach().clone(),
+                    ],
+                    dim=0,
+                )
+                for expert_idx in range(2)
+            ],
+            dim=0,
+        ),
+        "block.experts.gate_up_proj_bias": torch.stack(
+            [
+                torch.cat(
+                    [
+                        source_model.block.experts.get_submodule(str(expert_idx)).gate_proj.bias.detach().clone(),
+                        source_model.block.experts.get_submodule(str(expert_idx)).up_proj.bias.detach().clone(),
+                    ],
+                    dim=0,
+                )
+                for expert_idx in range(2)
+            ],
+            dim=0,
+        ),
+    }
+    save_file(checkpoint_tensors, str(model_dir / shard_name))
+    _write_checkpoint_index(model_dir, shard_name, checkpoint_tensors)
+
+    expert = shell_model.block.experts.get_submodule("1").gate_proj
+    expert.weight = nn.Parameter(torch.empty_like(expert.weight, device="meta"), requires_grad=expert.weight.requires_grad)
+    expert.bias = nn.Parameter(torch.empty_like(expert.bias, device="meta"), requires_grad=expert.bias.requires_grad)
+
+    source = LazyTurtle.maybe_create(
+        model_local_path=str(model_dir),
+        config=SimpleNamespace(_experts_implementation=None),
+        model_init_kwargs={"device_map": {"": "cpu"}},
+    )
+    assert source is not None
+
+    alias_from_turtle_for_submodule(
+        target_model=shell_model,
+        turtle_model=source,
+        target_submodule=expert,
+        device=torch.device("cpu"),
+    )
+
+    expected = source_model.block.experts.get_submodule("1").gate_proj
+    torch.testing.assert_close(expert.weight, expected.weight)
+    torch.testing.assert_close(expert.bias, expected.bias)
+
+
+def test_lazy_turtle_materializes_rectangular_transposed_experts_from_fused_checkpoint_tensors(tmp_path):
+    """Transposed expert checkpoints should transpose weights before matching defused leaves."""
+
+    source_model = _RectFusedExpertsWrapper(width=8, intermediate=6, expert_count=2, is_transposed=True)
+    shell_model = _RectFusedExpertsWrapper(width=8, intermediate=6, expert_count=2, is_transposed=True)
+    shell_model.load_state_dict(source_model.state_dict())
+
+    model_dir = tmp_path / "source_model"
+    model_dir.mkdir()
+    shard_name = "model.safetensors"
+    checkpoint_tensors = {
+        "block.experts.gate_up_proj": torch.stack(
+            [
+                torch.cat(
+                    [
+                        source_model.block.experts.get_submodule(str(expert_idx)).gate_proj.weight.detach().clone().transpose(0, 1),
+                        source_model.block.experts.get_submodule(str(expert_idx)).up_proj.weight.detach().clone().transpose(0, 1),
+                    ],
+                    dim=1,
+                )
+                for expert_idx in range(2)
+            ],
+            dim=0,
+        ),
+        "block.experts.gate_up_proj_bias": torch.stack(
+            [
+                torch.cat(
+                    [
+                        source_model.block.experts.get_submodule(str(expert_idx)).gate_proj.bias.detach().clone(),
+                        source_model.block.experts.get_submodule(str(expert_idx)).up_proj.bias.detach().clone(),
+                    ],
+                    dim=0,
+                )
+                for expert_idx in range(2)
+            ],
+            dim=0,
+        ),
+        "block.experts.down_proj": torch.stack(
+            [
+                source_model.block.experts.get_submodule(str(expert_idx)).down_proj.weight.detach().clone().transpose(0, 1)
+                for expert_idx in range(2)
+            ],
+            dim=0,
+        ),
+        "block.experts.down_proj_bias": torch.stack(
+            [
+                source_model.block.experts.get_submodule(str(expert_idx)).down_proj.bias.detach().clone()
+                for expert_idx in range(2)
+            ],
+            dim=0,
+        ),
+    }
+    save_file(checkpoint_tensors, str(model_dir / shard_name))
+    _write_checkpoint_index(model_dir, shard_name, checkpoint_tensors)
+
+    for expert_idx in range(2):
+        expert = shell_model.block.experts.get_submodule(str(expert_idx))
+        expert.gate_proj.weight = nn.Parameter(
+            torch.empty_like(expert.gate_proj.weight, device="meta"),
+            requires_grad=expert.gate_proj.weight.requires_grad,
+        )
+        expert.gate_proj.bias = nn.Parameter(
+            torch.empty_like(expert.gate_proj.bias, device="meta"),
+            requires_grad=expert.gate_proj.bias.requires_grad,
+        )
+        expert.up_proj.weight = nn.Parameter(
+            torch.empty_like(expert.up_proj.weight, device="meta"),
+            requires_grad=expert.up_proj.weight.requires_grad,
+        )
+        expert.up_proj.bias = nn.Parameter(
+            torch.empty_like(expert.up_proj.bias, device="meta"),
+            requires_grad=expert.up_proj.bias.requires_grad,
+        )
+        expert.down_proj.weight = nn.Parameter(
+            torch.empty_like(expert.down_proj.weight, device="meta"),
+            requires_grad=expert.down_proj.weight.requires_grad,
+        )
+        expert.down_proj.bias = nn.Parameter(
+            torch.empty_like(expert.down_proj.bias, device="meta"),
+            requires_grad=expert.down_proj.bias.requires_grad,
+        )
+
+    source = LazyTurtle.maybe_create(
+        model_local_path=str(model_dir),
+        config=SimpleNamespace(_experts_implementation=None),
+        model_init_kwargs={"device_map": {"": "cpu"}},
+    )
+    assert source is not None
+
+    alias_from_turtle_for_submodule(
+        target_model=shell_model,
+        turtle_model=source,
+        target_submodule=shell_model.block,
+        device=torch.device("cpu"),
+    )
+
+    for expert_idx in range(2):
+        expected = source_model.block.experts.get_submodule(str(expert_idx))
+        actual = shell_model.block.experts.get_submodule(str(expert_idx))
+        torch.testing.assert_close(actual.gate_proj.weight, expected.gate_proj.weight)
+        torch.testing.assert_close(actual.gate_proj.bias, expected.gate_proj.bias)
+        torch.testing.assert_close(actual.up_proj.weight, expected.up_proj.weight)
+        torch.testing.assert_close(actual.up_proj.bias, expected.up_proj.bias)
+        torch.testing.assert_close(actual.down_proj.weight, expected.down_proj.weight)
+        torch.testing.assert_close(actual.down_proj.bias, expected.down_proj.bias)
+
+
+def test_lazy_turtle_materializes_leaf_transposed_expert_gate_proj_from_fused_checkpoint_tensor(tmp_path):
+    """Leaf expert gate_proj modules should also honor transposed fused expert layouts."""
+
+    source_model = _RectFusedExpertsWrapper(width=8, intermediate=6, expert_count=2, is_transposed=True)
+    shell_model = _RectFusedExpertsWrapper(width=8, intermediate=6, expert_count=2, is_transposed=True)
+    shell_model.load_state_dict(source_model.state_dict())
+
+    model_dir = tmp_path / "source_model"
+    model_dir.mkdir()
+    shard_name = "model.safetensors"
+    checkpoint_tensors = {
+        "block.experts.gate_up_proj": torch.stack(
+            [
+                torch.cat(
+                    [
+                        source_model.block.experts.get_submodule(str(expert_idx)).gate_proj.weight.detach().clone().transpose(0, 1),
+                        source_model.block.experts.get_submodule(str(expert_idx)).up_proj.weight.detach().clone().transpose(0, 1),
+                    ],
+                    dim=1,
+                )
+                for expert_idx in range(2)
+            ],
+            dim=0,
+        ),
+        "block.experts.gate_up_proj_bias": torch.stack(
+            [
+                torch.cat(
+                    [
+                        source_model.block.experts.get_submodule(str(expert_idx)).gate_proj.bias.detach().clone(),
+                        source_model.block.experts.get_submodule(str(expert_idx)).up_proj.bias.detach().clone(),
+                    ],
+                    dim=0,
+                )
+                for expert_idx in range(2)
+            ],
+            dim=0,
+        ),
+    }
+    save_file(checkpoint_tensors, str(model_dir / shard_name))
+    _write_checkpoint_index(model_dir, shard_name, checkpoint_tensors)
+
+    expert = shell_model.block.experts.get_submodule("1").gate_proj
+    expert.weight = nn.Parameter(torch.empty_like(expert.weight, device="meta"), requires_grad=expert.weight.requires_grad)
+    expert.bias = nn.Parameter(torch.empty_like(expert.bias, device="meta"), requires_grad=expert.bias.requires_grad)
+
+    source = LazyTurtle.maybe_create(
+        model_local_path=str(model_dir),
+        config=SimpleNamespace(_experts_implementation=None),
+        model_init_kwargs={"device_map": {"": "cpu"}},
+    )
+    assert source is not None
+
+    alias_from_turtle_for_submodule(
+        target_model=shell_model,
+        turtle_model=source,
+        target_submodule=expert,
+        device=torch.device("cpu"),
+    )
+
+    expected = source_model.block.experts.get_submodule("1").gate_proj
+    torch.testing.assert_close(expert.weight, expected.weight)
+    torch.testing.assert_close(expert.bias, expected.bias)
+
+
+def test_alias_all_from_turtle_materializes_leaf_qwen_style_expert_gate_proj_from_fused_checkpoint_tensor(tmp_path):
+    """Direct-meta sync should resolve fused non-transposed expert tensors for leaf Linear modules."""
+
+    source_model = _RectFusedExpertsWrapper(width=8, intermediate=6, expert_count=2, is_transposed=False)
+    shell_model = _RectFusedExpertsWrapper(width=8, intermediate=6, expert_count=2, is_transposed=False)
+    shell_model.load_state_dict(source_model.state_dict())
+
+    expert = shell_model.block.experts.get_submodule("1").gate_proj
+    expert.weight = nn.Parameter(torch.empty_like(expert.weight, device="meta"), requires_grad=expert.weight.requires_grad)
+    expert.bias = nn.Parameter(torch.empty_like(expert.bias, device="meta"), requires_grad=expert.bias.requires_grad)
+
+    source = _build_lazy_turtle_from_checkpoint_tensors(
+        tmp_path,
+        _build_rect_fused_expert_checkpoint_tensors(source_model, include_down_proj=False),
+    )
+
+    alias_all_from_turtle_if_meta(shell_model=shell_model, turtle_model=source)
+
+    expected = source_model.block.experts.get_submodule("1").gate_proj
+    torch.testing.assert_close(expert.weight, expected.weight)
+    torch.testing.assert_close(expert.bias, expected.bias)
+
+
+def test_alias_all_from_turtle_materializes_leaf_transposed_expert_gate_proj_from_fused_checkpoint_tensor(tmp_path):
+    """Direct-meta sync should resolve fused transposed expert tensors for leaf Linear modules."""
+
+    source_model = _RectFusedExpertsWrapper(width=8, intermediate=6, expert_count=2, is_transposed=True)
+    shell_model = _RectFusedExpertsWrapper(width=8, intermediate=6, expert_count=2, is_transposed=True)
+    shell_model.load_state_dict(source_model.state_dict())
+
+    expert = shell_model.block.experts.get_submodule("1").gate_proj
+    expert.weight = nn.Parameter(torch.empty_like(expert.weight, device="meta"), requires_grad=expert.weight.requires_grad)
+    expert.bias = nn.Parameter(torch.empty_like(expert.bias, device="meta"), requires_grad=expert.bias.requires_grad)
+
+    source = _build_lazy_turtle_from_checkpoint_tensors(
+        tmp_path,
+        _build_rect_fused_expert_checkpoint_tensors(source_model, include_down_proj=False),
+    )
+
+    alias_all_from_turtle_if_meta(shell_model=shell_model, turtle_model=source)
+
+    expected = source_model.block.experts.get_submodule("1").gate_proj
+    torch.testing.assert_close(expert.weight, expected.weight)
+    torch.testing.assert_close(expert.bias, expected.bias)
+
+
+def test_lazy_turtle_warns_when_submodule_materialization_cannot_match_target_shape(monkeypatch, tmp_path):
+    """Shape-derived transform failures should produce warnings instead of silently skipping the tensor."""
+
+    source_model = _HybridWrapper(width=16)
+    shell_model = _HybridWrapper(width=16)
+    shell_model.load_state_dict(source_model.state_dict())
+
+    shell_model.block.dt_bias = nn.Parameter(torch.empty(8, device="meta"), requires_grad=source_model.block.dt_bias.requires_grad)
+    source = _build_lazy_turtle_from_module(tmp_path, source_model)
+    warnings = _capture_structure_warnings(monkeypatch)
+
+    alias_from_turtle_for_submodule(
+        target_model=shell_model,
+        turtle_model=source,
+        target_submodule=shell_model.block,
+        device=torch.device("cpu"),
+    )
+
+    assert any(
+        "skip submodule materialization param `dt_bias`" in warning
+        and "could not be reshaped into the target layout" in warning
+        and "target_shape=(8,)" in warning
+        for warning in warnings
+    )
+
+
+def test_alias_all_from_turtle_warns_when_direct_meta_shape_mismatch_slips_past_transform(monkeypatch, tmp_path):
+    """Keep an explicit warning path for post-transform shape mismatches in direct-meta sync."""
+
+    source_model = _HybridWrapper(width=16)
+    shell_model = _HybridWrapper(width=16)
+    shell_model.load_state_dict(source_model.state_dict())
+
+    shell_model.block.dt_bias = nn.Parameter(
+        torch.empty_like(shell_model.block.dt_bias, device="meta"),
+        requires_grad=source_model.block.dt_bias.requires_grad,
+    )
+    source = _build_lazy_turtle_from_module(tmp_path, source_model)
+    warnings = _capture_structure_warnings(monkeypatch)
+
+    original_transform = LazyTurtle._transform_checkpoint_tensor
+
+    def _return_wrong_shape(tensor: torch.Tensor, **kwargs) -> torch.Tensor | None:
+        transformed = original_transform(tensor, **kwargs)
+        if transformed is None:
+            return None
+        return transformed[:-1].contiguous()
+
+    # `_transform_checkpoint_tensor()` now guards most shape mismatches up front.
+    # Monkeypatch it here so the regression test still exercises the downstream
+    # warning branch that protects against malformed custom transforms.
+    monkeypatch.setattr(LazyTurtle, "_transform_checkpoint_tensor", staticmethod(_return_wrong_shape))
+
+    alias_all_from_turtle_if_meta(shell_model=shell_model, turtle_model=source)
+
+    assert any(
+        "skip direct-meta sync param `dt_bias`" in warning
+        and "shape does not match the transformed checkpoint tensor" in warning
+        and "source_shape=(15,)" in warning
+        and "target_shape=(16,)" in warning
+        for warning in warnings
+    )
 
 
 def test_alias_all_from_lazy_turtle_restores_direct_meta_tensors(tmp_path):

--- a/tests/test_offload_files.py
+++ b/tests/test_offload_files.py
@@ -17,7 +17,6 @@ from torch import nn
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding
 
-import gptqmodel.utils.structure as structure_utils
 from gptqmodel.utils.model import get_state_dict_for_save, move_to, streaming_state_dict_to_shards
 from gptqmodel.utils.offload import offload_to_disk, undo_offload_to_disk
 from gptqmodel.utils.structure import (
@@ -25,6 +24,7 @@ from gptqmodel.utils.structure import (
     alias_all_from_turtle_if_meta,
     alias_from_turtle_for_submodule,
 )
+from gptqmodel.utils.structure import log as structure_log
 
 
 class _LinearWithBuffers(nn.Module):
@@ -316,7 +316,7 @@ def _capture_structure_warnings(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     def _record_warning(message: str, *args):
         warnings.append(message % args if args else message)
 
-    monkeypatch.setattr(structure_utils.log, "warning", _record_warning, raising=False)
+    monkeypatch.setattr(structure_log, "warning", _record_warning, raising=False)
     return warnings
 
 


### PR DESCRIPTION
This PR fixes LazyTurtle rematerialization for fused MoE expert checkpoints that do not match the previously hard-coded split layout.

  The original logic could incorrectly materialize tensors such as `gate_proj.weight` by assuming a fixed split dimension. That breaks models with rectangular expert projections and models that store fused expert weights in
  transposed layouts.
