### PR TITLE
fix model def tree execution order ground truth

### DIFF
--- a/gptqmodel/looper/forward_executor.py
+++ b/gptqmodel/looper/forward_executor.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 from contextlib import nullcontext
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 import torch
 
@@ -69,6 +69,8 @@ class ForwardExecutor:
         *,
         module: torch.nn.Module,
         processor: "LoopProcessor",
+        current_subset: Optional[Dict[str, Any]],
+        ordered_module_names: Optional[List[str]],
         apply_moe_config: bool,
     ):
         """Pick the MoE routing context for a forward pass."""
@@ -89,7 +91,8 @@ class ForwardExecutor:
             self.looper,
             module,
             processor,
-            self.looper._current_subset,
+            current_subset,
+            ordered_module_names,
         )
 
     def run(
@@ -97,6 +100,8 @@ class ForwardExecutor:
         *,
         module: torch.nn.Module,
         processor: "LoopProcessor",
+        current_subset: Optional[Dict[str, Any]] = None,
+        ordered_module_names: Optional[List[str]] = None,
         layer_inputs: List[List[torch.Tensor]],
         layer_input_kwargs: List[Dict[str, torch.Tensor]],
         position_ids: List[torch.Tensor],
@@ -128,6 +133,8 @@ class ForwardExecutor:
             return self.run_single(
                 module=module,
                 processor=processor,
+                current_subset=current_subset,
+                ordered_module_names=ordered_module_names,
                 layer_inputs=layer_inputs,
                 layer_input_kwargs=layer_input_kwargs,
                 position_ids=position_ids,
@@ -152,6 +159,8 @@ class ForwardExecutor:
             return self.run_single(
                 module=module,
                 processor=processor,
+                current_subset=current_subset,
+                ordered_module_names=ordered_module_names,
                 layer_inputs=layer_inputs,
                 layer_input_kwargs=layer_input_kwargs,
                 position_ids=position_ids,
@@ -174,6 +183,8 @@ class ForwardExecutor:
         return self.run_parallel(
             module=module,
             processor=processor,
+            current_subset=current_subset,
+            ordered_module_names=ordered_module_names,
             layer_inputs=layer_inputs,
             layer_input_kwargs=layer_input_kwargs,
             position_ids=position_ids,
@@ -198,6 +209,8 @@ class ForwardExecutor:
         *,
         module: torch.nn.Module,
         processor: "LoopProcessor",
+        current_subset: Optional[Dict[str, Any]] = None,
+        ordered_module_names: Optional[List[str]] = None,
         layer_inputs: List[List[torch.Tensor]],
         layer_input_kwargs: List[Dict[str, torch.Tensor]],
         position_ids: List[torch.Tensor],
@@ -285,6 +298,8 @@ class ForwardExecutor:
                 with self._moe_forward_context(
                     module=module,
                     processor=processor,
+                    current_subset=current_subset,
+                    ordered_module_names=ordered_module_names,
                     apply_moe_config=apply_moe_config,
                 ):
                     module_output = None
@@ -345,6 +360,8 @@ class ForwardExecutor:
         *,
         module: torch.nn.Module,
         processor: "LoopProcessor",
+        current_subset: Optional[Dict[str, Any]] = None,
+        ordered_module_names: Optional[List[str]] = None,
         layer_inputs: List[List[torch.Tensor]],
         layer_input_kwargs: List[Dict[str, torch.Tensor]],
         position_ids: List[torch.Tensor],
@@ -435,6 +452,8 @@ class ForwardExecutor:
                 ctx = self._moe_forward_context(
                     module=replica,
                     processor=processor,
+                    current_subset=current_subset,
+                    ordered_module_names=ordered_module_names,
                     apply_moe_config=apply_moe_config,
                 )
 

--- a/gptqmodel/looper/module_looper.py
+++ b/gptqmodel/looper/module_looper.py
@@ -410,13 +410,14 @@ class ModuleLooper():
     class MoELifecycleContext:
         """Context manager for MoE lifecycle hooks integration."""
 
-        def __init__(self, module_looper, module, processor, current_subset):
+        def __init__(self, module_looper, module, processor, current_subset, ordered_module_names):
             """Capture the replica state needed to patch the MoE block."""
 
             self.module_looper = module_looper
             self.module = module
             self.processor = processor
             self.current_subset = current_subset
+            self.ordered_module_names = ordered_module_names
             self.moe_hooks_active = False
             self.moe_block = None
             self.moe_forward_original = None
@@ -442,6 +443,7 @@ class ModuleLooper():
                             hidden_states=hidden_states,
                             processor=self.processor,
                             subset=self.current_subset,
+                            ordered_module_names=self.ordered_module_names,
                             original_forward=self.moe_forward_original,
                             model_class=self.module_looper.gptq_model.__class__,
                             module_looper=self.module_looper,  # Pass for TLS-based hooks pausing
@@ -1117,6 +1119,8 @@ class ModuleLooper():
         *,
         module: torch.nn.Module,
         processor: LoopProcessor,
+        current_subset: Optional[Dict[str, Any]] = None,
+        ordered_module_names: Optional[List[str]] = None,
         layer_inputs: List[List[torch.Tensor]],
         layer_input_kwargs: List[Dict[str, torch.Tensor]],
         position_ids: List[torch.Tensor],
@@ -1141,6 +1145,8 @@ class ModuleLooper():
         return self._forward_executor.run(
             module=module,
             processor=processor,
+            current_subset=current_subset,
+            ordered_module_names=ordered_module_names,
             layer_inputs=layer_inputs,
             layer_input_kwargs=layer_input_kwargs,
             position_ids=position_ids,

--- a/gptqmodel/looper/stage_subset.py
+++ b/gptqmodel/looper/stage_subset.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import logging
 import os
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Callable, Dict, List, Literal, Optional, Tuple
 
 import pcre
@@ -93,7 +93,14 @@ class SubsetPlan:
     forward_device_map: Dict[str, torch.device]
     calibration_coverage_policy: CalibrationCoveragePolicy
     module_chunks: List[Dict[str, NamedModule]]
+    ordered_module_names: List[str] = field(default_factory=list)
     restore_forward_device_overrides: bool = True
+
+    def __post_init__(self) -> None:
+        """Freeze an explicit ordered module list for forward replay decisions."""
+
+        if not self.ordered_module_names:
+            self.ordered_module_names = list(self.modules.keys())
 
     @property
     def subset_forward_serial(self) -> bool:
@@ -122,7 +129,13 @@ class SubsetPlan:
     def for_modules(self, modules: Dict[str, NamedModule]) -> "SubsetPlan":
         """Reuse the same execution policy for one chunk or replay-only subset."""
 
-        return replace(self, modules=modules, module_chunks=[modules])
+        ordered_names = [name for name in self.ordered_module_names if name in modules]
+        return replace(
+            self,
+            modules=modules,
+            ordered_module_names=ordered_names,
+            module_chunks=[modules],
+        )
 
 
 @dataclass
@@ -516,6 +529,7 @@ def build_subset_plan(
 
     return SubsetPlan(
         modules=subset,
+        ordered_module_names=list(subset.keys()),
         subset_index=subset_index,
         subset_total=subset_total,
         execute_forward=execute_forward,
@@ -686,6 +700,7 @@ def _run_single_subset_pass(
     # Pull frequently used plan fields into locals so the execution flow below
     # reads linearly without re-deriving policy from processor state.
     subset = plan.modules
+    subset_names = plan.ordered_module_names or list(subset.keys())
     subset_index = plan.subset_index
     subset_total = plan.subset_total
     execution_config = processor.execution_config
@@ -696,7 +711,7 @@ def _run_single_subset_pass(
     execute_forward = plan.execute_forward if execute_forward is None else execute_forward
 
     handle = []
-    subset_size = len(subset)
+    subset_size = len(subset_names)
 
     if execute_forward:
         for named_module in subset.values():
@@ -720,7 +735,8 @@ def _run_single_subset_pass(
                         break
 
     if execute_forward:
-        for idx, (name, m) in enumerate(subset.items()):
+        for idx, name in enumerate(subset_names):
+            m = subset[name]
             # Register the forward hook that captures activations for quantization.
             # The final module optionally flips a flag so processors can trigger
             # once-per-subset logic after the forward pass.
@@ -788,7 +804,7 @@ def _run_single_subset_pass(
     forward_source = f"{layer_descriptor}:subset{subset_index + 1}/{subset_total}"
     if execute_forward:
         if subset_event_cb:
-            subset_event_cb(stage="forward_start", layer_idx=layer_index, subset_index=subset_index, subset_total=subset_total, module_names=list(subset.keys()), processor=getattr(processor, "name", type(processor).__name__))
+            subset_event_cb(stage="forward_start", layer_idx=layer_index, subset_index=subset_index, subset_total=subset_total, module_names=subset_names, processor=getattr(processor, "name", type(processor).__name__))
 
         fwd_start = time.perf_counter()
         reuse_kv = bool(getattr(module, "reuse_kv", False))
@@ -827,6 +843,8 @@ def _run_single_subset_pass(
             forward_outputs = looper._run_forward_batches(
                 module=module,
                 processor=processor,
+                current_subset=None if disable_moe_hooks else subset,
+                ordered_module_names=subset_names,
                 layer_inputs=layer_inputs,
                 layer_input_kwargs=layer_input_kwargs,
                 position_ids=position_ids,
@@ -875,7 +893,7 @@ def _run_single_subset_pass(
         del forward_outputs
 
     if execute_forward and subset_event_cb:
-        subset_event_cb(stage="forward_end", layer_idx=layer_index, subset_index=subset_index, subset_total=subset_total, module_names=list(subset.keys()), processor=getattr(processor, "name", type(processor).__name__))
+        subset_event_cb(stage="forward_end", layer_idx=layer_index, subset_index=subset_index, subset_total=subset_total, module_names=subset_names, processor=getattr(processor, "name", type(processor).__name__))
 
     fwd_time = (time.perf_counter() - fwd_start) if fwd_start is not None else 0.0
     processor.set_fwd_time(fwd_time)
@@ -891,7 +909,7 @@ def _run_single_subset_pass(
         h.remove()
 
     if execute_forward:
-        for name in subset:
+        for name in subset_names:
             # Reset inline hook attributes on NamedModule wrappers so future passes
             # do not reuse state from this subset run.
             if hasattr(subset[name], 'forward_hook'):
@@ -906,7 +924,7 @@ def _run_single_subset_pass(
         # Coverage validation is a policy decision captured by the plan.
         # The executor only applies that policy; it does not decide when the
         # processor should tolerate or prune never-invoked modules.
-        for name in subset:
+        for name in subset_names:
             # Skip MoE experts that never fired; they likely lacked calibration
             # traffic and would produce invalid statistics.
             if not processor.has_captured_input_ids(name):
@@ -935,7 +953,9 @@ def _run_single_subset_pass(
                     ] = {}
 
     quant_target_devices: Dict[str, torch.device] = {}
-    for name, named_module in subset.items():
+    active_subset_names = [name for name in subset_names if name in subset]
+    for name in active_subset_names:
+        named_module = subset[name]
         # Ensure each module has a matching processor task before sending it to
         # the worker pool; otherwise freeze it on the current device.
         task_map = getattr(processor, "tasks", None)
@@ -962,7 +982,7 @@ def _run_single_subset_pass(
     futures = []
 
     if subset_event_cb:
-        subset_event_cb(stage="quant_start", layer_idx=layer_index, subset_index=subset_index, subset_total=subset_total, module_names=list(subset.keys()), processor=getattr(processor, "name", type(processor).__name__))
+        subset_event_cb(stage="quant_start", layer_idx=layer_index, subset_index=subset_index, subset_total=subset_total, module_names=active_subset_names, processor=getattr(processor, "name", type(processor).__name__))
 
 
     @torch.inference_mode()
@@ -1029,7 +1049,8 @@ def _run_single_subset_pass(
                 )
         return nm.name, nm
 
-    for name, named_module in subset.items():
+    for name in active_subset_names:
+        named_module = subset[name]
         # Launch processing for every module in the subset; tasks may run in
         # parallel as allowed by the device thread pool.
         tgt_dev = quant_target_devices.get(name, cur_layer_device)
@@ -1068,7 +1089,7 @@ def _run_single_subset_pass(
         torch_sync()
 
     if subset_event_cb:
-        subset_event_cb(stage="quant_complete", layer_idx=layer_index, subset_index=subset_index, subset_total=subset_total, module_names=list(subset.keys()), processor=getattr(processor, "name", type(processor).__name__))
+        subset_event_cb(stage="quant_complete", layer_idx=layer_index, subset_index=subset_index, subset_total=subset_total, module_names=active_subset_names, processor=getattr(processor, "name", type(processor).__name__))
 
     used_data_parallel = False
     if execute_forward and forward_flush_device is None:
@@ -1126,7 +1147,7 @@ def run_subset_stage(
             layer_idx=layer_index,
             subset_index=plan.subset_index,
             subset_total=plan.subset_total,
-            module_names=list(plan.modules.keys()),
+            module_names=plan.ordered_module_names,
             processor=processor_name,
         )
 
@@ -1138,7 +1159,7 @@ def run_subset_stage(
                 plan.subset_index + 1,
                 plan.subset_total,
                 len(plan.modules),
-                list(plan.modules.keys())[:8],
+                plan.ordered_module_names[:8],
             )
         else:
             logger.debug(
@@ -1148,7 +1169,7 @@ def run_subset_stage(
                 plan.subset_total,
                 processor_name,
                 len(plan.modules),
-                list(plan.modules.keys())[:8],
+                plan.ordered_module_names[:8],
             )
     processed_results = {}
 

--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -565,16 +565,38 @@ class BaseQModel(nn.Module):
                     continue
 
                 if is_awq_quantize:
-                    # AWQ Required
-                    # result like: ['mlp.experts.0.gate_proj', 'mlp.experts.0.up_proj', 'mlp.experts.1.gate_proj', 'mlp.experts.1.up_proj', ...]
-                    for index in range(num_experts):
-                        for n in names:
-                            if EXPERT_INDEX_PLACEHOLDER in n:
-                                moe_simple[-1].append(n.replace(EXPERT_INDEX_PLACEHOLDER, str(index)))
-                    # added 'mlp.shared_expert.gate_proj', 'mlp.shared_expert.up_proj'
+                    # AWQ expands expert placeholders into concrete expert paths while
+                    # preserving the non-expert segments exactly where the model
+                    # definition placed them. This keeps the expanded block aligned
+                    # with forward execution order instead of forcing shared-expert
+                    # modules to the tail of every mixed MoE block.
+                    segments = []
+                    current_segment = []
+                    current_is_expert_segment = None
                     for n in names:
-                        if EXPERT_INDEX_PLACEHOLDER not in n:
-                            moe_simple[-1].append(n)
+                        is_expert_entry = EXPERT_INDEX_PLACEHOLDER in n
+                        if current_is_expert_segment is None:
+                            current_is_expert_segment = is_expert_entry
+                        if is_expert_entry != current_is_expert_segment:
+                            segments.append((current_is_expert_segment, current_segment))
+                            current_segment = []
+                            current_is_expert_segment = is_expert_entry
+                        current_segment.append(n)
+
+                    if current_segment:
+                        segments.append((current_is_expert_segment, current_segment))
+
+                    # Example:
+                    # ['shared_expert.gate_proj', 'shared_expert.up_proj', 'experts.#.gate_proj', 'experts.#.up_proj']
+                    # becomes
+                    # ['shared_expert.gate_proj', 'shared_expert.up_proj', 'experts.0.gate_proj', 'experts.0.up_proj', ...]
+                    for is_expert_segment, segment_names in segments:
+                        if not is_expert_segment:
+                            moe_simple[-1].extend(segment_names)
+                            continue
+                        for index in range(num_experts):
+                            for n in segment_names:
+                                moe_simple[-1].append(n.replace(EXPERT_INDEX_PLACEHOLDER, str(index)))
                     # Currently, only need to add `capture_only_modules` to `['mlp.experts.#.gate_proj', 'mlp.experts.#.up_proj']`
                     # or ['mlp.shared_expert.gate_proj', 'mlp.shared_expert.up_proj', 'mlp.experts.#.gate_proj', 'mlp.experts.#.up_proj']
                     # or ['mlp.shared_experts.gate_proj', 'mlp.shared_experts.up_proj', 'mlp.experts.#.gate_proj', 'mlp.experts.#.up_proj']
@@ -2362,9 +2384,10 @@ class BaseQModel(nn.Module):
 
             # Update tracker to the LAST item of this block
             if is_moe_gate_up_block:
-                # The block content is [...,  mlp.experts.{last_index}.up_proj, shared_expert.gate_proj, shared_expert.up_proj, mlp]
-                # mlp.experts.{last_index}.up_proj should be selected as last_module
-                # Find all indices that contain both ".experts" and "gate_proj"/"up_proj"
+                # Mixed MoE blocks can legitimately place shared-expert projections
+                # before or after routed experts depending on real forward order.
+                # For AWQ scaling, we still want the last routed expert gate/up proj
+                # as the effective boundary for the expert segment in this block.
                 gate_up_proj_indices = [
                     i for i, name in enumerate(block)
                     if any(k in name for k in self.moe_expert_module_name_prefixes) and ("gate" in name or "up" in name)

--- a/gptqmodel/models/definitions/qwen3_5_moe.py
+++ b/gptqmodel/models/definitions/qwen3_5_moe.py
@@ -35,7 +35,6 @@ class Qwen3_5_MoeQModel(BaseQModel):
     # MoE lifecycle hooks for gate_proj/up_proj/down_proj pattern
     moe_lifecycle_hooks = GateUpDownMoELifecycleHooks()
 
-
     module_tree = [
         "model",
         "language_model",
@@ -57,10 +56,15 @@ class Qwen3_5_MoeQModel(BaseQModel):
             "mlp:moe:?": {
                 "gate": ("gate:!",),  # <-- 0.5MB per layer. Not worth quantizing
                 "shared_expert_gate": ("shared_expert_gate:!",),
+                # Qwen 3.5/3.6 executes the shared expert path before routed experts
+                # in modeling_qwen3_5_moe.py, so keep the module tree aligned with
+                # real forward order. The previous reversed order hid a tree-vs-
+                # execution mismatch until subset early-stop started relying on the
+                # final module in the merged block.
+                "shared_expert:0": ("gate_proj:0", "up_proj:0", "down_proj:1"),
                 "experts:0": {
                     "#": ("gate_proj:0", "up_proj:0", "down_proj:1"),
                 },
-                "shared_expert:0": ("gate_proj:0", "up_proj:0", "down_proj:1"),
             },
         }
     ]

--- a/gptqmodel/models/moe_lifecycle.py
+++ b/gptqmodel/models/moe_lifecycle.py
@@ -192,27 +192,28 @@ class MoELifecycleHooks:
 
     def get_subset_execution_order(
             self,
-            subset: Dict[str, Any],
+            ordered_module_names: list[str],
             moe_block_prefix: Optional[str],
             experts_attr_name: Optional[str],
             shared_expert_attr_name: Optional[str],
     ) -> list[str]:
         """
-        Infer shared-expert vs routed-expert replay order from the subset keys.
+        Infer shared-expert vs routed-expert replay order from explicit subset names.
 
         The module tree is designed to mirror forward execution order, and
-        subset dictionaries preserve that order from `simple_layer_modules()`.
+        subset planning preserves that ordered module list explicitly.
         Replay should therefore follow the first occurrence of each MoE family
-        in the subset instead of relying on model-specific hardcoded ordering.
+        in `ordered_module_names` instead of relying on dict iteration or
+        model-specific hardcoded ordering.
         """
-        if not subset or moe_block_prefix is None:
+        if not ordered_module_names or moe_block_prefix is None:
             return []
 
         order = []
         expert_prefix = f"{moe_block_prefix}.{experts_attr_name}." if experts_attr_name else None
         shared_prefix = f"{moe_block_prefix}.{shared_expert_attr_name}." if shared_expert_attr_name else None
 
-        for key in subset.keys():
+        for key in ordered_module_names:
             if shared_prefix and key.startswith(shared_prefix):
                 if "shared" not in order:
                     order.append("shared")
@@ -229,6 +230,7 @@ class MoELifecycleHooks:
             hidden_states: torch.Tensor,
             processor: Any,
             subset: Dict[str, Any],
+            ordered_module_names: Optional[list[str]],
             original_forward: callable,
             model_class: type,
             module_looper: Any,
@@ -335,6 +337,7 @@ class ExpertProjectionMoELifecycleHooks(MoELifecycleHooks):
             hidden_states: torch.Tensor,
             processor: Any,
             subset: Dict[str, Any],
+            ordered_module_names: Optional[list[str]],
             original_forward: callable,
             model_class: type,
             module_looper: Any,  # Required for TLS-based hooks pausing
@@ -501,7 +504,7 @@ class ExpertProjectionMoELifecycleHooks(MoELifecycleHooks):
                     del expert_input
 
         execution_order = self.get_subset_execution_order(
-            subset=subset,
+            ordered_module_names=ordered_module_names or [],
             moe_block_prefix=moe_block_prefix,
             experts_attr_name=experts_attr_name,
             shared_expert_attr_name=shared_expert_attr_name,

--- a/gptqmodel/models/moe_lifecycle.py
+++ b/gptqmodel/models/moe_lifecycle.py
@@ -190,6 +190,39 @@ class MoELifecycleHooks:
         # This is normal - not all MoE models have shared experts
         return None
 
+    def get_subset_execution_order(
+            self,
+            subset: Dict[str, Any],
+            moe_block_prefix: Optional[str],
+            experts_attr_name: Optional[str],
+            shared_expert_attr_name: Optional[str],
+    ) -> list[str]:
+        """
+        Infer shared-expert vs routed-expert replay order from the subset keys.
+
+        The module tree is designed to mirror forward execution order, and
+        subset dictionaries preserve that order from `simple_layer_modules()`.
+        Replay should therefore follow the first occurrence of each MoE family
+        in the subset instead of relying on model-specific hardcoded ordering.
+        """
+        if not subset or moe_block_prefix is None:
+            return []
+
+        order = []
+        expert_prefix = f"{moe_block_prefix}.{experts_attr_name}." if experts_attr_name else None
+        shared_prefix = f"{moe_block_prefix}.{shared_expert_attr_name}." if shared_expert_attr_name else None
+
+        for key in subset.keys():
+            if shared_prefix and key.startswith(shared_prefix):
+                if "shared" not in order:
+                    order.append("shared")
+                continue
+            if expert_prefix and key.startswith(expert_prefix):
+                if "experts" not in order:
+                    order.append("experts")
+
+        return order
+
     def forward_to_all_experts(
             self,
             moe_block: nn.Module,
@@ -325,10 +358,9 @@ class ExpertProjectionMoELifecycleHooks(MoELifecycleHooks):
                            is on a different device than the original modules in subset.
             **kwargs: Additional arguments (attention_mask, etc.)
 
-        This implementation:
-        1. Forwards to shared_experts (if present and in subset)
-        2. Forwards to all individual experts (only those with modules in subset)
-        3. Returns normal routed forward output (not averaged)
+        This implementation replays shared-expert and routed-expert paths in the
+        order they appear in the subset/module tree, then calls the original
+        routed forward for the final output.
         """
         import torch.nn.functional as F
 
@@ -402,83 +434,57 @@ class ExpertProjectionMoELifecycleHooks(MoELifecycleHooks):
                         has_expert_projs = True
                         break
 
-        # Forward to shared experts if they exist AND if any of their modules are in subset
-        # Simply call the shared expert module's forward - hooks will fire for projections in subset
-        if has_shared_experts and shared_expert_attr_name:
+        def run_shared_experts():
+            nonlocal expert_count, stop_forward_raised
+            if not has_shared_experts or not shared_expert_attr_name:
+                return
             try:
-                # Get the shared expert module and call its forward
                 shared_expert_module = getattr(moe_block, shared_expert_attr_name)
-                # Ensure input is on correct device
                 shared_expert_device = get_device(shared_expert_module)
                 shared_expert_module(move_to(hidden_states, shared_expert_device))
                 expert_count += 1
             except StopForward:
                 stop_forward_raised = True
 
-        # Forward to all individual experts
-        if has_expert_projs and experts_module is not None and hasattr(experts_module,
-                                                                       '__iter__') and experts_attr_name:
-            # Reshape hidden_states from [B, S, H] to [B*S, H] for expert modules
+        def run_routed_experts():
+            nonlocal expert_count, stop_forward_raised
+            if not has_expert_projs or experts_module is None or not hasattr(experts_module, '__iter__') or not experts_attr_name:
+                return
+
             if hidden_states.dim() == 3:
                 hidden_states_2d = hidden_states.reshape(-1, hidden_states.shape[-1])
             else:
                 hidden_states_2d = hidden_states
 
             for expert_idx, expert in enumerate(experts_module):
-                # Construct keys for this expert's projections using the detected attribute name
                 gate_key = f"{moe_block_prefix}.{experts_attr_name}.{expert_idx}.{self.gate_proj_name}"
                 up_key = f"{moe_block_prefix}.{experts_attr_name}.{expert_idx}.{self.up_proj_name}"
                 down_key = f"{moe_block_prefix}.{experts_attr_name}.{expert_idx}.{self.down_proj_name}"
 
-                # Skip if none of this expert's projections are in subset
                 if gate_key not in subset and up_key not in subset and down_key not in subset:
                     continue
 
-                # Determine device for this expert
-                # Use gate_proj as reference since it's typically present
-                expert_device = None
                 gate_module_ref = getattr(expert, self.gate_proj_name, None)
-                if gate_module_ref is not None:
-                    expert_device = get_device(gate_module_ref)
-                else:
-                    expert_device = get_device(expert)
-
-                # Move input to expert device
+                expert_device = get_device(gate_module_ref) if gate_module_ref is not None else get_device(expert)
                 expert_input = move_to(hidden_states_2d, expert_device)
 
                 try:
-                    # Strategy: If down_proj is in subset, compute intermediate on-the-fly
-                    # Note: When down is in subset, gate/up are NOT in subset (separate subset groups)
-                    # We need to compute gate/up outputs to create the intermediate for down
                     if down_key in subset:
-                        # Get gate/up modules directly from expert via getattr
-                        # This returns the UNWRAPPED modules (not NamedModule wrappers)
-                        # Hooks are only registered on NamedModule wrappers in subset,
-                        # so calling unwrapped modules means NO hooks fire automatically.
                         gate_module = getattr(expert, self.gate_proj_name)
                         up_module = getattr(expert, self.up_proj_name)
-
-                        # Compute intermediate (no hooks fire since modules are unwrapped)
-                        # Ensure modules are called with input on correct device
-                        # gate_module/up_module are submodules of expert, so they are on expert_device
                         gate_out = gate_module(expert_input)
                         up_out = up_module(expert_input)
 
-                        # Compute intermediate using expert's activation function
                         if hasattr(expert, 'act_fn'):
                             intermediate = expert.act_fn(gate_out) * up_out
                         else:
                             intermediate = F.silu(gate_out) * up_out
                         del gate_out, up_out
 
-                        # Call down_proj via wrapper (or replica module) with hooks enabled for activation collection
-                        # Module returned by get_callable_module IS on expert_device (if replica is correct)
-                        # Intermediate is on expert_device
                         get_callable_module(down_key)(intermediate)
                         del intermediate
                         expert_count += 1
                     else:
-                        # For gate_proj/up_proj in subset, just call them directly via wrappers (or replica modules)
                         called_any = False
                         if gate_key in subset:
                             get_callable_module(gate_key)(expert_input)
@@ -492,8 +498,24 @@ class ExpertProjectionMoELifecycleHooks(MoELifecycleHooks):
                 except StopForward:
                     stop_forward_raised = True
                 finally:
-                    # Promptly release tensor copy to free VRAM
                     del expert_input
+
+        execution_order = self.get_subset_execution_order(
+            subset=subset,
+            moe_block_prefix=moe_block_prefix,
+            experts_attr_name=experts_attr_name,
+            shared_expert_attr_name=shared_expert_attr_name,
+        )
+        if has_shared_experts and "shared" not in execution_order:
+            execution_order.append("shared")
+        if has_expert_projs and "experts" not in execution_order:
+            execution_order.append("experts")
+
+        for group_name in execution_order:
+            if group_name == "shared":
+                run_shared_experts()
+            elif group_name == "experts":
+                run_routed_experts()
 
         if stop_forward_raised:
             # Re-raise StopForward if it was caught

--- a/tests/module_tree/test_subset.py
+++ b/tests/module_tree/test_subset.py
@@ -10,9 +10,13 @@ from types import SimpleNamespace
 from typing import Callable, Dict, List, Optional
 
 import torch
+from defuser import convert_model
 from transformers import Qwen3MoeConfig, Qwen3MoeForCausalLM
+from transformers.models.qwen3_5_moe.configuration_qwen3_5_moe import Qwen3_5MoeTextConfig
+from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import Qwen3_5MoeForCausalLM
 from transformers.models.qwen3_moe.modeling_qwen3_moe import Qwen3MoeSparseMoeBlock
 
+from gptqmodel.models._const import EXPERT_INDEX_PLACEHOLDER
 from gptqmodel.models import BaseQModel
 
 
@@ -26,6 +30,7 @@ from gptqmodel.looper.loop_processor import ExecutionConfig, LoopProcessor
 from gptqmodel.looper.module_looper import ModuleLooper
 from gptqmodel.looper.named_module import NamedModule
 from gptqmodel.looper.stage_subset import build_subset_plan, run_subset_stage
+from gptqmodel.models.moe_lifecycle import GateUpDownMoELifecycleHooks
 from gptqmodel.models.definitions.qwen2_moe import Qwen2MoeQModel
 from gptqmodel.models.definitions.qwen3_5_moe import Qwen3_5_MoeQModel
 from gptqmodel.models.definitions.qwen3_moe import Qwen3MoeQModel
@@ -112,18 +117,94 @@ def test_qwen2_moe_shared_expert_merges_with_experts():
     assert len(expert_gate_blocks) == 1
 
 
+def test_qwen2_moe_awq_expansion_keeps_shared_expert_before_experts():
+    blocks = Qwen2MoeQModel.simple_layer_modules(
+        model_config=SimpleNamespace(num_experts=2),
+        quantize_config=SimpleNamespace(dynamic=None),
+        is_awq_quantize=True,
+    )
+
+    gate_block = next(block for block in blocks if "mlp.shared_expert.gate_proj" in block)
+    assert gate_block == [
+        "mlp.shared_expert.gate_proj",
+        "mlp.shared_expert.up_proj",
+        "mlp.experts.0.gate_proj",
+        "mlp.experts.0.up_proj",
+        "mlp.experts.1.gate_proj",
+        "mlp.experts.1.up_proj",
+    ]
+
+
 def test_qwen3_5_moe_shared_expert_merges_with_experts():
     blocks = Qwen3_5_MoeQModel.build_layer_modules(Qwen3_5_MoeQModel.module_tree)
-    print("blocks",blocks)
+
     gate_block = next(block for block in blocks if "mlp.shared_expert.gate_proj" in block)
+    assert gate_block.index("mlp.shared_expert.gate_proj") < gate_block.index("mlp.experts.{expert_index}.gate_proj")
+    assert gate_block.index("mlp.shared_expert.up_proj") < gate_block.index("mlp.experts.{expert_index}.up_proj")
     assert "mlp.experts.{expert_index}.gate_proj" in gate_block
     assert "mlp.experts.{expert_index}.up_proj" in gate_block
 
     down_block = next(block for block in blocks if "mlp.shared_expert.down_proj" in block)
+    assert down_block.index("mlp.shared_expert.down_proj") < down_block.index("mlp.experts.{expert_index}.down_proj")
     assert "mlp.experts.{expert_index}.down_proj" in down_block
 
     expert_gate_blocks = [block for block in blocks if "mlp.experts.{expert_index}.gate_proj" in block]
     assert len(expert_gate_blocks) == 1
+
+
+def test_awq_moe_expansion_preserves_non_expert_segments():
+    class _MockOrderedMoEModel(BaseQModel):
+        dynamic_expert_index = "num_experts"
+
+    expanded = _MockOrderedMoEModel.build_moe_modules_if_need(
+        SimpleNamespace(num_experts=2),
+        [[
+            "mlp.shared_expert.gate_proj",
+            "mlp.shared_expert.up_proj",
+            f"mlp.experts.{EXPERT_INDEX_PLACEHOLDER}.gate_proj",
+            f"mlp.experts.{EXPERT_INDEX_PLACEHOLDER}.up_proj",
+            "mlp.shared_expert.down_proj",
+        ]],
+        is_awq_quantize=True,
+    )
+
+    assert expanded == [[
+        "mlp.shared_expert.gate_proj",
+        "mlp.shared_expert.up_proj",
+        "mlp.experts.0.gate_proj",
+        "mlp.experts.0.up_proj",
+        "mlp.experts.1.gate_proj",
+        "mlp.experts.1.up_proj",
+        "mlp.shared_expert.down_proj",
+    ]]
+
+
+def test_moe_lifecycle_execution_order_follows_subset_key_order():
+    hooks = GateUpDownMoELifecycleHooks()
+
+    shared_first = hooks.get_subset_execution_order(
+        subset={
+            "mlp.shared_expert.gate_proj": object(),
+            "mlp.shared_expert.up_proj": object(),
+            "mlp.experts.0.gate_proj": object(),
+        },
+        moe_block_prefix="mlp",
+        experts_attr_name="experts",
+        shared_expert_attr_name="shared_expert",
+    )
+    assert shared_first == ["shared", "experts"]
+
+    experts_first = hooks.get_subset_execution_order(
+        subset={
+            "mlp.experts.0.gate_proj": object(),
+            "mlp.experts.0.up_proj": object(),
+            "mlp.shared_expert.gate_proj": object(),
+        },
+        moe_block_prefix="mlp",
+        experts_attr_name="experts",
+        shared_expert_attr_name="shared_expert",
+    )
+    assert experts_first == ["experts", "shared"]
 
 
 def test_awq_processor_enables_subset_early_stop():
@@ -414,3 +495,131 @@ def test_stage_subset_early_stop_and_callbacks():
     assert processor.hook_calls and processor.hook_calls[-1] == subset_names[-1]
     assert set(processor.process_calls) == set(subset_names)
     assert len(processor.process_calls) == len(subset_names)
+
+
+def test_qwen3_5_moe_subset_early_stop_follows_module_tree_execution_order():
+    """Regression for Qwen 3.5/3.6 shared-expert ordering inside merged MoE subsets."""
+
+    cfg = Qwen3_5MoeTextConfig(
+        hidden_size=64,
+        intermediate_size=128,
+        moe_intermediate_size=32,
+        shared_expert_intermediate_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        num_experts=4,
+        num_experts_per_tok=2,
+        vocab_size=128,
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+    )
+    model = Qwen3_5MoeForCausalLM(cfg)
+    convert_model(model, cleanup_original=False)
+    layer = model.model.layers[0]
+    replace_module_with_hooked_legacy(layer)
+
+    quant_cfg = _make_quant_config()
+
+    class _DummyQwen3_5Model:
+        moe_lifecycle_hooks = Qwen3_5_MoeQModel.moe_lifecycle_hooks
+        layer_modules_strict = True
+        lm_head = "lm_head"
+        supported_dense_vram_strategies = [VramStrategy.EXCLUSIVE, VramStrategy.BALANCED]
+
+        def __init__(self, qcfg: QuantizeConfig):
+            self.support_batch_quantize = False
+            self.quantize_config = qcfg
+            self.layer_callback = None
+            self.subset_callback = None
+
+        @classmethod
+        def get_moe_module_name(cls):
+            return Qwen3_5_MoeQModel.get_moe_module_name()
+
+        def shell_module_materialize(self, target_submodule, device, role=None, named_module=None):
+            return target_submodule
+
+        def prepare_layer_replay_kwargs(self, layer, layer_input, additional_inputs, target_device):
+            del layer, target_device
+            hidden_states = layer_input[0]
+            position_ids = additional_inputs.get("position_ids")
+            if position_ids is None:
+                position_ids = torch.arange(hidden_states.shape[1], device=hidden_states.device).unsqueeze(0)
+                additional_inputs["position_ids"] = position_ids
+            additional_inputs["position_embeddings"] = model.model.rotary_emb(hidden_states, position_ids)
+            return additional_inputs
+
+    processor = _StubAWQProcessor(quant_cfg)
+    looper = ModuleLooper(model=_DummyQwen3_5Model(quant_cfg), processors=[processor])
+
+    subset_names = next(
+        block
+        for block in Qwen3_5_MoeQModel.simple_layer_modules(
+            model_config=cfg,
+            quantize_config=SimpleNamespace(dynamic=None),
+            is_awq_quantize=True,
+        )
+        if "mlp.shared_expert.gate_proj" in block
+    )
+    assert subset_names[:2] == [
+        "mlp.shared_expert.gate_proj",
+        "mlp.shared_expert.up_proj",
+    ]
+    assert subset_names[-1] == "mlp.experts.3.up_proj"
+
+    layer_inputs = [[torch.randn(1, 4, cfg.hidden_size)]]
+    full_modules = find_modules(layer)
+    subset = looper.create_named_modules(
+        module=layer,
+        full=full_modules,
+        is_lm_head_module=False,
+        layer_index=0,
+        layers_prefix="layers",
+        names=subset_names,
+        processor=processor,
+        fallback=False,
+        layer_module=layer,
+    )
+    subset_plan = build_subset_plan(
+        looper,
+        processor=processor,
+        subset=subset,
+        subset_index=0,
+        subset_total=1,
+        full=full_modules,
+        fallback=False,
+        layer_inputs=layer_inputs,
+    )
+
+    run_subset_stage(
+        looper=looper,
+        plan=subset_plan,
+        processor=processor,
+        module=layer,
+        layer_inputs=layer_inputs,
+        layer_input_kwargs=[{}],
+        position_ids=[None],
+        attention_masks=[None],
+        cur_layer_device=torch.device("cpu"),
+        is_lm_head_module=False,
+        layer_descriptor="layers.0",
+        layer_title="subset-check",
+        layer_index=0,
+        full=full_modules,
+        fallback=False,
+        shared_kv_cache_dict={},
+        pb=_DummyProgress(),
+        log=None,
+        region_timer=None,
+        previous_processed_subset=None,
+        subset_event_cb=None,
+    )
+
+    assert processor.hook_calls[:2] == [
+        "mlp.shared_expert.gate_proj",
+        "mlp.shared_expert.up_proj",
+    ]
+    assert any(name.startswith("mlp.experts.") for name in processor.hook_calls)
+    assert processor.hook_calls[-1] == "mlp.experts.3.up_proj"

--- a/tests/module_tree/test_subset.py
+++ b/tests/module_tree/test_subset.py
@@ -179,15 +179,15 @@ def test_awq_moe_expansion_preserves_non_expert_segments():
     ]]
 
 
-def test_moe_lifecycle_execution_order_follows_subset_key_order():
+def test_moe_lifecycle_execution_order_follows_ordered_module_names():
     hooks = GateUpDownMoELifecycleHooks()
 
     shared_first = hooks.get_subset_execution_order(
-        subset={
-            "mlp.shared_expert.gate_proj": object(),
-            "mlp.shared_expert.up_proj": object(),
-            "mlp.experts.0.gate_proj": object(),
-        },
+        ordered_module_names=[
+            "mlp.shared_expert.gate_proj",
+            "mlp.shared_expert.up_proj",
+            "mlp.experts.0.gate_proj",
+        ],
         moe_block_prefix="mlp",
         experts_attr_name="experts",
         shared_expert_attr_name="shared_expert",
@@ -195,11 +195,11 @@ def test_moe_lifecycle_execution_order_follows_subset_key_order():
     assert shared_first == ["shared", "experts"]
 
     experts_first = hooks.get_subset_execution_order(
-        subset={
-            "mlp.experts.0.gate_proj": object(),
-            "mlp.experts.0.up_proj": object(),
-            "mlp.shared_expert.gate_proj": object(),
-        },
+        ordered_module_names=[
+            "mlp.experts.0.gate_proj",
+            "mlp.experts.0.up_proj",
+            "mlp.shared_expert.gate_proj",
+        ],
         moe_block_prefix="mlp",
         experts_attr_name="experts",
         shared_expert_attr_name="shared_expert",

--- a/tests/test_subset_plan.py
+++ b/tests/test_subset_plan.py
@@ -6,7 +6,7 @@ import torch
 
 from gptqmodel.looper.loop_processor import ExecutionConfig
 from gptqmodel.looper.named_module import NamedModule
-from gptqmodel.looper.stage_subset import build_layer_subset_plans, build_subset_plan
+from gptqmodel.looper.stage_subset import SubsetPlan, build_layer_subset_plans, build_subset_plan
 from gptqmodel.quantization.config import VramStrategy
 
 
@@ -82,6 +82,54 @@ def test_build_subset_plan_skips_forward_for_no_forward_processor():
     assert plan.forward_mode == "parallel"
     assert plan.module_chunks == [subset]
     assert plan.calibration_coverage_policy.validate_input_coverage is False
+
+
+def test_subset_plan_for_modules_preserves_parent_ordered_module_names():
+    modules = {
+        "mlp.experts.0.gate_proj": _make_named_module("mlp.experts.0.gate_proj"),
+        "mlp.shared_expert.gate_proj": _make_named_module("mlp.shared_expert.gate_proj"),
+        "mlp.experts.1.gate_proj": _make_named_module("mlp.experts.1.gate_proj"),
+    }
+    plan = SubsetPlan(
+        modules=modules,
+        subset_index=0,
+        subset_total=1,
+        execute_forward=True,
+        replay_after_process=False,
+        forward_mode="parallel",
+        batch_count=1,
+        forward_row_counts=[1],
+        forward_total_rows=1,
+        moe_groups={},
+        forward_device_map={},
+        calibration_coverage_policy=types.SimpleNamespace(
+            validate_input_coverage=False,
+            fallback_enabled=False,
+            prune_uncovered_modules=False,
+            record_dynamic_exclusions=False,
+        ),
+        module_chunks=[modules],
+        ordered_module_names=[
+            "mlp.shared_expert.gate_proj",
+            "mlp.experts.0.gate_proj",
+            "mlp.experts.1.gate_proj",
+        ],
+    )
+
+    chunk_modules = {
+        "mlp.experts.0.gate_proj": modules["mlp.experts.0.gate_proj"],
+        "mlp.shared_expert.gate_proj": modules["mlp.shared_expert.gate_proj"],
+    }
+    chunk_plan = plan.for_modules(chunk_modules)
+
+    assert list(chunk_plan.modules.keys()) == [
+        "mlp.experts.0.gate_proj",
+        "mlp.shared_expert.gate_proj",
+    ]
+    assert chunk_plan.ordered_module_names == [
+        "mlp.shared_expert.gate_proj",
+        "mlp.experts.0.gate_proj",
+    ]
 
 
 def test_build_subset_plan_balanced_moe_uses_serial_forward_and_device_map():


### PR DESCRIPTION
Major refractor of lifecycle to ensure that the model def tree is the absolute truth in model forward execution (post-quant replay) for all modules/subsets/blocks. We must not monkeypatch fixes downstream. Everything should be based on the ground-truth. 