### PR TITLE
Fix Kernel JIT compat when torch cuda does not match local nvcc toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 </p>
 
 ## Latest News
+* 04/15/2026 [main]: ✅Gemma 4 GPTQ package support completed end-to-end. `gptqmodel.models.definitions` now exports the full supported model-definition surface, and the Ampere CUDA path was revalidated on RTX 3090 / RTX 3060 (`sm_86`) hardware with a local Gemma 4 GPTQ model.
 * 04/08/2026 [main]: ✨ All CUDA kernels are now JIT compiled. The PyPI package is now about 300x smaller. On first use, GPT-QModel compiles only the kernels your workload actually needs. Improved Bonsai kernels now support execution `profile` control for `fast` or `low_memory` inference. Model weight loading during quantization has been optimized for large models like `GLM 5.1`. Added `GLM 5` and `GLM 5.1` model support.
 * 04/03/2026 [6.0.3](https://github.com/ModelCloud/GPTQModel/releases/tag/v6.0.3): 🎉 New quantization methods: `ParoQuant`, `GGUF`, `FP8`, `EXL3`, and `FOEM: First-Order Error Matters`. Added PrismML/Bonsai 1bit model quantization (inference only), faster ParoQuant/AWQ kernels, ParoQuant `optimization scope` control: `module` (Paro Lite) or `layer` (Paro reference), plus `Gemma4`, `MiniCPM-O`, `MiniCPM-V`, and `GLM4 MOE lite` model support.
 * 03/19/2026 [5.8.0](https://github.com/ModelCloud/GPTQModel/releases/tag/v5.8.0): ✨HF Transformers 5.3.0 support with auto-defusing of `fused` models via pypi pkg: [Defuser](https://github.com/ModelCloud/Defuser). Qwen 3.5 family support added. New fast HF `cpu` kernels for GPTQ/AWQ added. Experimental INT8 `cpu` kernel added for GPTQ. 
@@ -278,7 +279,7 @@ GPT-QModel is validated for Linux, MacOS, and Windows 11:
 
 | Platform        | Device        |     |  Optimized Arch          | Kernels                                       |
 |-----------------|---------------| --- | ------------ |-----------------------------------------------| 
-| 🐧 Linux           | Nvidia GPU    | ✅       | `Ampere+` | Marlin, Exllama V2, Exllama V1, Triton, Torch |
+| 🐧 Linux           | Nvidia GPU    | ✅       | `Ampere+` (`sm_80`/`sm_86`, incl. RTX 3090 / 3060) | Marlin, Exllama V2, Exllama V1, Triton, Torch |
 | 🐧 Linux | AMD GPU     | ✅             |   `7900XT+`,  `ROCm 6.2+` | Exllama V2, Exllama V1, Torch                 |
 | 🐧 Linux | Intel XPU     | ✅             |   `Arc`, `Datacenter Max` | TorchFused, TorchFusedAWQ, Torch              |
 | 🐧 Linux           | Intel/AMD CPU | ✅          | `avx`, `amx` | TorchFused, TorchFusedAWQ, Torch                           |

--- a/gptqmodel/looper/stage_subset.py
+++ b/gptqmodel/looper/stage_subset.py
@@ -1030,11 +1030,17 @@ def _run_single_subset_pass(
         return nm.name, nm
 
     for name, named_module in subset.items():
-        # Launch processing for every module in the subset; tasks may run in
-        # parallel as allowed by the device thread pool.
+        # Use submit_serial for CUDA to avoid glibc pthread priority-inheritance
+        # assertion (Ubuntu 24.04 glibc 2.39) when concurrent CUDA threads run
+        # simultaneous Cholesky decompositions.
         tgt_dev = quant_target_devices.get(name, cur_layer_device)
+        _submitter = (
+            DEVICE_THREAD_POOL.submit_serial
+            if torch.device(tgt_dev).type in ("cuda", "xpu", "mps")
+            else DEVICE_THREAD_POOL.submit
+        )
         futures.append(
-            DEVICE_THREAD_POOL.submit(
+            _submitter(
                 tgt_dev,
                 _process_on_worker,
                 processor,

--- a/gptqmodel/models/definitions/__init__.py
+++ b/gptqmodel/models/definitions/__init__.py
@@ -4,11 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 
+from packaging.version import Version
+from transformers import __version__ as TRANSFORMERS_VERSION
+
 # Many model architectures inherit from LlamaGPTQ, so it’s necessary to import llama first to avoid circular imports.
 from .llama import LlamaQModel
 
 # other model
+from .afmoe import AfMoeQModel
+from .apertus import ApertusQModel
 from .baichuan import BaiChuanQModel
+from .bailing_moe import BailingMoeQModel
 from .bloom import BloomQModel
 from .brumby import BrumbyQModel
 from .chatglm import ChatGLMQModel
@@ -24,58 +30,75 @@ from .exaone import ExaOneQModel
 from .exaone4 import Exaone4QModel
 from .ernie4_5 import Ernie4_5QModel
 from .ernie4_5_moe import Ernie4_5_MoeQModel
+from .falcon_h1 import FalconH1QModel
 from .gemma2 import Gemma2QModel
-from .gemma3 import Gemma3QModel
+from .gemma3 import Gemma3ForConditionalGenerationGPTQ, Gemma3QModel
 from .gemma4 import Gemma4ForConditionalGenerationGPTQ, Gemma4TextQModel
 from .glm import GlmQModel
+from .glm4_moe import GLM4MoEGPTQ
+from .glm4_moe_lite import Glm4MoeLiteQModel
+from .glm4v import Glm4vGPTQ
 from .glm_moe_dsa import GlmMoeDsaQModel
 from .gpt2 import GPT2QModel
 from .gpt_bigcode import GptBigCodeQModel
 from .gpt_neo import GptNeoQModel
 from .gpt_neox import GPTNeoXQModel
+from .gpt_oss import GPTOSSGPTQ
 from .gptj import GptJQModel
+from .granitemoehybrid import GraniteMoeHybridQModel
 from .grinmoe import GrinMoeQModel
 from .hymba import HymbaQModel
 from .instella import InstellaQModel
 from .internlm import InternLMQModel
 from .internlm2 import InternLM2QModel
+from .klear import KlearQModel
+from .lfm2_moe import LFM2MoeQModel
+from .llada2 import LLaDA2MoeQModel
 from .llama4 import Llama4QModel
+from .llava_qwen2 import LlavaQwen2QModel
+from .longcat_flash import LongCatFlashQModel
 from .mimo import MimoQModel
+from .minicpm import MiniCPMGPTQ
 from .minicpm3 import MiniCpm3QModel
 from .minicpm_o import MiniCPMOQModel
 from .minicpm_v import MiniCPMVQModel
 from .minimax_m2 import MiniMaxM2GPTQ
+from .mistral3 import Mistral3GPTQ
 from .mixtral import MixtralQModel
 from .mllama import MLlamaQModel
 from .mobilellm import MobileLLMQModel
 from .moss import MossQModel
 from .mpt import MptQModel
+from .nemotron_h import NemotronHQModel
+from .olmoe import OlmoeGPTQ
 from .opt import OptQModel
 from .ovis import OvisQModel
+from .ovis2 import Ovis2QModel
+from .pangu_alpha import PanguAlphaQModel
 from .phi import PhiQModel
-from .phi3 import Phi3QModel
+from .phi3 import Phi3QModel, PhiMoEGPTQForCausalLM
+from .phi4 import Phi4MMGPTQ
 from .qwen import QwenQModel
 from .qwen2 import Qwen2QModel
+from .qwen2_5_omni import Qwen2_5_OmniGPTQ
 from .qwen2_5_vl import Qwen2_5_VLQModel
 from .qwen2_moe import Qwen2MoeQModel
 from .qwen2_vl import Qwen2VLQModel
 from .qwen3 import Qwen3QModel
 from .qwen3_moe import Qwen3MoeQModel
+from .qwen3_next import Qwen3NextGPTQ
+from .qwen3_omni_moe import Qwen3OmniMoeGPTQ
 from .qwen3_vl import Qwen3_VLQModel
 from .rw import RwgQModel
 from .starcoder2 import Starcoder2QModel
 from .telechat2 import TeleChat2QModel
-from .xverse import XverseQModel
-from .falcon_h1 import FalconH1QModel
-from .pangu_alpha import PanguAlphaQModel
-from .longcat_flash import LongCatFlashQModel
-from .apertus import ApertusQModel
-from .klear import KlearQModel
-from .llava_qwen2 import LlavaQwen2QModel
-from .nemotron_h import NemotronHQModel
-from .qwen3_omni_moe import Qwen3OmniMoeGPTQ
-from .mistral3 import Mistral3GPTQ
-from .afmoe import AfMoeQModel
-from .glm4v import Glm4vGPTQ
 from .voxtral import VoxtralGPTQ
-from .glm4_moe_lite import Glm4MoeLiteQModel
+from .xverse import XverseQModel
+
+TRANSFORMERS_SUPPORTS_QWEN3_5 = Version(TRANSFORMERS_VERSION) >= Version("5.2.0")
+if TRANSFORMERS_SUPPORTS_QWEN3_5:
+    from .qwen3_5 import Qwen3_5QModel
+    from .qwen3_5_moe import Qwen3_5_MoeQModel
+else:
+    Qwen3_5QModel = None
+    Qwen3_5_MoeQModel = None

--- a/gptqmodel/models/definitions/olmoe.py
+++ b/gptqmodel/models/definitions/olmoe.py
@@ -4,11 +4,11 @@
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 
 from .._const import EXPERT_INDEX_PLACEHOLDER
-from ..base import BaseGPTQModel
+from ..base import BaseQModel
 
 
 # Both DeepSeek-v2 and DeepSeek-v2-lite are supported in this model def
-class OlmoeGPTQ(BaseGPTQModel):
+class OlmoeGPTQ(BaseQModel):
 
     dynamic_expert_index = "num_experts"
 

--- a/gptqmodel/nn_modules/qlinear/__init__.py
+++ b/gptqmodel/nn_modules/qlinear/__init__.py
@@ -123,7 +123,7 @@ class BaseQuantLinear(nn.Module):
                 pass
                 # print(f"Adapter lazy init: {self.adapter.name()}: {self.adapter}, module: {self.name}")
 
-            # TDOO: allow merged lora weights exist in gptq model safetensor file for direct loading
+            # TODO: allow merged lora weights exist in gptq model safetensor file for direct loading
             # EoRA need to preallocate buffers for Lora_A and B weights so HF can load
             # self.register_buffer(
             #     "lora_A",

--- a/gptqmodel/quantization/gptq.py
+++ b/gptqmodel/quantization/gptq.py
@@ -867,7 +867,7 @@ class GPTQ:
                             f"(started at {recovery_initial_damp:.5f})."
                         )
                     return Hinv_result, used_damp
-                except torch._C._LinAlgError as e:
+                except (torch._C._LinAlgError, RuntimeError) as e:
                     last_error = e
                     diag_view.copy_(current_diag)
                     if self.qcfg.damp_auto_increment != 0:
@@ -966,6 +966,8 @@ class GPTQ:
         # H = self.H.to(device=self.H.device)
 
         if use_hessian:
+            # Replace NaN/Inf in H before processing (can occur with some model architectures)
+            self.H.nan_to_num_(nan=0.0, posinf=0.0, neginf=0.0)
             dead = torch.diag(self.H) == 0
             self.H[dead, dead] = 1
             W[:, dead] = 0

--- a/gptqmodel/utils/cpp.py
+++ b/gptqmodel/utils/cpp.py
@@ -9,7 +9,9 @@ import hashlib
 import logging
 import math
 import os
+import re
 import shutil
+import subprocess
 import sys
 import threading
 import time
@@ -54,6 +56,29 @@ _LOCAL_INCLUDE_PATTERN = pcre.compile(
 # timings collected on an AMD Zen 3 CPU running at 2.2 GHz, where 8 threads was
 # the best overall tradeoff across Marlin, AWQ, QQQ, ExLlama, and ParoQuant.
 _DEFAULT_NVCC_THREADS = "8"
+
+
+def local_nvcc_version_at_least(major: int, minor: int) -> bool:
+    nvcc_path = shutil.which("nvcc")
+    if not nvcc_path:
+        return False
+
+    try:
+        result = subprocess.run(
+            [nvcc_path, "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return False
+
+    version_text = (result.stdout or "") + "\n" + (result.stderr or "")
+    match = re.search(r"release\s+(\d+)\.(\d+)", version_text)
+    if not match:
+        return False
+
+    return (int(match.group(1)), int(match.group(2))) >= (major, minor)
 
 
 def _format_compile_duration_seconds(seconds: float) -> str:

--- a/gptqmodel/utils/machete.py
+++ b/gptqmodel/utils/machete.py
@@ -23,6 +23,7 @@ from .cpp import (
     default_jit_cflags,
     default_jit_cuda_cflags,
     default_torch_ops_build_root,
+    local_nvcc_version_at_least,
     resolved_cuda_arch_flags,
 )
 from .logger import setup_logger
@@ -61,18 +62,6 @@ def _machete_project_root() -> Path:
 
 def _machete_source_root() -> Path:
     return _machete_project_root() / "gptqmodel_ext" / "machete"
-
-
-def _machete_cuda_version_at_least(major: int, minor: int) -> bool:
-    raw = getattr(torch.version, "cuda", None)
-    if not raw:
-        return False
-    try:
-        parts = raw.split(".")
-        current = (int(parts[0]), int(parts[1]) if len(parts) > 1 else 0)
-    except (TypeError, ValueError):  # pragma: no cover - depends on torch build metadata
-        return False
-    return current >= (major, minor)
 
 
 def _repo_local_cutlass_root() -> Path:
@@ -388,7 +377,7 @@ def _machete_extra_cuda_cflags() -> list[str]:
         ),
         *_machete_hopper_arch_cuda_cflags(),
     ]
-    if _machete_cuda_version_at_least(12, 8):
+    if local_nvcc_version_at_least(12, 8):
         flags.insert(0, "-static-global-template-stub=false")
     return flags
 

--- a/gptqmodel/utils/marlin.py
+++ b/gptqmodel/utils/marlin.py
@@ -21,6 +21,7 @@ from .cpp import (
     default_jit_cuda_cflags,
     default_torch_ops_build_root,
     detected_cuda_wheel_include_paths,
+    local_nvcc_version_at_least,
 )
 from .marlin_scalar_type import ScalarType
 from .rocm import IS_ROCM
@@ -64,18 +65,6 @@ marlin_import_exception = _marlin_environment_error() or None
 
 def _marlin_root() -> Path:
     return Path(__file__).resolve().parents[2] / "gptqmodel_ext" / "marlin"
-
-
-def _marlin_cuda_version_at_least(major: int, minor: int) -> bool:
-    raw = getattr(torch.version, "cuda", None)
-    if not raw:
-        return False
-    try:
-        parts = raw.split(".")
-        current = (int(parts[0]), int(parts[1]) if len(parts) > 1 else 0)
-    except (TypeError, ValueError):  # pragma: no cover - depends on torch build metadata
-        return False
-    return current >= (major, minor)
 
 
 def _marlin_cuda_extra_name() -> str | None:
@@ -195,7 +184,7 @@ def _marlin_extra_cuda_cflags() -> list[str]:
         include_fatbin_compression=True,
         include_diag_suppress=True,
     )
-    if _marlin_cuda_version_at_least(12, 8):
+    if local_nvcc_version_at_least(12, 8):
         flags.insert(0, "-static-global-template-stub=false")
     return flags
 

--- a/tests/models/test_minimax_m2_hf.py
+++ b/tests/models/test_minimax_m2_hf.py
@@ -7,7 +7,7 @@
 MiniMax-M2 Hugging Face checkpoint sanity check with streaming output.
 
 Usage:
-    python test_minimax_m2_hf.py \
+    python tests/models/test_minimax_m2_hf.py \
         --model-path /monster/data/model/MiniMax-M2-bf16 \
         --question "How many letter A are there in the word Alphabet? Reply with the number only."
 """
@@ -109,6 +109,7 @@ def build_prompt(tokenizer: AutoTokenizer, question: str) -> str:
 #                 expert, mlp_types
 #             ), f"Layer {layer_idx} expert {expert_idx}: expected MiniMax(M2)MLP, got {type(expert).__name__}"
 #
+
 
 def main() -> None:
     args = parse_args()

--- a/tests/test_model_definition_exports.py
+++ b/tests/test_model_definition_exports.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from packaging.version import Version
+from transformers import __version__ as TRANSFORMERS_VERSION
+
+from gptqmodel.models import definitions
+
+
+def test_public_model_definition_exports():
+    expected = [
+        "BailingMoeQModel",
+        "GLM4MoEGPTQ",
+        "GPTOSSGPTQ",
+        "Gemma3ForConditionalGenerationGPTQ",
+        "Gemma4ForConditionalGenerationGPTQ",
+        "Gemma4TextQModel",
+        "GraniteMoeHybridQModel",
+        "LFM2MoeQModel",
+        "LLaDA2MoeQModel",
+        "MiniCPMGPTQ",
+        "OlmoeGPTQ",
+        "Ovis2QModel",
+        "Phi4MMGPTQ",
+        "PhiMoEGPTQForCausalLM",
+        "Qwen2_5_OmniGPTQ",
+        "Qwen3NextGPTQ",
+    ]
+
+    for name in expected:
+        assert hasattr(definitions, name), f"missing export: {name}"
+
+
+def test_qwen3_5_exports_follow_transformers_support():
+    supported = Version(TRANSFORMERS_VERSION) >= Version("5.2.0")
+    if supported:
+        assert definitions.Qwen3_5QModel is not None
+        assert definitions.Qwen3_5_MoeQModel is not None
+    else:
+        assert definitions.Qwen3_5QModel is None
+        assert definitions.Qwen3_5_MoeQModel is None


### PR DESCRIPTION
## Summary
- finish the Gemma 4 package/export cleanup and move the MiniMax HF smoke test into tests/
- update README/frontpage notes for Gemma 4 plus Ampere 3090/3060 coverage
- fix Marlin/Machete JIT flag gating to use the local nvcc version so Ampere hosts with older local toolchains do not fail on `-static-global-template-stub=false`

## Validation
- `pytest -q tests/test_model_definition_exports.py`
- `python tests/models/test_minimax_m2_hf.py --help`
- `CUDA_VISIBLE_DEVICES=2,3 GPTQMODEL_MARLIN_FORCE_REBUILD=1 python ...` loading `/home/op/outputs/gemma4-abliterated/gptq-pro-4bit` across both RTX 3060 GPUs with `MarlinLinear` selected and generation succeeding