### PR TITLE
Fail fast for unsupported act-group-aware GPTQ shapes

### DIFF
--- a/gptqmodel/quantization/gptq.py
+++ b/gptqmodel/quantization/gptq.py
@@ -200,6 +200,7 @@ class GPTQ:
         self.validate_module(self.module)
 
         self.qcfg = qcfg if qcfg else QuantizeConfig()  # HF compat will not pass qcfg
+        self._validate_act_group_aware_shape()
 
         self.module_copy = None
 
@@ -241,6 +242,25 @@ class GPTQ:
         self._borrow_workspace_last_summary: Optional[Dict[str, object]] = None
         self._borrow_workspace_stage_dtype: Optional[torch.dtype] = None
         self._borrow_workspace_last_chunk_rows: Optional[int] = None
+
+    def _validate_act_group_aware_shape(self) -> None:
+        if not getattr(self.qcfg, "act_group_aware", False):
+            return
+
+        group_size = int(getattr(self.qcfg, "group_size", -1) or -1)
+        if group_size <= 0:
+            raise ValueError(
+                f"Quantization: Module `{self.name}` -> `act_group_aware=True` requires `group_size > 0`, "
+                f"got `{group_size}`."
+            )
+
+        if self.columns % group_size != 0:
+            raise ValueError(
+                f"Quantization: Module `{self.name}` -> `act_group_aware=True` requires the effective input "
+                f"columns to be divisible by `group_size`. effective_columns={self.columns}, "
+                f"group_size={group_size}. Disable `act_group_aware` or pad the module inputs "
+                f"(for example with `QuantizeConfig(preprocessors=[TensorParallelPadderConfig()])`)."
+            )
 
     @staticmethod
     def validate_module(module):

--- a/tests/models/test_falcon.py
+++ b/tests/models/test_falcon.py
@@ -21,6 +21,7 @@ class TestFalcon(ModelTest):
     EVAL_TASKS_FAST = ModelTest.derive_fast_eval_tasks(EVAL_TASKS_SLOW)
     EVAL_BATCH_SIZE = 6
     USE_VLLM = False
+    ACT_GROUP_AWARE = False
 
     def test_falcon(self):
         self.quantize_and_evaluate()

--- a/tests/models/test_gpt_oss.py
+++ b/tests/models/test_gpt_oss.py
@@ -20,6 +20,7 @@ class TestGPTOSS(ModelTest):
     TRUST_REMOTE_CODE = False
     EVAL_BATCH_SIZE = 6
     USE_VLLM = False
+    ACT_GROUP_AWARE = False
 
     def test_gpt_oss(self):
         self.quantize_and_evaluate()

--- a/tests/test_gptq.py
+++ b/tests/test_gptq.py
@@ -132,6 +132,22 @@ def test_gptq_cpu_hessian_fallback_returns_quantized_weights_to_original_cuda_de
     assert "moving final quantized weights back" in joined_logs
 
 
+def test_gptq_act_group_aware_requires_effective_columns_divisible_by_group_size():
+    layer = nn.Linear(10, 6, bias=False, dtype=torch.float32).eval()
+    qcfg = QuantizeConfig(bits=4, group_size=4, act_group_aware=True)
+
+    with pytest.raises(ValueError, match="effective input columns"):
+        GPTQ(layer, qcfg=qcfg)
+
+
+def test_gptq_act_group_aware_rejects_non_positive_group_size():
+    layer = nn.Linear(8, 6, bias=False, dtype=torch.float32).eval()
+    qcfg = QuantizeConfig(bits=4, group_size=-1, act_group_aware=True)
+
+    with pytest.raises(ValueError, match="group_size > 0"):
+        GPTQ(layer, qcfg=qcfg)
+
+
 class TestGPTQAddBatchCPU(ModelTest):
     ######### test_gptq_add_batch_cpu.py ###########
     pytestmark = pytest.mark.skipif(

--- a/tests/test_tensor_parallel_padder.py
+++ b/tests/test_tensor_parallel_padder.py
@@ -149,3 +149,21 @@ def test_tensor_parallel_padder_does_not_change_quantized_matmul_output():
     padded_output = F.linear(eval_inputs, padded_weight)
 
     torch.testing.assert_close(padded_output, baseline_output, rtol=0.0, atol=0.0)
+
+
+def test_tensor_parallel_padder_makes_act_group_aware_shape_valid():
+    linear = torch.nn.Linear(10, 7, bias=False)
+    named = NamedModule(linear, name="proj", full_name="layer.0.proj", layer_index=0)
+
+    qcfg = QuantizeConfig(
+        bits=4,
+        group_size=12,
+        preprocessors=[TensorParallelPadderConfig()],
+    )
+    qcfg.desc_act = False
+    qcfg.act_group_aware = True
+
+    _build_preprocessor(qcfg).preprocess(named)
+
+    gptq = GPTQ(named, qcfg)
+    assert gptq.columns == 24


### PR DESCRIPTION
## Summary
act_group_aware/GAR currently assumes fixed positive groups. Unsupported shapes could proceed into quantize and fail later with harder-to-debug errors.

  - reject act_group_aware when group_size <= 0
  - reject act_group_aware when effective input columns are not divisible by group_size
