### PR TITLE
Raise on LazyTurtle materialization failures and silence expected skips

### DIFF
--- a/gptqmodel/utils/structure.py
+++ b/gptqmodel/utils/structure.py
@@ -953,7 +953,7 @@ class LazyTurtle:
         return self._resolve_fused_expert_tensor_name("", combined_name)
 
     @staticmethod
-    def _warn_materialization_skip(
+    def _materialization_issue_message(
         *,
         phase: str,
         kind: str,
@@ -966,8 +966,8 @@ class LazyTurtle:
         expert_index: Optional[int] = None,
         split_index: Optional[int] = None,
         split_dim: Optional[int] = None,
-    ) -> None:
-        """Emit a consistent warning when a checkpoint-backed tensor cannot be materialized."""
+    ) -> str:
+        """Build a consistent error message for checkpoint-backed materialization failures."""
 
         details = []
         if full_name is not None:
@@ -984,14 +984,9 @@ class LazyTurtle:
             details.append(f"split_dim={split_dim}")
 
         suffix = f" ({', '.join(details)})" if details else ""
-        log.warning(
-            "LazyTurtle: skip %s %s `%s` under `%s`: %s%s",
-            phase,
-            kind,
-            rel_name,
-            module_path or "<root>",
-            reason,
-            suffix,
+        return (
+            f"LazyTurtle: {phase} {kind} `{rel_name}` under `{module_path or '<root>'}`: "
+            f"{reason}{suffix}"
         )
 
     def _load_checkpoint_tensors_for_module_path(
@@ -1046,30 +1041,23 @@ class LazyTurtle:
         for rel_name in t_params:
             full_name, expert_index, split_index, split_dim = self._resolve_checkpoint_tensor_source(module_path, rel_name)
             if full_name is None:
-                self._warn_materialization_skip(
-                    phase="submodule materialization",
-                    kind="param",
-                    module_path=module_path,
-                    rel_name=rel_name,
-                    reason="no checkpoint tensor mapping was found",
-                    target_shape=tuple(t_params[rel_name].shape),
-                )
                 continue
             shard = self._weight_map.get(full_name)
             if shard is None:
-                self._warn_materialization_skip(
-                    phase="submodule materialization",
-                    kind="param",
-                    module_path=module_path,
-                    rel_name=rel_name,
-                    reason="checkpoint tensor mapping resolved to a missing shard",
-                    full_name=full_name,
-                    target_shape=tuple(t_params[rel_name].shape),
-                    expert_index=expert_index,
-                    split_index=split_index,
-                    split_dim=split_dim,
+                raise RuntimeError(
+                    self._materialization_issue_message(
+                        phase="submodule materialization",
+                        kind="param",
+                        module_path=module_path,
+                        rel_name=rel_name,
+                        reason="checkpoint tensor mapping resolved to a missing shard",
+                        full_name=full_name,
+                        target_shape=tuple(t_params[rel_name].shape),
+                        expert_index=expert_index,
+                        split_index=split_index,
+                        split_dim=split_dim,
+                    )
                 )
-                continue
             grouped_names.setdefault(shard, []).append(("param", rel_name, full_name, expert_index, split_index, split_dim))
 
         for rel_name, target_buffer in list(t_bufs.items()):
@@ -1120,7 +1108,7 @@ class LazyTurtle:
                             prefer_transposed=prefer_transposed,
                         )
                         if tensor is None:
-                            self._warn_materialization_skip(
+                            raise RuntimeError(self._materialization_issue_message(
                                 phase="submodule materialization",
                                 kind=kind,
                                 module_path=module_path,
@@ -1132,12 +1120,11 @@ class LazyTurtle:
                                 expert_index=expert_index,
                                 split_index=split_index,
                                 split_dim=split_dim,
-                            )
-                            continue
+                            ))
                         if kind == "param":
                             target_param = t_params.get(rel_name)
                             if target_param is None:
-                                self._warn_materialization_skip(
+                                raise RuntimeError(self._materialization_issue_message(
                                     phase="submodule materialization",
                                     kind=kind,
                                     module_path=module_path,
@@ -1148,10 +1135,9 @@ class LazyTurtle:
                                     expert_index=expert_index,
                                     split_index=split_index,
                                     split_dim=split_dim,
-                                )
-                                continue
+                                ))
                             if target_param.shape != tensor.shape:
-                                self._warn_materialization_skip(
+                                raise RuntimeError(self._materialization_issue_message(
                                     phase="submodule materialization",
                                     kind=kind,
                                     module_path=module_path,
@@ -1163,8 +1149,7 @@ class LazyTurtle:
                                     expert_index=expert_index,
                                     split_index=split_index,
                                     split_dim=split_dim,
-                                )
-                                continue
+                                ))
                             target_param_new = _ensure_target_storage_on_device_(target_param, device)
                             if target_param_new is not target_param:
                                 t_parent, leaf = _get_parent_and_leaf_by_path(target_submodule, rel_name)
@@ -1188,7 +1173,7 @@ class LazyTurtle:
                             continue
 
                         if tuple(target_buffer.shape) != tuple(source.shape):
-                            self._warn_materialization_skip(
+                            raise RuntimeError(self._materialization_issue_message(
                                 phase="submodule materialization",
                                 kind=kind,
                                 module_path=module_path,
@@ -1200,8 +1185,7 @@ class LazyTurtle:
                                 expert_index=expert_index,
                                 split_index=split_index,
                                 split_dim=split_dim,
-                            )
-                            continue
+                            ))
 
                         if getattr(target_buffer, "is_meta", False) or target_buffer.device.type == "meta":
                             new_buffer = torch.empty_like(target_buffer, device=device)
@@ -1358,18 +1342,10 @@ class LazyTurtle:
 
                 full_name, expert_index, split_index, split_dim = self._resolve_checkpoint_tensor_source(module_path, name)
                 if full_name is None:
-                    self._warn_materialization_skip(
-                        phase="direct-meta sync",
-                        kind="param",
-                        module_path=module_path,
-                        rel_name=name,
-                        reason="no checkpoint tensor mapping was found",
-                        target_shape=tuple(shell_param.shape),
-                    )
                     continue
                 shard = self._weight_map.get(full_name)
                 if shard is None:
-                    self._warn_materialization_skip(
+                    raise RuntimeError(self._materialization_issue_message(
                         phase="direct-meta sync",
                         kind="param",
                         module_path=module_path,
@@ -1380,8 +1356,7 @@ class LazyTurtle:
                         expert_index=expert_index,
                         split_index=split_index,
                         split_dim=split_dim,
-                    )
-                    continue
+                    ))
 
                 source_path = os.path.join(self.model_local_path, shard)
                 with safe_open(source_path, framework="pt", device="cpu") as handler:
@@ -1395,7 +1370,7 @@ class LazyTurtle:
                     prefer_transposed=getattr(shell_sub, "is_transposed", None),
                 )
                 if source_param is None:
-                    self._warn_materialization_skip(
+                    raise RuntimeError(self._materialization_issue_message(
                         phase="direct-meta sync",
                         kind="param",
                         module_path=module_path,
@@ -1407,11 +1382,10 @@ class LazyTurtle:
                         expert_index=expert_index,
                         split_index=split_index,
                         split_dim=split_dim,
-                    )
-                    continue
+                    ))
 
                 if shell_param.shape != source_param.shape:
-                    self._warn_materialization_skip(
+                    raise RuntimeError(self._materialization_issue_message(
                         phase="direct-meta sync",
                         kind="param",
                         module_path=module_path,
@@ -1423,8 +1397,7 @@ class LazyTurtle:
                         expert_index=expert_index,
                         split_index=split_index,
                         split_dim=split_dim,
-                    )
-                    continue
+                    ))
 
                 cache_key = (full_name, expert_index, split_index, split_dim, shell_param.dtype, shell_param.requires_grad)
                 new_param = param_cache.get(cache_key)
@@ -1446,18 +1419,10 @@ class LazyTurtle:
 
                 full_name, expert_index, split_index, split_dim = self._resolve_checkpoint_tensor_source(module_path, name)
                 if full_name is None:
-                    self._warn_materialization_skip(
-                        phase="direct-meta sync",
-                        kind="buffer",
-                        module_path=module_path,
-                        rel_name=name,
-                        reason="no checkpoint tensor mapping was found",
-                        target_shape=tuple(shell_buffer.shape),
-                    )
                     continue
                 shard = self._weight_map.get(full_name)
                 if shard is None:
-                    self._warn_materialization_skip(
+                    raise RuntimeError(self._materialization_issue_message(
                         phase="direct-meta sync",
                         kind="buffer",
                         module_path=module_path,
@@ -1468,8 +1433,7 @@ class LazyTurtle:
                         expert_index=expert_index,
                         split_index=split_index,
                         split_dim=split_dim,
-                    )
-                    continue
+                    ))
 
                 source_path = os.path.join(self.model_local_path, shard)
                 with safe_open(source_path, framework="pt", device="cpu") as handler:
@@ -1483,7 +1447,7 @@ class LazyTurtle:
                     prefer_transposed=getattr(shell_sub, "is_transposed", None),
                 )
                 if source_buffer is None:
-                    self._warn_materialization_skip(
+                    raise RuntimeError(self._materialization_issue_message(
                         phase="direct-meta sync",
                         kind="buffer",
                         module_path=module_path,
@@ -1495,11 +1459,10 @@ class LazyTurtle:
                         expert_index=expert_index,
                         split_index=split_index,
                         split_dim=split_dim,
-                    )
-                    continue
+                    ))
 
                 if shell_buffer.shape != source_buffer.shape:
-                    self._warn_materialization_skip(
+                    raise RuntimeError(self._materialization_issue_message(
                         phase="direct-meta sync",
                         kind="buffer",
                         module_path=module_path,
@@ -1511,8 +1474,7 @@ class LazyTurtle:
                         expert_index=expert_index,
                         split_index=split_index,
                         split_dim=split_dim,
-                    )
-                    continue
+                    ))
 
                 persistent = name not in getattr(shell_sub, "_non_persistent_buffers_set", set())
                 cache_key = (full_name, expert_index, split_index, split_dim, shell_buffer.dtype)

--- a/tests/test_offload_files.py
+++ b/tests/test_offload_files.py
@@ -24,7 +24,6 @@ from gptqmodel.utils.structure import (
     alias_all_from_turtle_if_meta,
     alias_from_turtle_for_submodule,
 )
-from gptqmodel.utils.structure import log as structure_log
 
 
 class _LinearWithBuffers(nn.Module):
@@ -306,18 +305,6 @@ def _build_rect_fused_expert_checkpoint_tensors(
         )
 
     return checkpoint_tensors
-
-
-def _capture_structure_warnings(monkeypatch: pytest.MonkeyPatch) -> list[str]:
-    """Capture LazyTurtle warnings without depending on the logging backend implementation."""
-
-    warnings: list[str] = []
-
-    def _record_warning(message: str, *args):
-        warnings.append(message % args if args else message)
-
-    monkeypatch.setattr(structure_log, "warning", _record_warning, raising=False)
-    return warnings
 
 
 def test_offload_to_disk_writes_single_dat_file(tmp_path):
@@ -1244,8 +1231,8 @@ def test_alias_all_from_turtle_materializes_leaf_transposed_expert_gate_proj_fro
     torch.testing.assert_close(expert.bias, expected.bias)
 
 
-def test_lazy_turtle_warns_when_submodule_materialization_cannot_match_target_shape(monkeypatch, tmp_path):
-    """Shape-derived transform failures should produce warnings instead of silently skipping the tensor."""
+def test_lazy_turtle_raises_when_submodule_materialization_cannot_match_target_shape(tmp_path):
+    """Shape-derived transform failures should fail materialization immediately."""
 
     source_model = _HybridWrapper(width=16)
     shell_model = _HybridWrapper(width=16)
@@ -1253,25 +1240,21 @@ def test_lazy_turtle_warns_when_submodule_materialization_cannot_match_target_sh
 
     shell_model.block.dt_bias = nn.Parameter(torch.empty(8, device="meta"), requires_grad=source_model.block.dt_bias.requires_grad)
     source = _build_lazy_turtle_from_module(tmp_path, source_model)
-    warnings = _capture_structure_warnings(monkeypatch)
 
-    alias_from_turtle_for_submodule(
-        target_model=shell_model,
-        turtle_model=source,
-        target_submodule=shell_model.block,
-        device=torch.device("cpu"),
-    )
-
-    assert any(
-        "skip submodule materialization param `dt_bias`" in warning
-        and "could not be reshaped into the target layout" in warning
-        and "target_shape=(8,)" in warning
-        for warning in warnings
-    )
+    with pytest.raises(
+        RuntimeError,
+        match=r"submodule materialization param `dt_bias`.*could not be reshaped into the target layout.*target_shape=\(8,\)",
+    ):
+        alias_from_turtle_for_submodule(
+            target_model=shell_model,
+            turtle_model=source,
+            target_submodule=shell_model.block,
+            device=torch.device("cpu"),
+        )
 
 
-def test_alias_all_from_turtle_warns_when_direct_meta_shape_mismatch_slips_past_transform(monkeypatch, tmp_path):
-    """Keep an explicit warning path for post-transform shape mismatches in direct-meta sync."""
+def test_alias_all_from_turtle_raises_when_direct_meta_shape_mismatch_slips_past_transform(monkeypatch, tmp_path):
+    """Post-transform shape mismatches in direct-meta sync should fail immediately."""
 
     source_model = _HybridWrapper(width=16)
     shell_model = _HybridWrapper(width=16)
@@ -1282,7 +1265,6 @@ def test_alias_all_from_turtle_warns_when_direct_meta_shape_mismatch_slips_past_
         requires_grad=source_model.block.dt_bias.requires_grad,
     )
     source = _build_lazy_turtle_from_module(tmp_path, source_model)
-    warnings = _capture_structure_warnings(monkeypatch)
 
     original_transform = LazyTurtle._transform_checkpoint_tensor
 
@@ -1294,18 +1276,14 @@ def test_alias_all_from_turtle_warns_when_direct_meta_shape_mismatch_slips_past_
 
     # `_transform_checkpoint_tensor()` now guards most shape mismatches up front.
     # Monkeypatch it here so the regression test still exercises the downstream
-    # warning branch that protects against malformed custom transforms.
+    # hard-failure branch that protects against malformed custom transforms.
     monkeypatch.setattr(LazyTurtle, "_transform_checkpoint_tensor", staticmethod(_return_wrong_shape))
 
-    alias_all_from_turtle_if_meta(shell_model=shell_model, turtle_model=source)
-
-    assert any(
-        "skip direct-meta sync param `dt_bias`" in warning
-        and "shape does not match the transformed checkpoint tensor" in warning
-        and "source_shape=(15,)" in warning
-        and "target_shape=(16,)" in warning
-        for warning in warnings
-    )
+    with pytest.raises(
+        RuntimeError,
+        match=r"direct-meta sync param `dt_bias`.*shape does not match the transformed checkpoint tensor.*source_shape=\(15,\).*target_shape=\(16,\)",
+    ):
+        alias_all_from_turtle_if_meta(shell_model=shell_model, turtle_model=source)
 
 
 def test_alias_all_from_lazy_turtle_restores_direct_meta_tensors(tmp_path):


### PR DESCRIPTION
## Summary

Raise on LazyTurtle materialization failures and silence expected skips

## What Changed

  - raise `RuntimeError` when LazyTurtle hits actual materialization failures:
    - resolved checkpoint tensor points to a missing shard
    - checkpoint tensor cannot be transformed into the target layout
    - transformed tensor shape still mismatches the target tensor
    - target parameter disappears before materialization
  - keep normal skip paths as silent no-ops when no checkpoint tensor mapping exists