### PR TITLE
Fix LLMAWQ execution on SM120 GPUs

### DIFF
--- a/.github/scripts/test.yaml
+++ b/.github/scripts/test.yaml
@@ -13,10 +13,6 @@ tests:
     gpu: 2
     py: 3.14t
 
-  test_awq_inference_llm_awq:
-    sm: '<120'
-
-
 tests/models:
   py: 3.13
 

--- a/gptqmodel/nn_modules/qlinear/gemv_fast_awq.py
+++ b/gptqmodel/nn_modules/qlinear/gemv_fast_awq.py
@@ -153,6 +153,11 @@ class AwqGEMVFastLinear(AWQuantLinear):
             else:
                 self.bias = None
 
+        # Blackwell/SM120 currently misbehaves with the fused AWQ kernels, so
+        # those devices rebuild one dense compatibility weight per module.
+        self._sm120_compat_weight: torch.Tensor | None = None
+        self._sm120_compat_weight_device: tuple[torch.device, torch.dtype] | None = None
+
     def forward(self, x: torch.Tensor):
         if not awq_runtime_available():
             raise ModuleNotFoundError("AWQ torch.ops kernels are not properly installed. Error: " + awq_runtime_error())
@@ -174,6 +179,11 @@ class AwqGEMVFastLinear(AWQuantLinear):
             inputs = inputs.contiguous()
 
         self._ensure_runtime_buffers(device=inputs.device, dtype=inputs.dtype)
+
+        # Route SM120 devices through a compatibility implementation until the
+        # fused decode/prefill kernels are fixed for Blackwell.
+        if self._use_sm120_compat_path(inputs.device):
+            return self._sm120_compat_forward(x=x, inputs=inputs, input_dtype=input_dtype)
 
         zeros = self._runtime_zeros()
         if inputs_dim == 3 and batch_size < 8 and n_tokens == 1:
@@ -202,9 +212,84 @@ class AwqGEMVFastLinear(AWQuantLinear):
 
         return out
 
+    def _use_sm120_compat_path(self, device: torch.device) -> bool:
+        """Enable the SM120 compatibility path on Blackwell-class CUDA devices."""
+
+        if device.type != "cuda":
+            return False
+        major, _minor = torch.cuda.get_device_capability(device)
+        return major >= 12
+
+    def _sm120_compat_forward(
+            self,
+            *,
+            x: torch.Tensor,
+            inputs: torch.Tensor,
+            input_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """Run a dense compatibility matmul for SM120 until fused kernels are stable."""
+
+        out_shape = inputs.shape[:-1] + (self.out_features,)
+        weight = self._sm120_compat_dense_weight(device=inputs.device, dtype=inputs.dtype)
+        out = inputs.reshape(-1, inputs.shape[-1]).matmul(weight).reshape(out_shape)
+
+        if input_dtype != torch.float16:
+            out = out.to(dtype=input_dtype)
+
+        out = out + self.bias if self.bias is not None else out
+
+        if self.adapter:
+            out = self.adapter.apply(x=x, out=out)
+
+        return out
+
+    def _sm120_compat_dense_weight(self, *, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+        """Cache one dense AWQ weight matrix per device/dtype for the SM120 path."""
+
+        cache_key = (device, dtype)
+        if self._sm120_compat_weight is not None and self._sm120_compat_weight_device == cache_key:
+            return self._sm120_compat_weight
+
+        intweight = self._unpack_reference_intweight(device=device)
+
+        num_groups = max(1, (self.in_features + self.group_size - 1) // self.group_size)
+        scales = self.scales.transpose(0, 1)[:, :num_groups].to(device=device, dtype=dtype)
+        zeros = self._runtime_zeros().transpose(0, 1)[:, :num_groups].to(device=device, dtype=dtype)
+
+        scales = scales.repeat_interleave(self.group_size, dim=1)[:, : self.in_features]
+        zeros = zeros.repeat_interleave(self.group_size, dim=1)[:, : self.in_features]
+
+        weight = (intweight.to(dtype=dtype) * scales + zeros).transpose(0, 1).contiguous()
+        self._sm120_compat_weight = weight
+        self._sm120_compat_weight_device = cache_key
+        return weight
+
+    def _unpack_reference_intweight(self, *, device: torch.device) -> torch.Tensor:
+        """Invert the GEMV_FAST int16 packing so SM120 can rebuild dense weights."""
+
+        packed = self.qweight.to(device=device, dtype=torch.int32)
+        unpacked = torch.stack(
+            [
+                torch.bitwise_and(torch.bitwise_right_shift(packed, shift), 0xF)
+                for shift in (0, 4, 8, 12)
+            ],
+            dim=-1,
+        )
+        unpacked = unpacked.view(packed.shape[0], packed.shape[1] // 64, 4, 64)
+        unpacked = unpacked.permute(0, 2, 1, 3).contiguous()
+        unpacked = unpacked.view(packed.shape[0] * 4, self.in_features)
+        unpacked = unpacked.view(packed.shape[0] * 4, self.in_features // 32, 4, 2, 4)
+        unpacked = unpacked.permute(0, 1, 2, 4, 3).contiguous()
+        unpacked = unpacked.view(packed.shape[0] * 4, self.in_features // 32, 32)
+        unpacked = unpacked.view(packed.shape[0] * 4, self.in_features // 32, 4, 4, 2)
+        unpacked = unpacked.permute(0, 1, 3, 2, 4).contiguous()
+        return unpacked.view(self.out_features, self.in_features)
+
     def _ensure_runtime_buffers(self, *, device: torch.device, dtype: torch.dtype):
         if self.qweight.device != device or not self.qweight.is_contiguous():
             self.qweight = self.qweight.to(device=device).contiguous()
+            self._sm120_compat_weight = None
+            self._sm120_compat_weight_device = None
 
         zeros = self._runtime_zeros()
         if zeros.device != device or zeros.dtype != dtype or not zeros.is_contiguous():
@@ -215,9 +300,13 @@ class AwqGEMVFastLinear(AWQuantLinear):
                 self.scaled_zeros = zeros
             else:
                 raise ValueError(f"Unsupported zeros buffer: {self.zeros_name}")
+            self._sm120_compat_weight = None
+            self._sm120_compat_weight_device = None
 
         if self.scales.device != device or self.scales.dtype != dtype or not self.scales.is_contiguous():
             self.scales = self.scales.to(device=device, dtype=dtype).contiguous()
+            self._sm120_compat_weight = None
+            self._sm120_compat_weight_device = None
 
         if self.bias is not None and (
             self.bias.device != device or self.bias.dtype != dtype or not self.bias.is_contiguous()

--- a/tests/test_awq_gemv_fast_jit.py
+++ b/tests/test_awq_gemv_fast_jit.py
@@ -105,6 +105,34 @@ def test_awq_gemv_fast_raises_runtime_error_when_jit_ops_missing(monkeypatch):
         module(torch.randn((1, 1, module.in_features), dtype=torch.float16))
 
 
+def test_awq_gemv_fast_uses_sm120_compat_path(monkeypatch):
+    module = _build_module()
+    calls = {"compat": 0}
+
+    monkeypatch.setattr(gemv_fast_awq, "awq_runtime_available", lambda: True)
+    monkeypatch.setattr(gemv_fast_awq.AwqGEMVFastLinear, "_use_sm120_compat_path", lambda self, device: True)
+
+    def fail_decode(*_args, **_kwargs):
+        raise AssertionError("decode kernel should not run on the SM120 compatibility path")
+
+    def fail_prefill(*_args, **_kwargs):
+        raise AssertionError("prefill kernel should not run on the SM120 compatibility path")
+
+    def fake_compat(self, *, x, inputs, input_dtype):
+        del x, input_dtype
+        calls["compat"] += 1
+        return torch.ones((inputs.shape[0], inputs.shape[1], self.out_features), dtype=inputs.dtype)
+
+    monkeypatch.setattr(gemv_fast_awq, "awq_fast_gemv_forward_decode", fail_decode)
+    monkeypatch.setattr(gemv_fast_awq, "awq_fast_gemm_forward_prefill", fail_prefill)
+    monkeypatch.setattr(gemv_fast_awq.AwqGEMVFastLinear, "_sm120_compat_forward", fake_compat)
+
+    out = module(torch.randn((1, 1, module.in_features), dtype=torch.float16))
+
+    assert calls["compat"] == 1
+    assert out.shape == (1, 1, module.out_features)
+
+
 def test_awq_gemv_fast_decode_normalizes_noncontiguous_inputs_and_buffers(monkeypatch):
     module = _build_module()
     module.qweight = module.qweight.t().contiguous().t()
@@ -112,6 +140,7 @@ def test_awq_gemv_fast_decode_normalizes_noncontiguous_inputs_and_buffers(monkey
     module.qzeros = module.qzeros.t().contiguous().t()
 
     monkeypatch.setattr(gemv_fast_awq, "awq_runtime_available", lambda: True)
+    monkeypatch.setattr(gemv_fast_awq.torch.cuda, "get_device_capability", lambda device=None: (8, 9))
 
     def fake_decode(inputs, qweight, scales, zeros, m, n, k, group_size):
         assert inputs.is_contiguous()
@@ -135,6 +164,7 @@ def test_awq_gemv_fast_prefill_normalizes_noncontiguous_inputs(monkeypatch):
     module = _build_module()
 
     monkeypatch.setattr(gemv_fast_awq, "awq_runtime_available", lambda: True)
+    monkeypatch.setattr(gemv_fast_awq.torch.cuda, "get_device_capability", lambda device=None: (8, 9))
     monkeypatch.setattr(gemv_fast_awq, "awq_fast_gemv_forward_decode", lambda *_args, **_kwargs: None)
 
     def fake_prefill(inputs, qweight, scales, zeros):
@@ -158,6 +188,7 @@ def test_llm_awq_decode_normalizes_scaled_zeros_without_dynamic_attr_access(monk
     module.scaled_zeros = module.scaled_zeros.t().contiguous().t()
 
     monkeypatch.setattr(gemv_fast_awq, "awq_runtime_available", lambda: True)
+    monkeypatch.setattr(gemv_fast_awq.torch.cuda, "get_device_capability", lambda device=None: (8, 9))
 
     def fake_decode(inputs, qweight, scales, zeros, m, n, k, group_size):
         assert zeros.is_contiguous()

--- a/tests/test_awq_inference_llm_awq.py
+++ b/tests/test_awq_inference_llm_awq.py
@@ -11,7 +11,6 @@ from gptqmodel import BACKEND
 pytestmark = [pytest.mark.model, pytest.mark.slow]
 
 
-# TODO: 4090 works after ModelCloud/GPTQModel/pull/2798. 5090 still crash with illegal memory access
 def test_inference_quantized_by_llm_awq():
     run_inference_only_generation_test(
         "ModelCloud/opt-125m-llm-awq",  # this quantized by llm-awq


### PR DESCRIPTION
Problem: AWQ JIT now builds correctly, but LLMAwqLinear still hit illegal memory access on Blackwell/SM120 GPUs while Ada/SM89 continued to work. The fused decode and prefill kernels were stable on RTX 4090 but not on RTX 5090.

Fix: keep the existing fast AWQ kernels on pre-SM120 GPUs, add an SM120-specific compatibility path inside LLMAwqLinear that rebuilds and caches one dense AWQ weight matrix per module before running the same linear op, and add regression coverage for the SM120 dispatch path. Also keep the semaphore zero-initialization fix already present for split-K launch ordering.
