### PR TITLE
[REFACTOR] replace `checkpoint_path_aliases` with `HF_CONVERSION_MAP_REVERSED`

### DIFF
--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -247,7 +247,9 @@ class BaseQModel(nn.Module):
     server = None
 
     support_offload_to_disk = True
-    checkpoint_path_aliases: tuple[tuple[str, str], ...] = ()
+    # Optional runtime->checkpoint prefix overrides for LazyTurtle. When unset,
+    # the loader derives them from Hugging Face conversion mappings.
+    HF_CONVERSION_MAP_REVERSED: Optional[Dict[str, str]] = None
 
     moe_expert_module_name_prefixes = [".expert"]
 
@@ -416,6 +418,15 @@ class BaseQModel(nn.Module):
             return False
         _, flags = cls._parse_module_flags(module_spec)
         return MOE_FLAG.lstrip(":") in flags
+
+    @classmethod
+    def resolve_hf_conversion_map_reversed(cls, target_model: Optional[nn.Module] = None) -> Optional[Dict[str, str]]:
+        configured_map = getattr(cls, "HF_CONVERSION_MAP_REVERSED", None)
+        if configured_map is not None:
+            return copy.deepcopy(configured_map)
+
+        inferred_map = LazyTurtle.infer_hf_conversion_map_reversed(target_model=target_model)
+        return copy.deepcopy(inferred_map) if inferred_map is not None else None
 
     @classmethod
     def _collect_moe_modules_from_tree(cls, tree_node, parent_path="", parent_is_moe=False) -> Set[str]:

--- a/gptqmodel/models/definitions/base_qwen2_vl.py
+++ b/gptqmodel/models/definitions/base_qwen2_vl.py
@@ -18,23 +18,6 @@ from ..base import BaseQModel
 
 class BaseQwen2VLGPTQ(BaseQModel):
     loader = AutoModelForImageTextToText
-    # Qwen2-VL and Qwen2.5-VL expose the text tower at runtime as
-    # `model.language_model.*`, but the original safetensors checkpoints flatten
-    # those same tensors under `model.*`.
-    #
-    # Example:
-    #   runtime shell      -> model.language_model.embed_tokens.weight
-    #   checkpoint tensor  -> model.embed_tokens.weight
-    #   runtime shell      -> model.language_model.layers.0.self_attn.q_proj.weight
-    #   checkpoint tensor  -> model.layers.0.self_attn.q_proj.weight
-    #
-    # Without this alias mapping LazyTurtle fails to find the checkpoint source,
-    # leaves embed/layer tensors on `meta`, and Qwen2-VL later crashes during
-    # multimodal placeholder validation because `inputs_embeds` never materialized.
-    checkpoint_path_aliases = (
-        ("model.language_model", "model"),
-        ("language_model", "model"),
-    )
 
     pre_lm_head_norm_module = ["model.language_model.norm", "language_model.norm"]
 

--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -657,7 +657,10 @@ def ModelLoader(cls):
                     config=model.config,
                     model_init_kwargs=shell_model_init_kwargs,
                     module_tree=copy.deepcopy(getattr(cls, "module_tree", None)),
-                    checkpoint_path_aliases=copy.deepcopy(getattr(cls, "checkpoint_path_aliases", ())),
+                    hf_conversion_map_reversed=copy.deepcopy(
+                        cls.resolve_hf_conversion_map_reversed(target_model=model)
+                    ),
+                    target_model=model,
                 )
 
                 if turtle_model is None:

--- a/gptqmodel/utils/structure.py
+++ b/gptqmodel/utils/structure.py
@@ -29,7 +29,9 @@ import copy
 import inspect
 import json
 import os
+import re
 import threading
+from importlib import import_module
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Optional, Set, Tuple
 
@@ -578,6 +580,9 @@ class LazyTurtle:
 
     supports_reload = False
     is_lazy_checkpoint_source = True
+    _HF_SIMPLE_SOURCE_PREFIX_RE = re.compile(r"^\^?([A-Za-z0-9_.]+)\$?$")
+    _HF_SIMPLE_TARGET_PREFIX_RE = re.compile(r"^([A-Za-z0-9_.]+)$")
+
     def __init__(
         self,
         *,
@@ -585,7 +590,8 @@ class LazyTurtle:
         config: Any,
         model_init_kwargs: Optional[Dict[str, Any]] = None,
         module_tree: Optional[Any] = None,
-        checkpoint_path_aliases: Optional[Any] = None,
+        hf_conversion_map_reversed: Optional[Any] = None,
+        target_model: Optional[nn.Module] = None,
     ) -> None:
         self.model_local_path = model_local_path
         self.config = copy.deepcopy(config)
@@ -594,20 +600,14 @@ class LazyTurtle:
         # Lazy checkpoint name resolution must come from model-definition truth.
         self._module_tree = copy.deepcopy(module_tree)
         self._module_tree_layer_prefix, self._moe_alias_specs = self._build_moe_alias_specs(self._module_tree)
-        alias_items: list[tuple[str, str]] = []
-        raw_aliases = checkpoint_path_aliases or ()
-        if isinstance(raw_aliases, dict):
-            raw_aliases = raw_aliases.items()
-        for runtime_prefix, checkpoint_prefix in raw_aliases:
-            if not isinstance(runtime_prefix, str) or not isinstance(checkpoint_prefix, str):
-                continue
-            runtime_prefix = runtime_prefix.strip(".")
-            checkpoint_prefix = checkpoint_prefix.strip(".")
-            if not runtime_prefix:
-                continue
-            alias_items.append((runtime_prefix, checkpoint_prefix))
-        alias_items.sort(key=lambda item: len(item[0]), reverse=True)
-        self._checkpoint_path_aliases = tuple(alias_items)
+        # Resolve runtime->checkpoint aliases once up front so per-tensor lookups
+        # only need cheap prefix rewrites.
+        alias_items = self._normalize_runtime_to_checkpoint_aliases(
+            hf_conversion_map_reversed
+            if hf_conversion_map_reversed is not None
+            else self.infer_hf_conversion_map_reversed(target_model=target_model)
+        )
+        self._runtime_to_checkpoint_aliases = tuple(alias_items)
         self._lock = threading.RLock()
 
     @classmethod
@@ -618,7 +618,8 @@ class LazyTurtle:
         config: Any,
         model_init_kwargs: Optional[Dict[str, Any]] = None,
         module_tree: Optional[Any] = None,
-        checkpoint_path_aliases: Optional[Any] = None,
+        hf_conversion_map_reversed: Optional[Any] = None,
+        target_model: Optional[nn.Module] = None,
     ) -> Optional["LazyTurtle"]:
         if not model_local_path or not os.path.isdir(model_local_path):
             return None
@@ -629,7 +630,8 @@ class LazyTurtle:
                 config=config,
                 model_init_kwargs=model_init_kwargs,
                 module_tree=module_tree,
-                checkpoint_path_aliases=checkpoint_path_aliases,
+                hf_conversion_map_reversed=hf_conversion_map_reversed,
+                target_model=target_model,
             )
         except Exception as exc:
             log.debug(
@@ -744,6 +746,110 @@ class LazyTurtle:
         if not rel_name:
             return module_path
         return f"{module_path}.{rel_name}"
+
+    @staticmethod
+    def _normalize_runtime_to_checkpoint_aliases(raw_aliases: Optional[Any]) -> tuple[tuple[str, str], ...]:
+        alias_items: list[tuple[str, str]] = []
+        if raw_aliases is None:
+            return ()
+        if isinstance(raw_aliases, dict):
+            raw_aliases = raw_aliases.items()
+        for runtime_prefix, checkpoint_prefix in raw_aliases:
+            if not isinstance(runtime_prefix, str) or not isinstance(checkpoint_prefix, str):
+                continue
+            runtime_prefix = runtime_prefix.strip(".")
+            checkpoint_prefix = checkpoint_prefix.strip(".")
+            if not runtime_prefix:
+                continue
+            alias_items.append((runtime_prefix, checkpoint_prefix))
+        alias_items.sort(key=lambda item: len(item[0]), reverse=True)
+        return tuple(alias_items)
+
+    @classmethod
+    def _extract_hf_source_prefix(cls, pattern: Any) -> Optional[str]:
+        if not isinstance(pattern, str):
+            return None
+        match = cls._HF_SIMPLE_SOURCE_PREFIX_RE.fullmatch(pattern.strip())
+        if match is None:
+            return None
+        return match.group(1).strip(".") or None
+
+    @classmethod
+    def _extract_hf_target_prefix(cls, prefix: Any) -> Optional[str]:
+        if not isinstance(prefix, str):
+            return None
+        match = cls._HF_SIMPLE_TARGET_PREFIX_RE.fullmatch(prefix.strip())
+        if match is None:
+            return None
+        return match.group(1).strip(".") or None
+
+    @classmethod
+    def _iter_hf_conversion_pairs(cls, conversion_mapping: Optional[Any]) -> Iterable[tuple[str, str]]:
+        if isinstance(conversion_mapping, dict):
+            for checkpoint_pattern, runtime_prefix in conversion_mapping.items():
+                if isinstance(checkpoint_pattern, str) and isinstance(runtime_prefix, str):
+                    yield checkpoint_pattern, runtime_prefix
+            return
+
+        if not isinstance(conversion_mapping, (list, tuple)):
+            return
+
+        for entry in conversion_mapping:
+            source_patterns = getattr(entry, "source_patterns", None)
+            target_patterns = getattr(entry, "target_patterns", None)
+            operations = getattr(entry, "operations", None)
+            if operations:
+                continue
+            if not isinstance(source_patterns, (list, tuple)) or not isinstance(target_patterns, (list, tuple)):
+                continue
+            if len(source_patterns) != 1 or len(target_patterns) != 1:
+                continue
+            checkpoint_pattern = source_patterns[0]
+            runtime_prefix = target_patterns[0]
+            if isinstance(checkpoint_pattern, str) and isinstance(runtime_prefix, str):
+                yield checkpoint_pattern, runtime_prefix
+
+    @classmethod
+    def reverse_hf_conversion_map(cls, conversion_mapping: Optional[Any]) -> Optional[Dict[str, str]]:
+        """Invert simple HF checkpoint renames into runtime->checkpoint aliases."""
+        reversed_map: Dict[str, str] = {}
+        for checkpoint_pattern, runtime_prefix in cls._iter_hf_conversion_pairs(conversion_mapping):
+            checkpoint_prefix = cls._extract_hf_source_prefix(checkpoint_pattern)
+            runtime_prefix = cls._extract_hf_target_prefix(runtime_prefix)
+            if checkpoint_prefix is None or runtime_prefix is None:
+                continue
+
+            if runtime_prefix in reversed_map:
+                continue
+            reversed_map[runtime_prefix] = checkpoint_prefix
+
+        return reversed_map or None
+
+    @classmethod
+    def infer_hf_conversion_map_reversed(cls, *, target_model: Optional[nn.Module] = None) -> Optional[Dict[str, str]]:
+        if target_model is None:
+            return None
+
+        model_type = getattr(getattr(target_model, "config", None), "model_type", None)
+        if isinstance(model_type, str):
+            # Prefer the public transformers conversion registry and fall back to
+            # older per-model mappings when needed.
+            try:
+                conversion_mapping_module = import_module("transformers.conversion_mapping")
+            except Exception:
+                conversion_mapping_module = None
+            if conversion_mapping_module is not None:
+                get_checkpoint_conversion_mapping = getattr(
+                    conversion_mapping_module,
+                    "get_checkpoint_conversion_mapping",
+                    None,
+                )
+                if callable(get_checkpoint_conversion_mapping):
+                    reversed_map = cls.reverse_hf_conversion_map(get_checkpoint_conversion_mapping(model_type))
+                    if reversed_map is not None:
+                        return reversed_map
+
+        return cls.reverse_hf_conversion_map(getattr(target_model, "_checkpoint_conversion_mapping", None))
 
     @staticmethod
     def _parse_module_spec(module_spec: str) -> tuple[tuple[str, ...], tuple[str, ...]]:
@@ -957,7 +1063,7 @@ class LazyTurtle:
             candidates.append(candidate)
         return candidates
 
-    def _checkpoint_path_alias_candidates(self, name: str) -> list[str]:
+    def _runtime_to_checkpoint_alias_candidates(self, name: str) -> list[str]:
         """Return `name` plus any runtime->checkpoint prefix rewrites declared by the model.
 
         This handles model families whose execution shell layout does not match
@@ -980,12 +1086,25 @@ class LazyTurtle:
             seen.add(current)
             candidates.append(current)
 
-            for runtime_prefix, checkpoint_prefix in self._checkpoint_path_aliases:
+            for runtime_prefix, checkpoint_prefix in self._runtime_to_checkpoint_aliases:
                 if current == runtime_prefix:
                     suffix = ""
                 elif current.startswith(f"{runtime_prefix}."):
                     suffix = current[len(runtime_prefix):]
                 else:
+                    continue
+
+                # Avoid repeatedly re-applying aliases that expand a prefix into
+                # one that still begins with the original runtime prefix, e.g.
+                # `language_model -> language_model.model`, which would otherwise
+                # generate:
+                #   language_model.layers.0
+                #   language_model.model.layers.0
+                #   language_model.model.model.layers.0
+                #   ...
+                if checkpoint_prefix and (
+                    current == checkpoint_prefix or current.startswith(f"{checkpoint_prefix}.")
+                ):
                     continue
 
                 aliased = f"{checkpoint_prefix}{suffix}" if checkpoint_prefix else suffix.lstrip(".")
@@ -997,7 +1116,7 @@ class LazyTurtle:
     def _resolve_checkpoint_module_path(self, module_path: str) -> str:
         """Resolve a shell module path to the checkpoint path when wrappers add extra roots."""
 
-        candidates = self._checkpoint_path_alias_candidates(module_path)
+        candidates = self._runtime_to_checkpoint_alias_candidates(module_path)
         for aliased in tuple(candidates):
             # Apply declared runtime->checkpoint aliases before the generic
             # prefix-stripping fallback so nested shell paths such as
@@ -1005,7 +1124,7 @@ class LazyTurtle:
             # checkpoint paths like `model.layers.0`.
             candidates.extend(self._module_tree_name_aliases(aliased))
             for candidate_path in self._candidate_module_paths(aliased):
-                candidates.extend(self._checkpoint_path_alias_candidates(candidate_path))
+                candidates.extend(self._runtime_to_checkpoint_alias_candidates(candidate_path))
 
         seen: set[str] = set()
         for candidate in candidates:
@@ -1024,7 +1143,7 @@ class LazyTurtle:
         candidates: list[str] = []
         seen: set[str] = set()
         for candidate_path in self._candidate_module_paths(module_path, allow_empty=True):
-            for aliased_path in self._checkpoint_path_alias_candidates(candidate_path):
+            for aliased_path in self._runtime_to_checkpoint_alias_candidates(candidate_path):
                 candidate_name = self._join_tensor_name(aliased_path, rel_name)
                 if candidate_name not in seen:
                     seen.add(candidate_name)

--- a/tests/test_lazy_turtle_conversion_mapping.py
+++ b/tests/test_lazy_turtle_conversion_mapping.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+from safetensors.torch import save_file
+from torch import nn
+
+from gptqmodel.models.definitions.mixtral import MixtralQModel
+from gptqmodel.utils import structure as structure_module
+from gptqmodel.utils.structure import LazyTurtle
+
+
+def _write_checkpoint_index(path: Path, shard_name: str, state_dict: dict[str, torch.Tensor]) -> None:
+    weight_map = dict.fromkeys(state_dict, shard_name)
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": weight_map}),
+        encoding="utf-8",
+    )
+
+
+def _build_lazy_turtle(
+    tmp_path: Path,
+    checkpoint_tensors: dict[str, torch.Tensor],
+    *,
+    module_tree=None,
+    hf_conversion_map_reversed=None,
+    target_model: nn.Module | None = None,
+) -> LazyTurtle:
+    model_dir = tmp_path / "source_model"
+    model_dir.mkdir()
+    shard_name = "model.safetensors"
+    save_file(checkpoint_tensors, str(model_dir / shard_name))
+    _write_checkpoint_index(model_dir, shard_name, checkpoint_tensors)
+    turtle = LazyTurtle.maybe_create(
+        model_local_path=str(model_dir),
+        config=SimpleNamespace(_experts_implementation=None),
+        model_init_kwargs={"device_map": {"": "cpu"}},
+        module_tree=module_tree,
+        hf_conversion_map_reversed=hf_conversion_map_reversed,
+        target_model=target_model,
+    )
+    assert turtle is not None
+    return turtle
+
+
+class _Gemma3DummyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(model_type="gemma3")
+
+
+class _LegacyGemma3DummyModel(nn.Module):
+    _checkpoint_conversion_mapping = {
+        "^language_model.model": "model.language_model",
+        "^vision_tower": "model.vision_tower",
+        "^multi_modal_projector": "model.multi_modal_projector",
+        "^language_model.lm_head": "lm_head",
+    }
+
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(model_type="gemma3")
+
+
+class _WeightRenamingStub:
+    def __init__(self, source_pattern: str, target_pattern: str):
+        self.source_patterns = [source_pattern]
+        self.target_patterns = [target_pattern]
+        self.operations = []
+
+
+def _gemma3_weight_renamings():
+    return [
+        _WeightRenamingStub(r"^language_model.model", "model.language_model"),
+        _WeightRenamingStub(r"^language_model.lm_head", "lm_head"),
+        _WeightRenamingStub(r"^vision_tower", "model.vision_tower"),
+        _WeightRenamingStub(r"^multi_modal_projector", "model.multi_modal_projector"),
+    ]
+
+
+def _assert_gemma3_alias_resolution(turtle: LazyTurtle) -> None:
+    assert turtle._resolve_checkpoint_module_path("model.language_model") == "language_model.model"
+    assert turtle._resolve_checkpoint_module_path("model.vision_tower") == "vision_tower"
+    assert turtle._resolve_checkpoint_module_path("model.multi_modal_projector") == "multi_modal_projector"
+    assert turtle._resolve_checkpoint_module_path("lm_head") == "language_model.lm_head"
+
+    assert (
+        turtle._resolve_checkpoint_tensor_name(
+            "model.language_model.layers.0.mlp",
+            "gate_proj.weight",
+        )
+        == "language_model.model.layers.0.mlp.gate_proj.weight"
+    )
+    assert (
+        turtle._resolve_checkpoint_tensor_name(
+            "wrapper.model.language_model.layers.0.mlp",
+            "gate_proj.weight",
+        )
+        == "language_model.model.layers.0.mlp.gate_proj.weight"
+    )
+    assert (
+        turtle._resolve_checkpoint_tensor_name(
+            "model.vision_tower.vision_model.head",
+            "weight",
+        )
+        == "vision_tower.vision_model.head.weight"
+    )
+    assert (
+        turtle._resolve_checkpoint_tensor_name(
+            "model.multi_modal_projector",
+            "mm_input_projection_weight",
+        )
+        == "multi_modal_projector.mm_input_projection_weight"
+    )
+    assert turtle._resolve_checkpoint_tensor_name("lm_head", "weight") == "language_model.lm_head.weight"
+
+
+def test_lazy_turtle_reverses_transformers_weight_renaming_list():
+    reversed_map = LazyTurtle.reverse_hf_conversion_map(_gemma3_weight_renamings())
+
+    assert reversed_map == {
+        "model.language_model": "language_model.model",
+        "lm_head": "language_model.lm_head",
+        "model.vision_tower": "vision_tower",
+        "model.multi_modal_projector": "multi_modal_projector",
+    }
+
+
+def test_lazy_turtle_runtime_to_checkpoint_alias_candidates_do_not_expand_infinitely(tmp_path):
+    turtle = _build_lazy_turtle(
+        tmp_path,
+        {
+            "language_model.model.layers.0.self_attn.q_proj.weight": torch.zeros(2, 2),
+        },
+        hf_conversion_map_reversed={
+            "language_model": "language_model.model",
+            "lm_head": "language_model.lm_head",
+        },
+    )
+
+    assert turtle._runtime_to_checkpoint_alias_candidates("language_model.layers.0") == [
+        "language_model.layers.0",
+        "language_model.model.layers.0",
+    ]
+
+
+def test_lazy_turtle_uses_transformers_checkpoint_conversion_mapping_for_gemma3(tmp_path, monkeypatch):
+    conversion_mapping_module = SimpleNamespace(
+        get_checkpoint_conversion_mapping=lambda model_type: _gemma3_weight_renamings()
+        if model_type == "gemma3"
+        else None
+    )
+    monkeypatch.setattr(structure_module, "import_module", lambda name: conversion_mapping_module)
+
+    turtle = _build_lazy_turtle(
+        tmp_path,
+        {
+            "language_model.model.layers.0.mlp.gate_proj.weight": torch.zeros(2, 2),
+            "vision_tower.vision_model.head.weight": torch.zeros(2, 2),
+            "multi_modal_projector.mm_input_projection_weight": torch.zeros(2, 2),
+            "language_model.lm_head.weight": torch.zeros(2, 2),
+        },
+        target_model=_Gemma3DummyModel(),
+    )
+
+    _assert_gemma3_alias_resolution(turtle)
+
+
+def test_lazy_turtle_falls_back_to_legacy_checkpoint_conversion_mapping(tmp_path, monkeypatch):
+    def _raise_import_error(_name: str):
+        raise ImportError("transformers.conversion_mapping is unavailable")
+
+    monkeypatch.setattr(structure_module, "import_module", _raise_import_error)
+
+    turtle = _build_lazy_turtle(
+        tmp_path,
+        {
+            "language_model.model.layers.0.mlp.gate_proj.weight": torch.zeros(2, 2),
+            "vision_tower.vision_model.head.weight": torch.zeros(2, 2),
+            "multi_modal_projector.mm_input_projection_weight": torch.zeros(2, 2),
+            "language_model.lm_head.weight": torch.zeros(2, 2),
+        },
+        target_model=_LegacyGemma3DummyModel(),
+    )
+
+    _assert_gemma3_alias_resolution(turtle)
+
+
+def test_lazy_turtle_keeps_module_tree_alias_resolution_for_mixtral(tmp_path):
+    turtle = _build_lazy_turtle(
+        tmp_path,
+        {
+            "model.layers.0.block_sparse_moe.experts.0.w1.weight": torch.zeros(2, 2),
+        },
+        module_tree=MixtralQModel.module_tree,
+    )
+
+    assert (
+        turtle._resolve_checkpoint_tensor_name(
+            "model.layers.0.mlp.experts.0",
+            "gate_proj.weight",
+        )
+        == "model.layers.0.block_sparse_moe.experts.0.w1.weight"
+    )

--- a/tests/test_offload_files.py
+++ b/tests/test_offload_files.py
@@ -599,7 +599,7 @@ def test_alias_all_from_lazy_turtle_handles_shell_root_prefix_mismatch(tmp_path)
     torch.testing.assert_close(shell_model.transformer.block.dt_scale, source_model.block.dt_scale)
 
 
-def test_lazy_turtle_checkpoint_path_aliases_resolve_nested_language_model_prefix(tmp_path):
+def test_lazy_turtle_hf_conversion_map_reversed_resolves_nested_language_model_prefix(tmp_path):
     source_model = _FlatLanguageCheckpointWrapper(vocab_size=32, width=16)
     shell_model = _NestedLanguageShellWrapper(vocab_size=32, width=16)
 


### PR DESCRIPTION
## Summary

  - remove the legacy `checkpoint_path_aliases` plumbing from `BaseQModel`, `ModelLoader`, and `LazyTurtle`
  - standardize runtime->checkpoint alias resolution on `HF_CONVERSION_MAP_REVERSED`
  - keep automatic alias inference from `transformers.conversion_mapping`, with fallback to legacy `_checkpoint_conversion_mapping`
  - migrate Qwen2-VL overrides and rename the internal alias-candidate path to `runtime_to_checkpoint`
  - add regression tests for Qwen2-VL, Gemma3 conversion mappings, and infinite alias expansion prevention
