### PR TITLE
[FIX] multi-GPU quantization OOM by canonicalizing get_supported_kwargs cache keys

### DIFF
--- a/gptqmodel/utils/inspect.py
+++ b/gptqmodel/utils/inspect.py
@@ -13,12 +13,8 @@ from typing import Any, Callable, FrozenSet, Optional, Tuple
 SupportedKwargInfo = Tuple[bool, Optional[FrozenSet[str]]]
 
 
-@lru_cache(maxsize=None)
-def get_supported_kwargs(callable_obj: Callable) -> SupportedKwargInfo:
-    """Return (accepts_var_kwargs, allowed_kwargs) for a callable.
-
-    allowed_kwargs is None when the callable uses ``**kwargs`` or when inspection fails.
-    """
+def _get_supported_kwargs_uncached(callable_obj: Callable) -> SupportedKwargInfo:
+    """Inspect one callable without retaining it in any global cache."""
     try:
         signature = inspect.signature(callable_obj)
     except (TypeError, ValueError):
@@ -33,6 +29,60 @@ def get_supported_kwargs(callable_obj: Callable) -> SupportedKwargInfo:
         if param.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
     )
     return False, allowed
+
+
+@lru_cache(maxsize=256)
+def _get_supported_kwargs_cached(signature_target: Callable) -> SupportedKwargInfo:
+    """Inspect a cache-safe callable identity.
+
+    Only stable function objects should reach this helper. Bound methods and
+    instance-bound builtin methods must be normalized or bypass this cache so
+    the cache never keeps heavyweight objects alive.
+    """
+    return _get_supported_kwargs_uncached(signature_target)
+
+
+def _is_cache_safe_builtin(callable_obj: Callable) -> bool:
+    """Return True only for builtin callables that are safe to cache directly.
+
+    Keep this branch conservative. Builtin methods such as ``[].append`` expose
+    ``__self__`` as the owning instance; caching them directly would retain that
+    instance. Module-level builtins like ``len`` instead point at the builtins
+    module and are safe to reuse across the process.
+    """
+    if not inspect.isbuiltin(callable_obj):
+        return False
+
+    owner = getattr(callable_obj, "__self__", None)
+    return owner is None or inspect.ismodule(owner)
+
+
+def get_supported_kwargs(callable_obj: Callable) -> SupportedKwargInfo:
+    """Return (accepts_var_kwargs, allowed_kwargs) for a callable.
+
+    allowed_kwargs is None when the callable uses ``**kwargs`` or when inspection fails.
+
+    Never cache ``callable_obj`` directly. Multi-device quantization passes
+    bound ``nn.Module.forward`` methods here; caching those bound methods keeps
+    the owning module replicas alive and pins their device tensors in memory.
+    Instead, bound Python methods are normalized to ``__func__`` before hitting
+    the internal cache, while less stable callables fall back to uncached
+    inspection.
+    """
+    func = getattr(callable_obj, "__func__", None)
+    if func is not None:
+        # Bound Python methods differ per instance but share the same
+        # underlying function object. Caching on ``__func__`` preserves reuse
+        # without retaining the bound instance.
+        return _get_supported_kwargs_cached(func)
+
+    if inspect.isfunction(callable_obj):
+        return _get_supported_kwargs_cached(callable_obj)
+
+    if _is_cache_safe_builtin(callable_obj):
+        return _get_supported_kwargs_cached(callable_obj)
+
+    return _get_supported_kwargs_uncached(callable_obj)
 
 
 def safe_kwargs_call(

--- a/tests/test_inspect_utils.py
+++ b/tests/test_inspect_utils.py
@@ -1,0 +1,117 @@
+import gc
+import weakref
+
+from gptqmodel.utils import inspect as inspect_utils
+from gptqmodel.utils.inspect import get_supported_kwargs, safe_kwargs_call
+
+
+class _CallableWithoutVarKwargs:
+    def __call__(self, hidden_states, attention_mask=None, use_cache=False):
+        return hidden_states, attention_mask, use_cache
+
+
+def _clear_supported_kwargs_cache():
+    inspect_utils._get_supported_kwargs_cached.cache_clear()
+
+
+def test_get_supported_kwargs_does_not_keep_bound_callable_alive():
+    _clear_supported_kwargs_cache()
+    callable_obj = _CallableWithoutVarKwargs()
+    obj_ref = weakref.ref(callable_obj)
+
+    # Bound Python methods should be normalized to the shared function object,
+    # so this lookup must not keep the instance alive.
+    accepts_var_kw, allowed_kwargs = get_supported_kwargs(callable_obj.__call__)
+
+    assert accepts_var_kw is False
+    assert allowed_kwargs is not None
+    assert "attention_mask" in allowed_kwargs
+    assert "use_cache" in allowed_kwargs
+
+    del callable_obj
+    gc.collect()
+
+    assert obj_ref() is None
+
+
+def test_get_supported_kwargs_caches_bound_methods_by_unbound_function(monkeypatch):
+    _clear_supported_kwargs_cache()
+
+    signature_calls = []
+    original_signature = inspect_utils.inspect.signature
+
+    def counting_signature(callable_obj):
+        signature_calls.append(callable_obj)
+        return original_signature(callable_obj)
+
+    monkeypatch.setattr(inspect_utils.inspect, "signature", counting_signature)
+
+    first = _CallableWithoutVarKwargs()
+    second = _CallableWithoutVarKwargs()
+
+    # Two bound methods from different instances should collapse onto the same
+    # underlying function cache key.
+    get_supported_kwargs(first.__call__)
+    get_supported_kwargs(second.__call__)
+
+    assert signature_calls == [_CallableWithoutVarKwargs.__call__]
+
+
+def test_get_supported_kwargs_caches_module_level_builtins(monkeypatch):
+    _clear_supported_kwargs_cache()
+
+    signature_calls = []
+    original_signature = inspect_utils.inspect.signature
+
+    def counting_signature(callable_obj):
+        signature_calls.append(callable_obj)
+        return original_signature(callable_obj)
+
+    monkeypatch.setattr(inspect_utils.inspect, "signature", counting_signature)
+
+    # Module-level builtins such as len are process-stable and safe to cache.
+    get_supported_kwargs(len)
+    get_supported_kwargs(len)
+
+    assert signature_calls == [len]
+
+
+def test_get_supported_kwargs_does_not_cache_instance_bound_builtin_methods(monkeypatch):
+    _clear_supported_kwargs_cache()
+
+    signature_calls = []
+    original_signature = inspect_utils.inspect.signature
+
+    def counting_signature(callable_obj):
+        signature_calls.append(callable_obj)
+        return original_signature(callable_obj)
+
+    monkeypatch.setattr(inspect_utils.inspect, "signature", counting_signature)
+
+    values = []
+    append = values.append
+
+    # Instance-bound builtin methods retain their owner through __self__, so
+    # they must stay on the uncached path.
+    get_supported_kwargs(append)
+    get_supported_kwargs(append)
+
+    assert len(signature_calls) == 2
+
+
+def test_safe_kwargs_call_filters_unsupported_kwargs():
+    _clear_supported_kwargs_cache()
+    callable_obj = _CallableWithoutVarKwargs()
+
+    # safe_kwargs_call should preserve supported kwargs while dropping extras.
+    result = safe_kwargs_call(
+        callable_obj,
+        "hidden",
+        kwargs={
+            "attention_mask": "mask",
+            "use_cache": True,
+            "unsupported": "drop-me",
+        },
+    )
+
+    assert result == ("hidden", "mask", True)


### PR DESCRIPTION
## Summary
  During multi-GPU quantization, the parallel replay path inspects `module.forward` on per-device replicas.

  When `get_supported_kwargs` caches the bound method object itself, the cache key keeps a strong reference to the owning module replica. That prevents those replicas and their device tensors from being reclaimed after replay,
  so VRAM usage grows across layers/subsets and eventually hits OOM.

  Single-GPU runs are mostly unaffected because they usually stay on the serial path and do not repeatedly inspect per-replica bound forwards.


## What Changed

  - canonicalize `get_supported_kwargs` cache keys to avoid retaining bound callables
  - cache Python bound methods by `__func__` instead of the bound method object
  
fix #2805 
fix #2810 