### PR TITLE
[FIX] Avoid replacing modules like Llama4Router with HookedLinear

### DIFF
--- a/gptqmodel/looper/stage_layer.py
+++ b/gptqmodel/looper/stage_layer.py
@@ -162,6 +162,19 @@ def _collect_layer_forward_progress(
     return batch_count, forward_row_counts, forward_total_rows
 
 
+def _collect_hook_skip_modules(planning_layer_modules: List[List[str]]) -> set[str]:
+    """Collect module paths flagged as non-quantized in module-tree planning blocks."""
+
+    skip_modules: set[str] = set()
+    for block in planning_layer_modules:
+        for module_name in block:
+            if ":!" in module_name:
+                path = module_name.split(":", 1)[0]
+                if path:
+                    skip_modules.add(path)
+    return skip_modules
+
+
 def _replay_layer_outputs(
     looper: "ModuleLooper",
     *,
@@ -380,6 +393,7 @@ def run_layer_stage(
 
     log = logger or setup_logger()
     durable_progress_logs = live_renderables_suppressed()
+    hook_skip_modules = _collect_hook_skip_modules(planning_layer_modules)
     for layer_index in pb:
         # Iterate over every transformer layer (plus lm_head when enabled) as
         # progress-bar controlled units of work.
@@ -445,7 +459,11 @@ def run_layer_stage(
             if needs_group_pristine:
                 pristine_group_module = copy.deepcopy(module) if needs_pristine_group_clone else None
 
-            replace_module_with_hooked_legacy(module, quant_lm_head=looper.gptq_model.quantize_config.lm_head)
+            replace_module_with_hooked_legacy(
+                module,
+                quant_lm_head=looper.gptq_model.quantize_config.lm_head,
+                skip_module_paths=hook_skip_modules,
+            )
 
             layers[layer_index] = module
 

--- a/gptqmodel/models/definitions/llama4.py
+++ b/gptqmodel/models/definitions/llama4.py
@@ -32,6 +32,7 @@ class Llama4QModel(BaseQModel):
             "self_attn": ("q_proj:0", "k_proj:0", "v_proj:0", "o_proj:1"),
             "post_attention_layernorm": ("post_attention_layernorm:!",),
             "feed_forward:moe": {
+                "router": ("router:!",), # Llama4Router.forward() returns two values, skipping its quantization.
                 "experts:0": {
                     "#": ("gate_proj:0", "up_proj:0", "down_proj:1"),
                 },

--- a/gptqmodel/nn_modules/hooked_linear.py
+++ b/gptqmodel/nn_modules/hooked_linear.py
@@ -259,16 +259,14 @@ def _replace_module(module, child, name, level: int = 0, debug: bool = False) ->
     if debug:
         log.info(f"{level_indent} Hook: {instance_type.__name__}: {name}")
 
-    # Only replace plain nn.Linear. Subclasses may override forward() and
-    # change return contract (e.g. PhimoeTopKRouter, Llama4Router), which HookedLinear
-    # cannot preserve.
-    if instance_type is torch.nn.Linear:
+    # Replace nn.Linear with HookedLinear, except PhimoeTopKRouter which returns a tuple in forward()
+    if isinstance(child, torch.nn.Linear) and child.__class__.__name__ != "PhimoeTopKRouter":
         setattr(module, name, HookedLinear.from_linear(child))
-    elif instance_type is transformers.Conv1D:
+    elif isinstance(child, transformers.Conv1D):
         setattr(module, name, HookedTransformerConv1D.from_conv1d(child))
-    elif instance_type is nn.Conv1d:
+    elif isinstance(child, nn.Conv1d):
         setattr(module, name, HookedConv1d.from_conv1d(child))
-    elif instance_type is nn.Conv2d:
+    elif isinstance(child, nn.Conv2d):
         setattr(module, name, HookedConv2d.from_conv2d(child))
     else:
         if debug:

--- a/gptqmodel/nn_modules/hooked_linear.py
+++ b/gptqmodel/nn_modules/hooked_linear.py
@@ -259,14 +259,16 @@ def _replace_module(module, child, name, level: int = 0, debug: bool = False) ->
     if debug:
         log.info(f"{level_indent} Hook: {instance_type.__name__}: {name}")
 
-    # Replace nn.Linear with HookedLinear, except PhimoeTopKRouter which returns a tuple in forward()
-    if isinstance(child, torch.nn.Linear) and child.__class__.__name__ != "PhimoeTopKRouter":
+    # Only replace plain nn.Linear. Subclasses may override forward() and
+    # change return contract (e.g. PhimoeTopKRouter, Llama4Router), which HookedLinear
+    # cannot preserve.
+    if instance_type is torch.nn.Linear:
         setattr(module, name, HookedLinear.from_linear(child))
-    elif isinstance(child, transformers.Conv1D):
+    elif instance_type is transformers.Conv1D:
         setattr(module, name, HookedTransformerConv1D.from_conv1d(child))
-    elif isinstance(child, nn.Conv1d):
+    elif instance_type is nn.Conv1d:
         setattr(module, name, HookedConv1d.from_conv1d(child))
-    elif isinstance(child, nn.Conv2d):
+    elif instance_type is nn.Conv2d:
         setattr(module, name, HookedConv2d.from_conv2d(child))
     else:
         if debug:

--- a/gptqmodel/nn_modules/hooked_linear.py
+++ b/gptqmodel/nn_modules/hooked_linear.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 import copy
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 import torch
 import transformers
@@ -276,7 +276,13 @@ def _replace_module(module, child, name, level: int = 0, debug: bool = False) ->
     return True
 
 
-def replace_module_with_hooked_legacy(module, level: int = 0, quant_lm_head: bool = False):
+def replace_module_with_hooked_legacy(
+    module,
+    level: int = 0,
+    quant_lm_head: bool = False,
+    skip_module_paths: Optional[Set[str]] = None,
+    _prefix: str = "",
+):
     # if level == 0:
     #     log.info("Hooked Modules: Using legacy based config for targeting of modules")
 
@@ -284,8 +290,18 @@ def replace_module_with_hooked_legacy(module, level: int = 0, quant_lm_head: boo
         if not quant_lm_head and hasattr(module, "get_output_embeddings") and child == module.get_output_embeddings():
             continue
 
+        child_path = f"{_prefix}.{name}" if _prefix else name
+        if skip_module_paths and child_path in skip_module_paths:
+            continue
+
         if not _replace_module(module, child, name, level, quant_lm_head):
-            replace_module_with_hooked_legacy(child, level=level+1, quant_lm_head=quant_lm_head)
+            replace_module_with_hooked_legacy(
+                child,
+                level=level + 1,
+                quant_lm_head=quant_lm_head,
+                skip_module_paths=skip_module_paths,
+                _prefix=child_path,
+            )
 
 # deprecated features
 def replace_module_with_hooked_tree(module, tree: Union[List,Dict] = [], level: int = 0, debug: bool = False):

--- a/tests/module_tree/test_subset.py
+++ b/tests/module_tree/test_subset.py
@@ -301,31 +301,6 @@ class _MiniLayer(torch.nn.Module):
         return (x,)
 
 
-class _RouterLinear(torch.nn.Linear):
-    def forward(self, hidden_states):
-        logits = super().forward(hidden_states)
-        return logits, logits.mean(dim=-1, keepdim=True)
-
-
-class _RouterContainer(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.router = _RouterLinear(4, 4)
-
-
-def test_replace_module_with_hooked_legacy_skips_linear_subclass_with_custom_forward():
-    module = _RouterContainer()
-    original_router = module.router
-
-    replace_module_with_hooked_legacy(module)
-
-    assert module.router is original_router
-    logits, aux = module.router(torch.randn(2, 4))
-    assert torch.is_tensor(logits)
-    assert torch.is_tensor(aux)
-    assert aux.shape[-1] == 1
-
-
 def test_stage_subset_early_stop_and_callbacks():
     quant_cfg = _make_quant_config()
     mini_layer = _MiniLayer()

--- a/tests/module_tree/test_subset.py
+++ b/tests/module_tree/test_subset.py
@@ -301,6 +301,31 @@ class _MiniLayer(torch.nn.Module):
         return (x,)
 
 
+class _RouterLinear(torch.nn.Linear):
+    def forward(self, hidden_states):
+        logits = super().forward(hidden_states)
+        return logits, logits.mean(dim=-1, keepdim=True)
+
+
+class _RouterContainer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.router = _RouterLinear(4, 4)
+
+
+def test_replace_module_with_hooked_legacy_skips_linear_subclass_with_custom_forward():
+    module = _RouterContainer()
+    original_router = module.router
+
+    replace_module_with_hooked_legacy(module)
+
+    assert module.router is original_router
+    logits, aux = module.router(torch.randn(2, 4))
+    assert torch.is_tensor(logits)
+    assert torch.is_tensor(aux)
+    assert aux.shape[-1] == 1
+
+
 def test_stage_subset_early_stop_and_callbacks():
     quant_cfg = _make_quant_config()
     mini_layer = _MiniLayer()

--- a/tests/module_tree/test_subset.py
+++ b/tests/module_tree/test_subset.py
@@ -29,7 +29,7 @@ from gptqmodel.looper.stage_subset import build_subset_plan, run_subset_stage
 from gptqmodel.models.definitions.qwen2_moe import Qwen2MoeQModel
 from gptqmodel.models.definitions.qwen3_5_moe import Qwen3_5_MoeQModel
 from gptqmodel.models.definitions.qwen3_moe import Qwen3MoeQModel
-from gptqmodel.nn_modules.hooked_linear import replace_module_with_hooked_legacy
+from gptqmodel.nn_modules.hooked_linear import HookedLinear, replace_module_with_hooked_legacy
 from gptqmodel.quantization import FORMAT, METHOD
 from gptqmodel.quantization.config import QuantizeConfig, VramStrategy
 from gptqmodel.utils.model import find_modules, get_module_by_name_prefix
@@ -299,6 +299,28 @@ class _MiniLayer(torch.nn.Module):
         x = self.self_attn.o_proj(x)
         self.after_o_proj_called = True
         return (x,)
+
+
+class _MiniRouterLayer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.router = torch.nn.Linear(4, 4)
+        self.proj = torch.nn.Linear(4, 4)
+
+    def forward(self, hidden_states, **kwargs):
+        x = self.router(hidden_states)
+        x = self.proj(x)
+        return (x,)
+
+
+def test_replace_module_with_hooked_legacy_skips_not_quantized_paths():
+    layer = _MiniRouterLayer()
+
+    replace_module_with_hooked_legacy(layer, skip_module_paths={"router"})
+
+    assert isinstance(layer.router, torch.nn.Linear)
+    assert not isinstance(layer.router, HookedLinear)
+    assert isinstance(layer.proj, HookedLinear)
 
 
 def test_stage_subset_early_stop_and_callbacks():


### PR DESCRIPTION
```
class Llama4Router(nn.Linear):
    def __init__(self, config):
        super().__init__(config.hidden_size, config.num_local_experts, bias=False)
        self.num_experts = config.num_local_experts
        self.top_k = config.num_experts_per_tok

    def forward(self, hidden_states):
        router_logits = super().forward(hidden_states)
        router_top_value, router_indices = torch.topk(router_logits, self.top_k, dim=1)
        router_scores = torch.full_like(router_logits, float("-inf")).scatter_(1, router_indices, router_top_value)
        router_scores = torch.nn.functional.sigmoid(router_scores.float()).to(router_scores.dtype)
        return router_scores, router_logits
```

Avoid replacing modules like `Llama4Router` with `HookedLinear`, as this will result in an error:

```
    def forward(self, hidden_states):
        hidden_states = hidden_states.reshape(-1, self.hidden_dim)
>       router_scores, router_logits = self.router(hidden_states)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       ValueError: too many values to unpack (expected 2)
```


