### PR TITLE
Align LazyTurtle HF key resolution with reversed WeightRenaming semantics

### DIFF
--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -247,9 +247,9 @@ class BaseQModel(nn.Module):
     server = None
 
     support_offload_to_disk = True
-    # Optional runtime->checkpoint prefix overrides for LazyTurtle. When unset,
-    # the loader derives them from Hugging Face conversion mappings.
-    HF_CONVERSION_MAP_REVERSED: Optional[Dict[str, str]] = None
+    # Optional runtime->checkpoint overrides for LazyTurtle. Prefer reversed
+    # `WeightRenaming` entries; legacy runtime->checkpoint dicts are still accepted.
+    HF_CONVERSION_MAP_REVERSED: Optional[Any] = None
 
     moe_expert_module_name_prefixes = [".expert"]
 
@@ -420,7 +420,7 @@ class BaseQModel(nn.Module):
         return MOE_FLAG.lstrip(":") in flags
 
     @classmethod
-    def resolve_hf_conversion_map_reversed(cls, target_model: Optional[nn.Module] = None) -> Optional[Dict[str, str]]:
+    def resolve_hf_conversion_map_reversed(cls, target_model: Optional[nn.Module] = None) -> Optional[Any]:
         configured_map = getattr(cls, "HF_CONVERSION_MAP_REVERSED", None)
         if configured_map is not None:
             return copy.deepcopy(configured_map)

--- a/gptqmodel/models/definitions/base_qwen2_vl.py
+++ b/gptqmodel/models/definitions/base_qwen2_vl.py
@@ -21,14 +21,6 @@ class BaseQwen2VLGPTQ(BaseQModel):
     loader = AutoModelForImageTextToText
 
     pre_lm_head_norm_module = ["model.language_model.norm", "language_model.norm"]
-    HF_CONVERSION_MAP_REVERSED = {
-        "model.language_model": "model",
-        "language_model": "model",
-    }
-    checkpoint_path_aliases = (
-        ("model.language_model", "model"),
-        ("language_model", "model"),
-    )
 
     module_tree = [
         "model",

--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -657,7 +657,6 @@ def ModelLoader(cls):
                     config=model.config,
                     model_init_kwargs=shell_model_init_kwargs,
                     module_tree=copy.deepcopy(getattr(cls, "module_tree", None)),
-                    checkpoint_path_aliases=copy.deepcopy(getattr(cls, "checkpoint_path_aliases", None)),
                     hf_conversion_map_reversed=copy.deepcopy(
                         cls.resolve_hf_conversion_map_reversed(target_model=model)
                     ),

--- a/gptqmodel/utils/structure.py
+++ b/gptqmodel/utils/structure.py
@@ -29,6 +29,7 @@ import copy
 import inspect
 import json
 import os
+import re
 import threading
 from dataclasses import dataclass
 from importlib import import_module

--- a/gptqmodel/utils/structure.py
+++ b/gptqmodel/utils/structure.py
@@ -719,7 +719,6 @@ class LazyTurtle:
         config: Any,
         model_init_kwargs: Optional[Dict[str, Any]] = None,
         module_tree: Optional[Any] = None,
-        checkpoint_path_aliases: Optional[Any] = None,
         hf_conversion_map_reversed: Optional[Any] = None,
         target_model: Optional[nn.Module] = None,
     ) -> Optional["LazyTurtle"]:
@@ -732,7 +731,6 @@ class LazyTurtle:
                 config=config,
                 model_init_kwargs=model_init_kwargs,
                 module_tree=module_tree,
-                checkpoint_path_aliases=checkpoint_path_aliases,
                 hf_conversion_map_reversed=hf_conversion_map_reversed,
                 target_model=target_model,
             )

--- a/gptqmodel/utils/structure.py
+++ b/gptqmodel/utils/structure.py
@@ -566,6 +566,109 @@ class _MoEAliasSpec:
     leaf_alias_groups: tuple[tuple[tuple[str, ...], ...], ...]
 
 
+@dataclass
+class _LazyWeightRenaming:
+    """Lightweight 1:1 renaming rule that mirrors `transformers.WeightRenaming` matching semantics."""
+
+    source_patterns: list[str] | str
+    target_patterns: list[str] | str
+
+    def __post_init__(self) -> None:
+        self.source_patterns = self._coerce_patterns(self.source_patterns)
+        self.target_patterns = self._coerce_patterns(self.target_patterns)
+        if len(self.source_patterns) != 1 or len(self.target_patterns) != 1:
+            raise ValueError("_LazyWeightRenaming expects exactly one source and one target pattern.")
+
+    @staticmethod
+    def _coerce_patterns(patterns: list[str] | tuple[str, ...] | str | None) -> list[str]:
+        if isinstance(patterns, str):
+            return [patterns]
+        if isinstance(patterns, (list, tuple)):
+            return [pattern for pattern in patterns if isinstance(pattern, str)]
+        return []
+
+    @staticmethod
+    def _process_target_pattern(pattern: str) -> tuple[str, str | None]:
+        # Mirror HF reverse-mapping prep: strip anchors/lookarounds, then turn
+        # the first capturing group into a reusable `\1` placeholder.
+        pattern = pattern.removeprefix("^")
+        pattern = pattern.removesuffix("$")
+        pattern = re.sub(r"\(\?.+?\)?\)", "", pattern)
+        pattern = pattern.replace(r"\.", ".")
+
+        capturing_group_match = re.search(r"\(.+?\)", pattern)
+        captured_group = None
+        if capturing_group_match:
+            captured_group = capturing_group_match.group(0)
+            pattern = pattern.replace(captured_group, r"\1", 1)
+
+        return pattern, captured_group
+
+    @staticmethod
+    def _process_source_pattern(source_pattern: str, target_pattern: str) -> str:
+        if target_pattern.startswith("^"):
+            source_pattern = f"^{source_pattern}" if not source_pattern.startswith("^") else source_pattern
+        if target_pattern.endswith("$"):
+            source_pattern = f"{source_pattern}$" if not source_pattern.endswith("$") else source_pattern
+        return source_pattern
+
+    def _prepared_patterns(self) -> tuple[list[str], list[str], re.Pattern]:
+        # Derive the regex lazily so the object only stores the original
+        # source/target patterns, not cached match state.
+        processed_targets: list[str] = []
+        target_capturing_groups: list[str] = []
+        for pattern in self.target_patterns:
+            processed_pattern, captured_group = self._process_target_pattern(pattern)
+            processed_targets.append(processed_pattern)
+            if captured_group is not None:
+                target_capturing_groups.append(captured_group)
+
+        unique_capturing_groups = set(target_capturing_groups)
+        if len(unique_capturing_groups) > 1:
+            raise ValueError(
+                f"Multiple different capturing groups found in target_patterns: {unique_capturing_groups}. "
+                f"All target patterns must use the same capturing group pattern."
+            )
+        unique_capturing_group = unique_capturing_groups.pop() if unique_capturing_groups else None
+
+        processed_sources: list[str] = []
+        for i, pattern in enumerate(self.source_patterns):
+            processed_pattern = pattern
+            if r"\1" in processed_pattern:
+                if unique_capturing_group is None:
+                    raise ValueError(
+                        f"Source pattern '{pattern}' contains \\1 backreference, but no capturing groups "
+                        f"found in target_patterns."
+                    )
+                processed_pattern = processed_pattern.replace(r"\1", unique_capturing_group, 1)
+            processed_pattern = self._process_source_pattern(processed_pattern, self.target_patterns[i])
+            processed_sources.append(processed_pattern)
+
+        branches = []
+        for i, source_pattern in enumerate(processed_sources):
+            group_name = f"g{i}"
+            pattern = source_pattern.replace(".*.", r"\..*\.")
+            branches.append(f"(?P<{group_name}>{pattern})")
+        compiled_sources = re.compile("|".join(branches))
+
+        return processed_sources, processed_targets, compiled_sources
+
+    def rename_source_key(self, source_key: str) -> tuple[str, str | None]:
+        _, processed_targets, compiled_sources = self._prepared_patterns()
+        match_object = compiled_sources.search(source_key)
+        if match_object is None:
+            return source_key, None
+
+        matching_group_name = next(name for name, val in match_object.groupdict().items() if val is not None)
+        source_pattern_that_matched = self.source_patterns[int(matching_group_name[1:])]
+        replacement = processed_targets[0]
+        if r"\1" in replacement:
+            replaced_group_idx = compiled_sources.groupindex[matching_group_name] + 1
+            replacement = replacement.replace(r"\1", match_object.group(replaced_group_idx))
+        renamed_key = source_key.replace(match_object.group(0), replacement, 1)
+        return renamed_key, source_pattern_that_matched
+
+
 class LazyTurtle:
     """Checkpoint-backed shell materializer for local safetensors models.
 
@@ -580,9 +683,6 @@ class LazyTurtle:
 
     supports_reload = False
     is_lazy_checkpoint_source = True
-    _HF_SIMPLE_SOURCE_PREFIX_RE = re.compile(r"^\^?([A-Za-z0-9_.]+)\$?$")
-    _HF_SIMPLE_TARGET_PREFIX_RE = re.compile(r"^([A-Za-z0-9_.]+)$")
-
     def __init__(
         self,
         *,
@@ -600,14 +700,14 @@ class LazyTurtle:
         # Lazy checkpoint name resolution must come from model-definition truth.
         self._module_tree = copy.deepcopy(module_tree)
         self._module_tree_layer_prefix, self._moe_alias_specs = self._build_moe_alias_specs(self._module_tree)
-        # Resolve runtime->checkpoint aliases once up front so per-tensor lookups
-        # only need cheap prefix rewrites.
-        alias_items = self._normalize_runtime_to_checkpoint_aliases(
+        # Resolve runtime->checkpoint renamings once up front so per-tensor
+        # lookups can apply the same renaming order as HF loading.
+        alias_items = self._normalize_runtime_to_checkpoint_renamings(
             hf_conversion_map_reversed
             if hf_conversion_map_reversed is not None
             else self.infer_hf_conversion_map_reversed(target_model=target_model)
         )
-        self._runtime_to_checkpoint_aliases = tuple(alias_items)
+        self._runtime_to_checkpoint_renamings = tuple(alias_items)
         self._lock = threading.RLock()
 
     @classmethod
@@ -748,40 +848,58 @@ class LazyTurtle:
         return f"{module_path}.{rel_name}"
 
     @staticmethod
-    def _normalize_runtime_to_checkpoint_aliases(raw_aliases: Optional[Any]) -> tuple[tuple[str, str], ...]:
-        alias_items: list[tuple[str, str]] = []
+    def _coerce_patterns(patterns: Any) -> list[str]:
+        if isinstance(patterns, str):
+            return [patterns]
+        if isinstance(patterns, (list, tuple)):
+            return [pattern for pattern in patterns if isinstance(pattern, str)]
+        return []
+
+    @classmethod
+    def _extract_weight_renaming_patterns(cls, entry: Any) -> Optional[tuple[str, str]]:
+        operations = getattr(entry, "operations", None)
+        if operations:
+            # LazyTurtle only needs reversible key renames here, not tensor ops.
+            return None
+
+        source_patterns = getattr(entry, "_original_source_patterns", getattr(entry, "source_patterns", None))
+        target_patterns = getattr(entry, "_original_target_patterns", getattr(entry, "target_patterns", None))
+        source_patterns = cls._coerce_patterns(source_patterns)
+        target_patterns = cls._coerce_patterns(target_patterns)
+        if len(source_patterns) != 1 or len(target_patterns) != 1:
+            return None
+        return source_patterns[0], target_patterns[0]
+
+    @classmethod
+    def _normalize_runtime_to_checkpoint_renamings(cls, raw_aliases: Optional[Any]) -> tuple[_LazyWeightRenaming, ...]:
+        renamings: list[_LazyWeightRenaming] = []
         if raw_aliases is None:
             return ()
+
         if isinstance(raw_aliases, dict):
-            raw_aliases = raw_aliases.items()
-        for runtime_prefix, checkpoint_prefix in raw_aliases:
-            if not isinstance(runtime_prefix, str) or not isinstance(checkpoint_prefix, str):
-                continue
-            runtime_prefix = runtime_prefix.strip(".")
-            checkpoint_prefix = checkpoint_prefix.strip(".")
-            if not runtime_prefix:
-                continue
-            alias_items.append((runtime_prefix, checkpoint_prefix))
-        alias_items.sort(key=lambda item: len(item[0]), reverse=True)
-        return tuple(alias_items)
+            # Backward compatibility for older runtime->checkpoint prefix maps.
+            for runtime_prefix, checkpoint_prefix in raw_aliases.items():
+                if not isinstance(runtime_prefix, str) or not isinstance(checkpoint_prefix, str):
+                    continue
+                runtime_prefix = runtime_prefix.strip(".")
+                checkpoint_prefix = checkpoint_prefix.strip(".")
+                if not runtime_prefix:
+                    continue
+                renamings.append(_LazyWeightRenaming(runtime_prefix, checkpoint_prefix))
+            return tuple(renamings)
 
-    @classmethod
-    def _extract_hf_source_prefix(cls, pattern: Any) -> Optional[str]:
-        if not isinstance(pattern, str):
-            return None
-        match = cls._HF_SIMPLE_SOURCE_PREFIX_RE.fullmatch(pattern.strip())
-        if match is None:
-            return None
-        return match.group(1).strip(".") or None
+        if not isinstance(raw_aliases, (list, tuple)):
+            return ()
 
-    @classmethod
-    def _extract_hf_target_prefix(cls, prefix: Any) -> Optional[str]:
-        if not isinstance(prefix, str):
-            return None
-        match = cls._HF_SIMPLE_TARGET_PREFIX_RE.fullmatch(prefix.strip())
-        if match is None:
-            return None
-        return match.group(1).strip(".") or None
+        for entry in raw_aliases:
+            patterns = cls._extract_weight_renaming_patterns(entry)
+            if patterns is None:
+                continue
+            # New path: consume reversed WeightRenaming-style entries directly.
+            runtime_pattern, checkpoint_pattern = patterns
+            renamings.append(_LazyWeightRenaming(runtime_pattern, checkpoint_pattern))
+
+        return tuple(renamings)
 
     @classmethod
     def _iter_hf_conversion_pairs(cls, conversion_mapping: Optional[Any]) -> Iterable[tuple[str, str]]:
@@ -795,38 +913,21 @@ class LazyTurtle:
             return
 
         for entry in conversion_mapping:
-            source_patterns = getattr(entry, "source_patterns", None)
-            target_patterns = getattr(entry, "target_patterns", None)
-            operations = getattr(entry, "operations", None)
-            if operations:
-                continue
-            if not isinstance(source_patterns, (list, tuple)) or not isinstance(target_patterns, (list, tuple)):
-                continue
-            if len(source_patterns) != 1 or len(target_patterns) != 1:
-                continue
-            checkpoint_pattern = source_patterns[0]
-            runtime_prefix = target_patterns[0]
-            if isinstance(checkpoint_pattern, str) and isinstance(runtime_prefix, str):
-                yield checkpoint_pattern, runtime_prefix
+            patterns = cls._extract_weight_renaming_patterns(entry)
+            if patterns is not None:
+                yield patterns
 
     @classmethod
-    def reverse_hf_conversion_map(cls, conversion_mapping: Optional[Any]) -> Optional[Dict[str, str]]:
-        """Invert simple HF checkpoint renames into runtime->checkpoint aliases."""
-        reversed_map: Dict[str, str] = {}
+    def reverse_hf_conversion_map(cls, conversion_mapping: Optional[Any]) -> Optional[list[_LazyWeightRenaming]]:
+        """Invert simple HF checkpoint renames into reversed `WeightRenaming`-style rules."""
+        reversed_map: list[_LazyWeightRenaming] = []
         for checkpoint_pattern, runtime_prefix in cls._iter_hf_conversion_pairs(conversion_mapping):
-            checkpoint_prefix = cls._extract_hf_source_prefix(checkpoint_pattern)
-            runtime_prefix = cls._extract_hf_target_prefix(runtime_prefix)
-            if checkpoint_prefix is None or runtime_prefix is None:
-                continue
-
-            if runtime_prefix in reversed_map:
-                continue
-            reversed_map[runtime_prefix] = checkpoint_prefix
+            reversed_map.append(_LazyWeightRenaming(runtime_prefix, checkpoint_pattern))
 
         return reversed_map or None
 
     @classmethod
-    def infer_hf_conversion_map_reversed(cls, *, target_model: Optional[nn.Module] = None) -> Optional[Dict[str, str]]:
+    def infer_hf_conversion_map_reversed(cls, *, target_model: Optional[nn.Module] = None) -> Optional[Any]:
         if target_model is None:
             return None
 
@@ -1064,7 +1165,7 @@ class LazyTurtle:
         return candidates
 
     def _runtime_to_checkpoint_alias_candidates(self, name: str) -> list[str]:
-        """Return `name` plus any runtime->checkpoint prefix rewrites declared by the model.
+        """Return `name` plus the result of applying runtime->checkpoint renamings once.
 
         This handles model families whose execution shell layout does not match
         the serialized checkpoint layout. For example, Qwen2-VL runs with
@@ -1075,42 +1176,14 @@ class LazyTurtle:
         if not name:
             return [name]
 
-        candidates: list[str] = []
-        queue = [name]
-        seen: set[str] = set()
-
-        while queue:
-            current = queue.pop(0)
-            if current in seen:
-                continue
-            seen.add(current)
-            candidates.append(current)
-
-            for runtime_prefix, checkpoint_prefix in self._runtime_to_checkpoint_aliases:
-                if current == runtime_prefix:
-                    suffix = ""
-                elif current.startswith(f"{runtime_prefix}."):
-                    suffix = current[len(runtime_prefix):]
-                else:
-                    continue
-
-                # Avoid repeatedly re-applying aliases that expand a prefix into
-                # one that still begins with the original runtime prefix, e.g.
-                # `language_model -> language_model.model`, which would otherwise
-                # generate:
-                #   language_model.layers.0
-                #   language_model.model.layers.0
-                #   language_model.model.model.layers.0
-                #   ...
-                if checkpoint_prefix and (
-                    current == checkpoint_prefix or current.startswith(f"{checkpoint_prefix}.")
-                ):
-                    continue
-
-                aliased = f"{checkpoint_prefix}{suffix}" if checkpoint_prefix else suffix.lstrip(".")
-                if aliased and aliased not in seen:
-                    queue.append(aliased)
-
+        candidates: list[str] = [name]
+        renamed = name
+        # Apply the reversed HF renaming chain once, in order, just like
+        # `transformers.rename_source_key()` walks WeightRenaming rules.
+        for renaming in self._runtime_to_checkpoint_renamings:
+            renamed, _ = renaming.rename_source_key(renamed)
+        if renamed and renamed not in candidates:
+            candidates.append(renamed)
         return candidates
 
     def _resolve_checkpoint_module_path(self, module_path: str) -> str:

--- a/tests/test_lazy_turtle_conversion_mapping.py
+++ b/tests/test_lazy_turtle_conversion_mapping.py
@@ -9,7 +9,10 @@ import torch
 from safetensors.torch import save_file
 from torch import nn
 
+from gptqmodel.models.definitions.gemma3 import Gemma3ForConditionalGenerationGPTQ
 from gptqmodel.models.definitions.mixtral import MixtralQModel
+from gptqmodel.models.definitions.qwen2_5_vl import Qwen2_5_VLQModel
+from gptqmodel.models.definitions.qwen2_vl import Qwen2VLQModel
 from gptqmodel.utils import structure as structure_module
 from gptqmodel.utils.structure import LazyTurtle
 
@@ -66,6 +69,18 @@ class _LegacyGemma3DummyModel(nn.Module):
         self.config = SimpleNamespace(model_type="gemma3")
 
 
+class _Qwen2VLDummyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(model_type="qwen2_vl")
+
+
+class _Qwen2_5_VLDummyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(model_type="qwen2_5_vl")
+
+
 class _WeightRenamingStub:
     def __init__(self, source_pattern: str, target_pattern: str):
         self.source_patterns = [source_pattern]
@@ -80,6 +95,21 @@ def _gemma3_weight_renamings():
         _WeightRenamingStub(r"^vision_tower", "model.vision_tower"),
         _WeightRenamingStub(r"^multi_modal_projector", "model.multi_modal_projector"),
     ]
+
+
+def _qwen2_vl_weight_renamings():
+    return [
+        _WeightRenamingStub(
+            r"(?<!_)model(?!\.(language_model|visual))",
+            "model.language_model",
+        ),
+        _WeightRenamingStub(r"^visual", "model.visual"),
+    ]
+
+
+def _renaming_pairs(renamings) -> list[tuple[str, str]]:
+    assert renamings is not None
+    return [(entry.source_patterns[0], entry.target_patterns[0]) for entry in renamings]
 
 
 def _assert_gemma3_alias_resolution(turtle: LazyTurtle) -> None:
@@ -119,33 +149,80 @@ def _assert_gemma3_alias_resolution(turtle: LazyTurtle) -> None:
     assert turtle._resolve_checkpoint_tensor_name("lm_head", "weight") == "language_model.lm_head.weight"
 
 
+def _assert_qwen2_vl_alias_resolution(turtle: LazyTurtle) -> None:
+    assert turtle._resolve_checkpoint_module_path("model.language_model") == "model"
+    assert turtle._resolve_checkpoint_module_path("model.visual") == "visual"
+
+    assert (
+        turtle._resolve_checkpoint_tensor_name(
+            "model.language_model.layers.0.mlp",
+            "gate_proj.weight",
+        )
+        == "model.layers.0.mlp.gate_proj.weight"
+    )
+    assert (
+        turtle._resolve_checkpoint_tensor_name(
+            "wrapper.model.language_model.layers.0.mlp",
+            "gate_proj.weight",
+        )
+        == "model.layers.0.mlp.gate_proj.weight"
+    )
+    assert (
+        turtle._resolve_checkpoint_tensor_name(
+            "model.visual.blocks.0.attn",
+            "weight",
+        )
+        == "visual.blocks.0.attn.weight"
+    )
+
+
 def test_lazy_turtle_reverses_transformers_weight_renaming_list():
     reversed_map = LazyTurtle.reverse_hf_conversion_map(_gemma3_weight_renamings())
 
-    assert reversed_map == {
-        "model.language_model": "language_model.model",
-        "lm_head": "language_model.lm_head",
-        "model.vision_tower": "vision_tower",
-        "model.multi_modal_projector": "multi_modal_projector",
-    }
+    assert _renaming_pairs(reversed_map) == [
+        ("model.language_model", r"^language_model.model"),
+        ("lm_head", r"^language_model.lm_head"),
+        ("model.vision_tower", r"^vision_tower"),
+        ("model.multi_modal_projector", r"^multi_modal_projector"),
+    ]
 
 
 def test_lazy_turtle_runtime_to_checkpoint_alias_candidates_do_not_expand_infinitely(tmp_path):
+    reversed_map = LazyTurtle.reverse_hf_conversion_map(
+        {
+            "language_model.model": "language_model",
+            "language_model.lm_head": "lm_head",
+        }
+    )
+
     turtle = _build_lazy_turtle(
         tmp_path,
         {
             "language_model.model.layers.0.self_attn.q_proj.weight": torch.zeros(2, 2),
         },
-        hf_conversion_map_reversed={
-            "language_model": "language_model.model",
-            "lm_head": "language_model.lm_head",
-        },
+        hf_conversion_map_reversed=reversed_map,
     )
 
     assert turtle._runtime_to_checkpoint_alias_candidates("language_model.layers.0") == [
         "language_model.layers.0",
         "language_model.model.layers.0",
     ]
+
+
+def test_lazy_turtle_applies_reversed_weight_renamings_with_capturing_groups(tmp_path):
+    reversed_map = LazyTurtle.reverse_hf_conversion_map(
+        [_WeightRenamingStub(r"(.+)", r"timm_model.\1")]
+    )
+
+    turtle = _build_lazy_turtle(
+        tmp_path,
+        {
+            "backbone.conv.weight": torch.zeros(2, 2),
+        },
+        hf_conversion_map_reversed=reversed_map,
+    )
+
+    assert turtle._resolve_checkpoint_tensor_name("timm_model.backbone.conv", "weight") == "backbone.conv.weight"
 
 
 def test_lazy_turtle_uses_transformers_checkpoint_conversion_mapping_for_gemma3(tmp_path, monkeypatch):
@@ -170,6 +247,53 @@ def test_lazy_turtle_uses_transformers_checkpoint_conversion_mapping_for_gemma3(
     _assert_gemma3_alias_resolution(turtle)
 
 
+def test_lazy_turtle_uses_transformers_checkpoint_conversion_mapping_for_qwen2_vl(tmp_path, monkeypatch):
+    conversion_mapping_module = SimpleNamespace(
+        get_checkpoint_conversion_mapping=lambda model_type: _qwen2_vl_weight_renamings()
+        if model_type == "qwen2_vl"
+        else None
+    )
+    monkeypatch.setattr(structure_module, "import_module", lambda name: conversion_mapping_module)
+
+    turtle = _build_lazy_turtle(
+        tmp_path,
+        {
+            "model.layers.0.mlp.gate_proj.weight": torch.zeros(2, 2),
+            "visual.blocks.0.attn.weight": torch.zeros(2, 2),
+        },
+        module_tree=Qwen2VLQModel.module_tree,
+        target_model=_Qwen2VLDummyModel(),
+    )
+
+    _assert_qwen2_vl_alias_resolution(turtle)
+
+
+def test_lazy_turtle_uses_transformers_checkpoint_conversion_mapping_for_qwen2_5_vl(tmp_path, monkeypatch):
+    observed_model_types: list[str] = []
+
+    def _get_checkpoint_conversion_mapping(model_type: str):
+        observed_model_types.append(model_type)
+        if model_type == "qwen2_5_vl":
+            return _qwen2_vl_weight_renamings()
+        return None
+
+    conversion_mapping_module = SimpleNamespace(get_checkpoint_conversion_mapping=_get_checkpoint_conversion_mapping)
+    monkeypatch.setattr(structure_module, "import_module", lambda name: conversion_mapping_module)
+
+    turtle = _build_lazy_turtle(
+        tmp_path,
+        {
+            "model.layers.0.mlp.gate_proj.weight": torch.zeros(2, 2),
+            "visual.blocks.0.attn.weight": torch.zeros(2, 2),
+        },
+        module_tree=Qwen2_5_VLQModel.module_tree,
+        target_model=_Qwen2_5_VLDummyModel(),
+    )
+
+    assert observed_model_types == ["qwen2_5_vl"]
+    _assert_qwen2_vl_alias_resolution(turtle)
+
+
 def test_lazy_turtle_falls_back_to_legacy_checkpoint_conversion_mapping(tmp_path, monkeypatch):
     def _raise_import_error(_name: str):
         raise ImportError("transformers.conversion_mapping is unavailable")
@@ -185,6 +309,45 @@ def test_lazy_turtle_falls_back_to_legacy_checkpoint_conversion_mapping(tmp_path
             "language_model.lm_head.weight": torch.zeros(2, 2),
         },
         target_model=_LegacyGemma3DummyModel(),
+    )
+
+    _assert_gemma3_alias_resolution(turtle)
+
+
+def test_base_qmodel_prefers_manual_hf_conversion_map_reversed(tmp_path, monkeypatch):
+    manual_renamings = LazyTurtle.reverse_hf_conversion_map(_gemma3_weight_renamings())
+    assert manual_renamings is not None
+    monkeypatch.setattr(
+        Gemma3ForConditionalGenerationGPTQ,
+        "HF_CONVERSION_MAP_REVERSED",
+        manual_renamings,
+        raising=False,
+    )
+
+    def _unexpected_import(_name: str):
+        raise AssertionError("manual HF_CONVERSION_MAP_REVERSED should bypass inferred transformers mappings")
+
+    monkeypatch.setattr(structure_module, "import_module", _unexpected_import)
+
+    resolved = Gemma3ForConditionalGenerationGPTQ.resolve_hf_conversion_map_reversed(target_model=_Gemma3DummyModel())
+    assert _renaming_pairs(resolved) == _renaming_pairs(manual_renamings)
+
+    resolved[0].source_patterns[0] = "mutated.runtime"
+    resolved_again = Gemma3ForConditionalGenerationGPTQ.resolve_hf_conversion_map_reversed(
+        target_model=_Gemma3DummyModel()
+    )
+    assert _renaming_pairs(resolved_again) == _renaming_pairs(manual_renamings)
+
+    turtle = _build_lazy_turtle(
+        tmp_path,
+        {
+            "language_model.model.layers.0.mlp.gate_proj.weight": torch.zeros(2, 2),
+            "vision_tower.vision_model.head.weight": torch.zeros(2, 2),
+            "multi_modal_projector.mm_input_projection_weight": torch.zeros(2, 2),
+            "language_model.lm_head.weight": torch.zeros(2, 2),
+        },
+        module_tree=Gemma3ForConditionalGenerationGPTQ.module_tree,
+        hf_conversion_map_reversed=resolved_again,
     )
 
     _assert_gemma3_alias_resolution(turtle)

--- a/tests/test_local_model_paths.py
+++ b/tests/test_local_model_paths.py
@@ -1,3 +1,4 @@
+import copy
 import json
 from types import SimpleNamespace
 
@@ -496,16 +497,18 @@ def test_model_loader_uses_lazy_turtle_for_local_safetensors(monkeypatch, tmp_pa
         require_pkgs = []
         supports_desc_act = [True, False]
         support_offload_to_disk = True
-        checkpoint_path_aliases = (("shell_model", "model"),)
+        HF_CONVERSION_MAP_REVERSED = (
+            SimpleNamespace(source_patterns=["shell_model"], target_patterns=["model"]),
+        )
         config_class = None
 
         @staticmethod
         def before_model_load(*_args, **_kwargs):
             return None
 
-        @staticmethod
-        def resolve_hf_conversion_map_reversed(*_args, **_kwargs):
-            return None
+        @classmethod
+        def resolve_hf_conversion_map_reversed(cls, *_args, **_kwargs):
+            return copy.deepcopy(cls.HF_CONVERSION_MAP_REVERSED)
 
         def __init__(self, model, **kwargs):
             self.model = model
@@ -531,7 +534,13 @@ def test_model_loader_uses_lazy_turtle_for_local_safetensors(monkeypatch, tmp_pa
     assert shell_configs
     assert load_calls == []
     assert isinstance(instance.turtle_model, LazyTurtle)
-    assert instance.turtle_model._runtime_to_checkpoint_aliases == DummyQModel.checkpoint_path_aliases
+    assert [
+        (entry.source_patterns[0], entry.target_patterns[0])
+        for entry in instance.turtle_model._runtime_to_checkpoint_renamings
+    ] == [
+        (entry.source_patterns[0], entry.target_patterns[0])
+        for entry in DummyQModel.HF_CONVERSION_MAP_REVERSED
+    ]
     assert instance.turtle_model.config._experts_implementation == "linear_loop"
     assert instance.turtle_model.config is not instance.model.config
 

--- a/tests/test_offload_files.py
+++ b/tests/test_offload_files.py
@@ -623,9 +623,9 @@ def test_lazy_turtle_hf_conversion_map_reversed_resolves_nested_language_model_p
         model_local_path=str(model_dir),
         config=SimpleNamespace(_experts_implementation=None),
         model_init_kwargs={"device_map": {"": "cpu"}},
-        checkpoint_path_aliases=(
-            ("model.language_model", "model"),
-            ("language_model", "model"),
+        hf_conversion_map_reversed=(
+            SimpleNamespace(source_patterns=["model.language_model"], target_patterns=["model"]),
+            SimpleNamespace(source_patterns=["language_model"], target_patterns=["model"]),
         ),
     )
     assert source is not None

--- a/tests/test_qwen2_family_compat.py
+++ b/tests/test_qwen2_family_compat.py
@@ -16,6 +16,7 @@ from torch import nn
 from transformers import PreTrainedTokenizerFast
 
 from gptqmodel.models.definitions import base_qwen2_5_omni, base_qwen2_vl
+from gptqmodel.utils import structure as structure_module
 from gptqmodel.utils.hf import load_tokenizer
 
 
@@ -37,12 +38,26 @@ def test_qwen2_vl_image_only_process_vision_info_returns_image_list():
     assert image_inputs == [image]
 
 
-def test_qwen2_vl_declares_checkpoint_path_aliases_for_language_model_shell():
-    assert base_qwen2_vl.BaseQwen2VLGPTQ.support_offload_to_disk is True
-    assert base_qwen2_vl.BaseQwen2VLGPTQ.checkpoint_path_aliases == (
-        ("model.language_model", "model"),
-        ("language_model", "model"),
+def test_qwen2_vl_resolves_hf_conversion_map_reversed_for_language_model_shell(monkeypatch):
+    conversion_mapping_module = types.SimpleNamespace(
+        get_checkpoint_conversion_mapping=lambda model_type: [
+            types.SimpleNamespace(
+                source_patterns=[r"(?<!_)model(?!\.(language_model|visual))"],
+                target_patterns=["model.language_model"],
+            ),
+        ]
+        if model_type == "qwen2_vl"
+        else None
     )
+    monkeypatch.setattr(structure_module, "import_module", lambda name: conversion_mapping_module)
+
+    target_model = types.SimpleNamespace(config=types.SimpleNamespace(model_type="qwen2_vl"))
+    resolved = base_qwen2_vl.BaseQwen2VLGPTQ.resolve_hf_conversion_map_reversed(target_model=target_model)
+
+    assert base_qwen2_vl.BaseQwen2VLGPTQ.support_offload_to_disk is True
+    assert [(entry.source_patterns[0], entry.target_patterns[0]) for entry in resolved] == [
+        ("model.language_model", r"(?<!_)model(?!\.(language_model|visual))"),
+    ]
 
 
 def test_qwen2_vl_pre_quantize_hooks_use_inner_model_layout():


### PR DESCRIPTION
## Summary

  This PR aligns LazyTurtle checkpoint key resolution with the same ordered key-renaming semantics used by `transformers.convert_and_load_state_dict_in_model()`.

  Instead of treating `HF_CONVERSION_MAP_REVERSED` as a flat runtime-to-checkpoint prefix dict, LazyTurtle now accepts reversed `WeightRenaming`-style rules and applies them in order when resolving checkpoint paths.