### PR TITLE
Fix bias dtype and validate AWQ bf16 ops

### DIFF
--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -1378,12 +1378,11 @@ def ModelLoader(cls):
                         f"Detected capability: `{device_capability}`."
                     )
 
-            # GPTQ Marlin supports fp16 and bf16 compute, while AWQ Marlin
-            # remains fp16-only for now.
+            # GPTQ Marlin and AWQ Marlin support fp16 and bf16 compute.
             if backend == BACKEND.GPTQ_MARLIN and dtype not in (torch.float16, torch.bfloat16):
                 raise ValueError("Marlin kernel requires dtype=torch.float16 or dtype=torch.bfloat16.")
-            if backend == BACKEND.AWQ_MARLIN and dtype != torch.float16:
-                raise ValueError("AWQ Marlin kernel requires dtype=torch.float16.")
+            if backend == BACKEND.AWQ_MARLIN and dtype not in (torch.float16, torch.bfloat16):
+                raise ValueError("AWQ Marlin kernel requires dtype=torch.float16 or dtype=torch.bfloat16.")
 
 
         if backend in [BACKEND.GPTQ_BITBLAS, BACKEND.AWQ_BITBLAS]:

--- a/gptqmodel/nn_modules/qlinear/marlin.py
+++ b/gptqmodel/nn_modules/qlinear/marlin.py
@@ -172,7 +172,7 @@ class MarlinLinear(GPTQQuantLinear):
                 torch.empty(
                     scales_and_zp_size,
                     self.out_features,
-                    dtype=torch.float16,
+                    dtype=self.compute_dtype,
                 ),
                 requires_grad=False
             ),
@@ -192,7 +192,7 @@ class MarlinLinear(GPTQQuantLinear):
         )
 
         if bias:
-            self.register_buffer("bias", torch.zeros((self.out_features), dtype=torch.float16))
+            self.register_buffer("bias", torch.zeros((self.out_features), dtype=self.compute_dtype))
         else:
             self.bias = None
 
@@ -311,6 +311,8 @@ class MarlinLinear(GPTQQuantLinear):
         # make sure scales is synced with x/input
         if x.dtype != self.scales.dtype:
             replace_parameter(self, "scales", self.scales.to(dtype=x.dtype))
+        if self.bias is not None and self.bias.dtype != x.dtype:
+            self.bias.data = self.bias.data.to(dtype=x.dtype)
 
         out = apply_gptq_marlin_linear(
             input=x.contiguous() if self.is_lm_head else x,

--- a/gptqmodel/nn_modules/qlinear/marlin_awq.py
+++ b/gptqmodel/nn_modules/qlinear/marlin_awq.py
@@ -55,7 +55,7 @@ class AwqMarlinLinear(AWQuantLinear):
     SUPPORTS_PACK_DTYPES = [torch.int32]
     SUPPORTS_ADAPTERS = [Lora]
 
-    SUPPORTS_DTYPES = [torch.float16]
+    SUPPORTS_DTYPES = [torch.float16, torch.bfloat16]
 
     REQUIRES_FORMAT_V2 = False
 
@@ -127,7 +127,7 @@ class AwqMarlinLinear(AWQuantLinear):
                     torch.empty(
                         self.in_features // self.group_size,
                         self.out_features,
-                        dtype=torch.float16,
+                        dtype=self.compute_dtype,
                     ),
                     requires_grad=False
                 )
@@ -138,7 +138,7 @@ class AwqMarlinLinear(AWQuantLinear):
                     "bias",
                     torch.zeros(
                         (out_features),
-                        dtype=torch.float16,
+                        dtype=self.compute_dtype,
                     ),
                 )
             else:

--- a/gptqmodel/nn_modules/qlinear/torch_awq.py
+++ b/gptqmodel/nn_modules/qlinear/torch_awq.py
@@ -36,7 +36,7 @@ class AwqTorchLinear(AWQuantLinear):
     SUPPORTS_PACK_DTYPES = [torch.int32]
     SUPPORTS_ADAPTERS = [Lora]
 
-    SUPPORTS_DTYPES = [torch.float16]
+    SUPPORTS_DTYPES = [torch.float16, torch.bfloat16]
 
     REQUIRES_FORMAT_V2 = False
 
@@ -56,6 +56,7 @@ class AwqTorchLinear(AWQuantLinear):
         register_buffers: bool = False,
         **kwargs,
     ):
+        self.compute_dtype = kwargs.get("dtype") or torch.float16
         super().__init__(
             bits=bits,
             group_size=group_size,
@@ -70,8 +71,17 @@ class AwqTorchLinear(AWQuantLinear):
             register_buffers=register_buffers,
             **kwargs,
         )
+        if register_buffers:
+            if self.scales is not None and self.scales.dtype != self.compute_dtype:
+                self.scales = self.scales.to(dtype=self.compute_dtype)
+            if self.bias is not None and self.bias.dtype != self.compute_dtype:
+                self.bias = self.bias.to(dtype=self.compute_dtype)
 
     def post_init(self):
+        if self.scales is not None and self.scales.dtype not in (torch.float16, torch.bfloat16):
+            self.scales = self.scales.to(dtype=torch.float16)
+        if self.bias is not None and self.bias.dtype not in (torch.float16, torch.bfloat16):
+            self.bias = self.bias.to(dtype=torch.float16)
         super().post_init()
 
     def extra_repr(self) -> str:
@@ -88,9 +98,11 @@ class AwqTorchLinear(AWQuantLinear):
         zeros = zeros.t().contiguous()
         scale_zeros = zeros * scales
 
-        self.register_buffer("scales", scales.clone().half())
+        scale_dtype = scales.dtype if scales.dtype in (torch.float16, torch.bfloat16) else torch.float16
+        self.register_buffer("scales", scales.clone().to(scale_dtype))
         if linear.bias is not None:
-            self.register_buffer("bias", linear.bias.clone().half())
+            bias_dtype = linear.bias.dtype if linear.bias.dtype in (torch.float16, torch.bfloat16) else scale_dtype
+            self.register_buffer("bias", linear.bias.clone().to(bias_dtype))
         else:
             self.bias = None
 
@@ -134,10 +146,26 @@ class AwqTorchLinear(AWQuantLinear):
         self.register_buffer("qweight", qweight)
         self.register_buffer("qzeros", qzeros)
 
+    def _ensure_runtime_dtype(self, *, device: torch.device, dtype: torch.dtype) -> None:
+        if self.scales.device != device or self.scales.dtype != dtype or not self.scales.is_contiguous():
+            self.scales = self.scales.to(device=device, dtype=dtype).contiguous()
+        if self.bias is not None and (
+            self.bias.device != device or self.bias.dtype != dtype or not self.bias.is_contiguous()
+        ):
+            self.bias = self.bias.to(device=device, dtype=dtype).contiguous()
+
     def forward(self, x: torch.Tensor):
+        input_dtype = x.dtype
+        compute_dtype = input_dtype if input_dtype in (torch.float16, torch.bfloat16) else torch.float16
         original_shape = x.shape[:-1] + (self.out_features,)
         device = x.device
         x_flat = x.reshape(-1, x.shape[-1])
+        if x_flat.dtype != compute_dtype or x_flat.device != device:
+            x_flat = x_flat.to(device=device, dtype=compute_dtype)
+        elif not x_flat.is_contiguous():
+            x_flat = x_flat.contiguous()
+
+        self._ensure_runtime_dtype(device=device, dtype=compute_dtype)
 
         weight = dequantize_gemm(
             qweight=self.qweight,
@@ -146,9 +174,10 @@ class AwqTorchLinear(AWQuantLinear):
             bits=self.bits,
             group_size=self.group_size,
         )
-        assert weight.dtype == torch.float16, f"weight {weight.dtype} is not float16"
-        if weight.dtype != x_flat.dtype or weight.device != device:
-            weight = weight.to(device=device, dtype=x_flat.dtype)
+        if weight.dtype not in (torch.float16, torch.bfloat16):
+            raise AssertionError(f"weight {weight.dtype} is not float16 or bfloat16")
+        if weight.dtype != compute_dtype or weight.device != device or not weight.is_contiguous():
+            weight = weight.to(device=device, dtype=compute_dtype).contiguous()
 
         output = torch.matmul(x_flat, weight)
 
@@ -157,6 +186,9 @@ class AwqTorchLinear(AWQuantLinear):
 
         if self.adapter:
             output = self.adapter.apply(x=x_flat, out=output)
+
+        if output.dtype != input_dtype:
+            output = output.to(dtype=input_dtype)
 
         output = output.reshape(original_shape)
 

--- a/tests/kernels/test_awq.py
+++ b/tests/kernels/test_awq.py
@@ -73,7 +73,7 @@ class TestAwqKernelOutput(unittest.TestCase):
     TARGET = "model.layers.20.self_attn.v_proj"
     BITS = 4
     GROUP_SIZE = 128
-    SUPPORTED_DTYPES = (torch.float16,)
+    SUPPORTED_DTYPES = (torch.float16, torch.bfloat16)
 
     baseline_backend = BACKEND.TORCH_AWQ
     backend_cases = [
@@ -353,6 +353,8 @@ class TestAwqKernelOutput(unittest.TestCase):
         qzeros_cpu: torch.Tensor,
         scales_cpu: torch.Tensor,
         bias_cpu: torch.Tensor,
+        *,
+        dtype: torch.dtype = torch.float16,
     ) -> Optional[AwqMarlinLinear]:
         if marlin_import_exception is not None:
             cls.backend_skip_reason[BACKEND.MARLIN] = f"AWQ Marlin kernel unavailable: {marlin_import_exception}"
@@ -374,14 +376,15 @@ class TestAwqKernelOutput(unittest.TestCase):
             in_features=cls.in_features,
             out_features=cls.out_features,
             bias=True,
+            dtype=dtype,
             adapter=None,
             register_buffers=True,
         ).to(cls.device)
 
         module.qweight.data.copy_(qweight_cpu.to(cls.device))
         module.qzeros.data.copy_(qzeros_cpu.to(cls.device))
-        module.scales.data.copy_(scales_cpu.to(torch.float16).to(cls.device))
-        module.bias.data.copy_(bias_cpu.to(torch.float16).to(cls.device))
+        module.scales.data.copy_(scales_cpu.to(dtype).to(cls.device))
+        module.bias.data.copy_(bias_cpu.to(dtype).to(cls.device))
 
         module.eval()
         module.post_init()
@@ -720,6 +723,43 @@ class TestAwqKernelOutput(unittest.TestCase):
             reference_mean_ms=reference_result.mean_ms,
             actual_mean_ms=actual_result.mean_ms,
         )
+
+    def test_awq_marlin_bfloat16_outputs(self) -> None:
+        self._maybe_skip_backend(BACKEND.MARLIN)
+
+        if not self.cuda_available:
+            self.skipTest("CUDA is required for AWQ Marlin kernel.")
+        if not torch.cuda.is_bf16_supported():
+            self.skipTest("CUDA bfloat16 not supported on this device.")
+
+        module = self._build_marlin_module(
+            self.qweight_cpu,
+            self.qzeros_cpu,
+            self.scales_cpu,
+            self.bias_cpu,
+            dtype=torch.bfloat16,
+        )
+        if module is None:
+            self.skipTest("AWQ Marlin bf16 module unavailable.")
+
+        try:
+            reference_result = self.reference_results[torch.bfloat16]
+            actual_result = self._forward(module, self.inputs[torch.bfloat16])
+            self._summarize_results(
+                reference_outputs=reference_result.outputs,
+                actual_outputs=actual_result.outputs,
+                backend=BACKEND.MARLIN,
+                dtype=torch.bfloat16,
+                atol=0.05,
+                title="AWQ Kernel Output torch.bfloat16",
+                reference_label="Torch AWQ output",
+                reference_mean_ms=reference_result.mean_ms,
+                actual_mean_ms=actual_result.mean_ms,
+            )
+        finally:
+            del module
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
 
     @parameterized.expand(
         [

--- a/tests/kernels/test_awq.py
+++ b/tests/kernels/test_awq.py
@@ -52,6 +52,9 @@ log = LogBar.shared()
 DEVICE = torch.device("cuda:0")
 CPU_DEVICE = torch.device("cpu")
 
+AWQ_MARLIN_FP16_ATOL = 0.006
+AWQ_MARLIN_BF16_ATOL = 0.02
+
 GREEN = "\033[32m"
 RED = "\033[31m"
 RESET = "\033[0m"
@@ -84,9 +87,9 @@ class TestAwqKernelOutput(unittest.TestCase):
         # (BACKEND.GEMM, torch.bfloat16, 0.05),
         (BACKEND.TRITON, torch.float16, 0.004),
         (BACKEND.MACHETE, torch.float16, 0.006),
-        (BACKEND.MARLIN, torch.float16, 0.006),
+        (BACKEND.MARLIN, torch.float16, AWQ_MARLIN_FP16_ATOL),
         (BACKEND.TORCH_FUSED_AWQ, torch.float16, 0.004),
-        # (BACKEND.MARLIN, torch.bfloat16, 0.05),
+        # (BACKEND.MARLIN, torch.bfloat16, AWQ_MARLIN_BF16_ATOL),
         (BACKEND.EXLLAMA_V2, torch.float16, 0.0068),
     ]
 
@@ -743,7 +746,7 @@ class TestAwqKernelOutput(unittest.TestCase):
                 actual_outputs=actual_result.outputs,
                 backend=BACKEND.MARLIN,
                 dtype=torch.bfloat16,
-                atol=0.05,
+                atol=AWQ_MARLIN_BF16_ATOL,
                 title="AWQ Kernel Output torch.bfloat16",
                 reference_label="Torch AWQ output",
                 reference_mean_ms=reference_result.mean_ms,

--- a/tests/kernels/test_awq.py
+++ b/tests/kernels/test_awq.py
@@ -78,7 +78,7 @@ class TestAwqKernelOutput(unittest.TestCase):
     baseline_backend = BACKEND.TORCH_AWQ
     backend_cases = [
         (baseline_backend, torch.float16, 0.0),
-        # (baseline_backend, torch.bfloat16, 0.0),
+        (baseline_backend, torch.bfloat16, 0.0),
         (BACKEND.GEMM, torch.float16, 0.004),
         (BACKEND.BITBLAS_AWQ, torch.float16, 0.004),
         # (BACKEND.GEMM, torch.bfloat16, 0.05),
@@ -212,16 +212,9 @@ class TestAwqKernelOutput(unittest.TestCase):
             if torch_module is None:
                 raise unittest.SkipTest("Torch AWQ kernel unavailable for baseline.")
 
-            forward_kwargs = {}
-            if dtype == torch.bfloat16:
-                forward_kwargs = {
-                    "compute_dtype": torch.float16,
-                    "output_dtype": dtype,
-                }
             cls.reference_results[dtype] = cls._forward(
                 torch_module,
                 converted_inputs,
-                **forward_kwargs,
             )
 
     @classmethod

--- a/tests/kernels/test_awq_torch.py
+++ b/tests/kernels/test_awq_torch.py
@@ -29,7 +29,7 @@ def _pack_awq_tensor(unpacked: torch.Tensor, bits: int) -> torch.Tensor:
     return packed
 
 
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_awq_torch_matches_manual_dequant(dtype):
     if dtype not in AwqTorchLinear.SUPPORTS_DTYPES:
         pytest.skip(f"dtype {dtype} not supported by AwqTorchLinear")
@@ -48,8 +48,8 @@ def test_awq_torch_matches_manual_dequant(dtype):
 
     int_weight = torch.randint(0, 2**bits, size=(in_features, out_features), dtype=torch.int32)
     zero_points = torch.randint(0, 2**bits, size=(groups, pack_cols), dtype=torch.int32)
-    scales = (torch.rand(groups, pack_cols, dtype=torch.float16) * 2.0) + 0.25
-    bias = torch.randn(out_features, dtype=torch.float16)
+    scales = ((torch.rand(groups, pack_cols, dtype=torch.float32) * 2.0) + 0.25).to(dtype)
+    bias = torch.randn(out_features, dtype=dtype)
 
     qweight = _pack_awq_tensor(int_weight, bits)
     qzeros = _pack_awq_tensor(zero_points, bits)
@@ -62,22 +62,24 @@ def test_awq_torch_matches_manual_dequant(dtype):
         in_features=in_features,
         out_features=out_features,
         bias=True,
+        dtype=dtype,
         register_buffers=True,
     )
 
     module.qweight.copy_(qweight)
     module.qzeros.copy_(qzeros)
-    module.scales = module.scales.to(dtype=torch.float16)
-    module.scales.copy_(scales.to(torch.float16))
-    module.bias.copy_(bias)
+    module.scales.copy_(scales.to(module.scales.dtype))
+    module.bias.copy_(bias.to(module.bias.dtype))
     module.post_init()
     module.eval()
 
     batch = 4
     x = torch.randn(batch, in_features, dtype=dtype)
 
-    bias_expected = module.bias
+    output_first = module(x)
+    output_second = module(x)
 
+    bias_expected = module.bias.to(dtype=dtype)
     dequant_weight = dequantize_gemm(
         qweight=module.qweight,
         qzeros=module.qzeros,
@@ -85,12 +87,11 @@ def test_awq_torch_matches_manual_dequant(dtype):
         bits=bits,
         group_size=group_size,
     ).to(dtype=dtype)
-
     expected = torch.matmul(x.to(dtype), dequant_weight)
     expected = expected + bias_expected
 
-    output_first = module(x)
-    output_second = module(x)
+    assert output_first.dtype == dtype
+    assert output_second.dtype == dtype
 
     atol = 1e-4 if dtype == torch.float32 else 5e-3
     rtol = 1e-4 if dtype == torch.float32 else 5e-3

--- a/tests/test_awq_loader_dtype.py
+++ b/tests/test_awq_loader_dtype.py
@@ -33,3 +33,21 @@ def test_auto_awq_backend_keeps_requested_dtype():
     )
 
     assert dtype == torch.bfloat16
+
+
+def test_explicit_awq_backend_keeps_supported_bfloat16(monkeypatch):
+    class FakeAwqKernel:
+        SUPPORTS_DTYPES = [torch.float16, torch.bfloat16]
+        __name__ = "FakeAwqKernel"
+
+    monkeypatch.setattr(loader, "get_kernel_for_backend", lambda *_args, **_kwargs: FakeAwqKernel)
+
+    qcfg = QuantizeConfig(bits=4, group_size=128, quant_method=METHOD.AWQ, format=FORMAT.GEMM)
+
+    dtype = loader._coerce_quantized_awq_dtype(
+        backend=BACKEND.MARLIN,
+        qcfg=qcfg,
+        dtype=torch.bfloat16,
+    )
+
+    assert dtype == torch.bfloat16

--- a/tests/test_marlin_jit.py
+++ b/tests/test_marlin_jit.py
@@ -10,6 +10,7 @@ import pytest
 import torch
 
 import gptqmodel.nn_modules.qlinear.marlin as marlin_qlinear_module
+import gptqmodel.nn_modules.qlinear.marlin_awq as marlin_awq_qlinear_module
 import gptqmodel.utils.marlin as marlin_utils
 from gptqmodel import extension as extension_api
 from gptqmodel.utils import cpp as cpp_module
@@ -405,6 +406,107 @@ def test_marlin_quant_linear_post_init_uses_compute_dtype_for_repack(monkeypatch
     module.post_init()
 
     assert captured == {"dtype": torch.bfloat16, "shape": tuple(module.qweight.shape)}
+
+
+def test_marlin_quant_linear_registers_runtime_buffers_in_compute_dtype(monkeypatch):
+    monkeypatch.setattr(marlin_qlinear_module, "marlin_import_exception", None)
+
+    module = marlin_qlinear_module.MarlinLinear(
+        bits=4,
+        group_size=128,
+        desc_act=False,
+        sym=True,
+        in_features=128,
+        out_features=64,
+        bias=True,
+        dtype=torch.bfloat16,
+    )
+
+    assert module.scales.dtype == torch.bfloat16
+    assert module.bias.dtype == torch.bfloat16
+
+
+def test_marlin_quant_linear_forward_promotes_bias_to_input_dtype(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(marlin_qlinear_module, "marlin_import_exception", None)
+    monkeypatch.setattr(marlin_qlinear_module, "marlin_runtime_available", lambda dtype: True)
+    monkeypatch.setattr(marlin_qlinear_module, "marlin_runtime_error", lambda dtype: "")
+    monkeypatch.setattr(
+        marlin_qlinear_module,
+        "marlin_make_workspace_new",
+        lambda device: torch.zeros(1, dtype=torch.int32, device=device),
+    )
+    monkeypatch.setattr(
+        marlin_qlinear_module,
+        "gptq_marlin_repack",
+        lambda b_q_weight, perm, size_k, size_n, num_bits, dtype=None: b_q_weight,
+    )
+    monkeypatch.setattr(
+        marlin_qlinear_module,
+        "marlin_permute_scales",
+        lambda scales, size_k, size_n, group_size: scales,
+    )
+    monkeypatch.setattr(marlin_qlinear_module, "marlin_permute_bias", lambda bias: bias)
+    monkeypatch.setattr(
+        marlin_qlinear_module,
+        "apply_gptq_marlin_linear",
+        lambda **kwargs: (
+            captured.update(
+                {
+                    "input_dtype": kwargs["input"].dtype,
+                    "scale_dtype": kwargs["weight_scale"].dtype,
+                    "bias_dtype": kwargs["bias"].dtype,
+                }
+            )
+            or torch.zeros(
+                (kwargs["input"].shape[0], kwargs["output_size_per_partition"]),
+                dtype=kwargs["input"].dtype,
+            )
+        ),
+    )
+
+    module = marlin_qlinear_module.MarlinLinear(
+        bits=4,
+        group_size=128,
+        desc_act=False,
+        sym=True,
+        in_features=128,
+        out_features=64,
+        bias=True,
+        dtype=torch.float16,
+    )
+    module.post_init()
+
+    out = module(torch.randn(2, 128, dtype=torch.bfloat16))
+
+    assert captured == {
+        "input_dtype": torch.bfloat16,
+        "scale_dtype": torch.bfloat16,
+        "bias_dtype": torch.bfloat16,
+    }
+    assert module.bias.dtype == torch.bfloat16
+    assert out.dtype == torch.bfloat16
+
+
+def test_awq_marlin_quant_linear_registers_runtime_buffers_in_compute_dtype(monkeypatch):
+    monkeypatch.setattr(marlin_awq_qlinear_module, "marlin_import_exception", None)
+
+    module = marlin_awq_qlinear_module.AwqMarlinLinear(
+        bits=4,
+        group_size=128,
+        desc_act=False,
+        sym=False,
+        in_features=128,
+        out_features=64,
+        bias=True,
+        dtype=torch.bfloat16,
+        register_buffers=True,
+    )
+
+    assert torch.bfloat16 in marlin_awq_qlinear_module.AwqMarlinLinear.SUPPORTS_DTYPES
+    assert module.scales.dtype == torch.bfloat16
+    assert module.bias.dtype == torch.bfloat16
 
 
 def test_marlin_runtime_error_appends_cuda_extra_install_hint_for_missing_headers(monkeypatch):


### PR DESCRIPTION
@jiqing-feng  This PR will re-enable `bf16` support for awq kernels. Still trying to figure out and minimize AWQ bf16's ~3.5x worse accuracy abs/mean vs fp16. Gptq kernels do not have this problem.  Even in AutoAWQ I saw they disabled bf16 ops, for likely same accuracy reason. However, many new models must operate in bf16 mode to reduce chance of NaN. So either I enable real bf16 at reduced accuracy, or just do fake bf16 where internal is fp16 and input is cast to fp16, fp16 ops, and output is cast to bf16. 