### PR TITLE
[MODEL] support `ernie4_5_vl_moe`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 </p>
 
 ## Latest News
-* 04/29/2026 `main`: Added `ERNIE 4.5 VL MoE` model support with LazyTurtle checkpoint alias handling for HF conversion mappings.
+* 04/29/2026 `main`: Added `ERNIE 4.5 VL MoE` model support.
 * 04/28/2026 [7.0.0](https://github.com/ModelCloud/GPTQModel/releases/tag/v7.0.0): 🚀 Added Huawei Ascend NPU support through native torch kernels for GPTQ, AWQ, ParoQuant, GGUF, QQQ, and EXL3. Added `internvl_chat`, `gemma3n`, `GLM-OCR`, `GLM-ASR`, and `falcon_mamba` model support.
 * 04/16/2026 [6.1.0](https://github.com/ModelCloud/GPTQModel/releases/tag/v6.1.0): 🚀🔥⚡ CUDA kernels are now fully JIT-compiled, shrinking the wheel by about 300x and building only what you use; Marlin now supports NVIDIA `Turing+` GPUs, Machete kernel validation now covers supported GPUs, `GLM 5/5.1` joins the lineup, and LazyTurtle plus AWQ / multi-GPU MoE fixes make large-model quantization easier, lighter, and smoother.
 * 04/03/2026 [6.0.3](https://github.com/ModelCloud/GPTQModel/releases/tag/v6.0.3): 🎉 New quantization methods: `ParoQuant`, `GGUF`, `FP8`, `EXL3`, and `FOEM: First-Order Error Matters`. Added PrismML/Bonsai 1bit model quantization (inference only), faster ParoQuant/AWQ kernels, ParoQuant `optimization scope` control: `module` (Paro Lite) or `layer` (Paro reference), plus `Gemma4`, `MiniCPM-O`, `MiniCPM-V`, and `GLM4 MoE Lite` model support.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 </p>
 
 ## Latest News
+* 04/29/2026 `main`: Added `ERNIE 4.5 VL MoE` model support with LazyTurtle checkpoint alias handling for HF conversion mappings.
 * 04/28/2026 [7.0.0](https://github.com/ModelCloud/GPTQModel/releases/tag/v7.0.0): 🚀 Added Huawei Ascend NPU support through native torch kernels for GPTQ, AWQ, ParoQuant, GGUF, QQQ, and EXL3. Added `internvl_chat`, `gemma3n`, `GLM-OCR`, `GLM-ASR`, and `falcon_mamba` model support.
 * 04/16/2026 [6.1.0](https://github.com/ModelCloud/GPTQModel/releases/tag/v6.1.0): 🚀🔥⚡ CUDA kernels are now fully JIT-compiled, shrinking the wheel by about 300x and building only what you use; Marlin now supports NVIDIA `Turing+` GPUs, Machete kernel validation now covers supported GPUs, `GLM 5/5.1` joins the lineup, and LazyTurtle plus AWQ / multi-GPU MoE fixes make large-model quantization easier, lighter, and smoother.
 * 04/03/2026 [6.0.3](https://github.com/ModelCloud/GPTQModel/releases/tag/v6.0.3): 🎉 New quantization methods: `ParoQuant`, `GGUF`, `FP8`, `EXL3`, and `FOEM: First-Order Error Matters`. Added PrismML/Bonsai 1bit model quantization (inference only), faster ParoQuant/AWQ kernels, ParoQuant `optimization scope` control: `module` (Paro Lite) or `layer` (Paro reference), plus `Gemma4`, `MiniCPM-O`, `MiniCPM-V`, and `GLM4 MoE Lite` model support.
@@ -253,7 +254,7 @@ Selected public references where teams or companies explicitly mention GPT-QMode
 | DeepSeek-V2/V3/R1 | ✅ | GPT-OSS       | ✅ | LongCat Flash          | ✅ | OLMo2 / LLaDA2 | ✅ | Yi                  | ✅ |
 | DeepSeek-V2-Lite  | ✅ | Granite / Granite MoE | ✅ | LongLLaMA       | ✅ | Ovis 1.6/2     | ✅ | Seed-OSS            | ✅ |
 | Dream             | ✅ | GRIN-MoE      | ✅ | Instella               | ✅ | Phi 1-4        | ✅ | Voxtral             | ✅ |
-| ERNIE 4.5 / 4.5 MoE | ✅ | GLM 4/4V/5/5.1/OCR/ASR | ✅ | GLM4 MoE / Lite   | ✅ | MiniCPM 3/O/V  | ✅ | PanGu-α             | ✅ |
+| ERNIE 4.5 / MoE / VL MoE | ✅ | GLM 4/4V/5/5.1/OCR/ASR | ✅ | GLM4 MoE / Lite   | ✅ | MiniCPM 3/O/V  | ✅ | PanGu-α             | ✅ |
 | XVERSE            | ✅ | Brumby        | ✅ | Hymba                  | ✅ | Mistral                      | ✅ | Qwen 1/2/3/3.5     | ✅ |
 | MiniMax M2        | ✅ | AfMoE         | ✅ | Bailing-MoE            | ✅ | LFM2-MoE       | ✅ | Marin               | ✅ |
 | InternVL Chat | ✅ |               |   |                        |   |                |   |                     |   |

--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -97,12 +97,12 @@ from .definitions.gemma3 import Gemma3ForConditionalGenerationGPTQ, Gemma3QModel
 from .definitions.gemma3n import Gemma3nForConditionalGenerationGPTQ, Gemma3nTextQModel  # noqa: E402
 from .definitions.gemma4 import Gemma4ForConditionalGenerationGPTQ, Gemma4TextQModel  # noqa: E402
 from .definitions.glm import GlmQModel  # noqa: E402
-from .definitions.glmasr import GlmASRGPTQ  # noqa: E402
-from .definitions.glm_ocr import GlmOCRGPTQ  # noqa: E402
 from .definitions.glm4_moe import GLM4MoEGPTQ  # noqa: E402
 from .definitions.glm4_moe_lite import Glm4MoeLiteQModel  # noqa: E402
 from .definitions.glm4v import Glm4vGPTQ  # noqa: E402
 from .definitions.glm_moe_dsa import GlmMoeDsaQModel  # noqa: E402
+from .definitions.glm_ocr import GlmOCRGPTQ  # noqa: E402
+from .definitions.glmasr import GlmASRGPTQ  # noqa: E402
 from .definitions.gpt2 import GPT2QModel  # noqa: E402
 from .definitions.gpt_bigcode import GptBigCodeQModel  # noqa: E402
 from .definitions.gpt_neo import GptNeoQModel  # noqa: E402

--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -87,6 +87,7 @@ from .definitions.dots1 import Dots1QModel  # noqa: E402
 from .definitions.dream import DreamQModel  # noqa: E402
 from .definitions.ernie4_5 import Ernie4_5QModel  # noqa: E402
 from .definitions.ernie4_5_moe import Ernie4_5_MoeQModel  # noqa: E402
+from .definitions.ernie4_5_vl_moe import Ernie4_5_VLMoeQModel  # noqa: E402
 from .definitions.exaone import ExaOneQModel  # noqa: E402
 from .definitions.exaone4 import Exaone4QModel  # noqa: E402
 from .definitions.falcon_h1 import FalconH1QModel  # noqa: E402
@@ -271,6 +272,8 @@ MODEL_MAP = {
     "gpt_pangu": PanguAlphaQModel,
     "ernie4_5": Ernie4_5QModel,
     "ernie4_5_moe": Ernie4_5_MoeQModel,
+    "ernie4_5_moe_vl": Ernie4_5_VLMoeQModel, # Backward Compatibility alias
+    "ernie4_5_vl_moe": Ernie4_5_VLMoeQModel,
     "seed_oss": LlamaQModel, # 100% llama clone
     "gpt_oss": GPTOSSGPTQ,
     "longcat_flash": LongCatFlashQModel,

--- a/gptqmodel/models/definitions/__init__.py
+++ b/gptqmodel/models/definitions/__init__.py
@@ -24,6 +24,7 @@ from .exaone import ExaOneQModel
 from .exaone4 import Exaone4QModel
 from .ernie4_5 import Ernie4_5QModel
 from .ernie4_5_moe import Ernie4_5_MoeQModel
+from .ernie4_5_vl_moe import Ernie4_5_VLMoeQModel
 from .gemma2 import Gemma2QModel
 from .gemma3 import Gemma3QModel
 from .gemma3n import Gemma3nForConditionalGenerationGPTQ, Gemma3nTextQModel

--- a/gptqmodel/models/definitions/ernie4_5_vl_moe.py
+++ b/gptqmodel/models/definitions/ernie4_5_vl_moe.py
@@ -1,0 +1,415 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import torch
+from PIL import Image
+from transformers import AutoModelForImageTextToText, AutoProcessor, ProcessorMixin
+from transformers.masking_utils import create_causal_mask
+
+from ..base import BaseQModel
+from ...utils.calibration import batched
+from ...utils.image import extract_vision_info, fetch_image
+from ...utils.model import MODALITY, get_module, get_module_by_name_prefix, move_to
+from ...utils.offload import offload_to_disk
+from .._const import CPU
+from .ernie4_5_moe import Ernie4_5_MoeQModel
+from ...utils.structure import print_module_tree
+
+
+class Ernie4_5_VLMoeQModel(BaseQModel):
+    loader = AutoModelForImageTextToText
+
+    require_load_processor = True
+    require_trust_remote_code = False
+    layer_modules_strict = False
+
+    pre_lm_head_norm_module = ["model.norm", "model.language_model.norm", "language_model.norm"]
+
+    modality = [MODALITY.TEXT, MODALITY.IMAGE_TO_TEXT]
+
+    module_tree = [
+        "model",
+        "language_model",
+        "layers",
+        "#",
+        {
+            "input_layernorm": ("input_layernorm:!",),
+            "self_attn": ("q_proj:0", "k_proj:0", "v_proj:0", "o_proj:1"),
+            "post_attention_layernorm": ("post_attention_layernorm:!",),
+            "mlp:moe": {
+                "gate_proj": ("gate_proj",),
+                "up_proj": ("up_proj",),
+                "down_proj": ("down_proj",),
+
+                "shared_experts": {
+                    "gate_proj": ("gate_proj:0",),
+                    "up_proj": ("up_proj:0",),
+                    "down_proj": ("down_proj:1",),
+                },
+                "text_moe": {
+                    "gate": ("gate:!",),
+                    "experts": {
+                        "#": ("gate_proj:0", "upe_proj:0", "down_proj:1"),
+                    },
+                },
+                "vision_moe": {
+                    "gate": ("gate:!",),
+                    "experts": {
+                        "#": ("gate_proj:0", "upe_proj:0", "down_proj:1"),
+                    },
+                }
+            },
+        }
+    ]
+
+    @classmethod
+    def extract_layers_node(cls):
+        return ["model.language_model.layers"]
+
+    @classmethod
+    def _resolve_multimodal_layout(cls, model):
+        for prefix in ("model", ""):
+            core_model = get_module(model, prefix) if prefix else model
+            if core_model is None:
+                continue
+            if hasattr(core_model, "language_model") and hasattr(core_model, "vision_tower"):
+                return prefix, core_model
+
+        raise AttributeError(
+            "Unable to resolve an ERNIE 4.5 VL MoE layout. Expected either "
+            "`model.language_model + model.vision_tower`."
+        )
+
+    @classmethod
+    def get_base_modules(cls, model):
+        prefix, core_model = cls._resolve_multimodal_layout(model)
+        base_modules = []
+        for name, _ in core_model.named_children():
+            if name != "language_model":
+                base_modules.append(f"{prefix}.{name}" if prefix else name)
+        return base_modules
+
+    def _materialize_module(self, parent, attr_name: str):
+        module = getattr(parent, attr_name, None)
+        if module is None:
+            return
+        if "_turtle_lock" not in self.__dict__ and "shell_module_materialize" not in self.__dict__:
+            setattr(parent, attr_name, move_to(module, device=self.quantize_config.device))
+            return
+        setattr(parent, attr_name, self.shell_module_materialize(module, self.quantize_config.device))
+
+    def _core_multimodal_model(self):
+        _, core_model = self._resolve_multimodal_layout(self.model)
+        return core_model
+
+    def pre_quantize_generate_hook_start(self):
+        core_model = self._core_multimodal_model()
+        language_model = core_model.language_model
+        self._materialize_module(core_model, "vision_tower")
+        self._materialize_module(language_model, "embed_tokens")
+        self._materialize_module(language_model, "rotary_emb")
+        self._materialize_module(core_model, "resampler_model")
+
+    def pre_quantize_generate_hook_end(self):
+        core_model = self._core_multimodal_model()
+        language_model = core_model.language_model
+        vision_module = core_model.vision_tower
+        resampler_module = core_model.resampler_model
+
+        if self.quantize_config.offload_to_disk:
+            if hasattr(language_model, "embed_tokens"):
+                offload_to_disk(
+                    model=language_model,
+                    module=language_model.embed_tokens,
+                    disk_path=self.quantize_config.offload_to_disk_path,
+                )
+            if hasattr(language_model, "rotary_emb"):
+                offload_to_disk(
+                    model=language_model,
+                    module=language_model.rotary_emb,
+                    disk_path=self.quantize_config.offload_to_disk_path,
+                )
+            if vision_module is not None:
+                offload_to_disk(
+                    model=core_model,
+                    module=vision_module,
+                    disk_path=self.quantize_config.offload_to_disk_path,
+                )
+            if resampler_module is not None:
+                offload_to_disk(
+                    model=core_model,
+                    module=resampler_module,
+                    disk_path=self.quantize_config.offload_to_disk_path,
+                )
+            return
+
+        if hasattr(language_model, "embed_tokens"):
+            language_model.embed_tokens = move_to(language_model.embed_tokens, device=CPU)
+        if hasattr(language_model, "rotary_emb"):
+            language_model.rotary_emb = move_to(language_model.rotary_emb, device=CPU)
+        if vision_module is not None:
+            setattr(core_model, vision_module, move_to(vision_module, device=CPU))
+        if resampler_module is not None:
+            setattr(core_model, resampler_module, move_to(resampler_module, device=CPU))
+
+    def lm_head_pre_quantize_generate_hook(self, inputs):
+        norm, _ = get_module_by_name_prefix(self.model, ["model.norm", "model.language_model.norm"])
+        if norm is None:
+            return inputs
+
+        norm = self.pre_quantize(norm)
+        for element in inputs:
+            for index in range(len(element)):
+                element[index] = norm(element[index])
+        self.post_quantize(norm)
+        return inputs
+
+    @staticmethod
+    def _flatten_multimodal_features(features: Any) -> torch.Tensor:
+        if torch.is_tensor(features):
+            return features
+        if isinstance(features, (list, tuple)):
+            return torch.cat(tuple(features), dim=0)
+        raise TypeError(f"Unsupported multimodal feature container: {type(features).__name__}")
+
+    @staticmethod
+    def _merge_placeholder_features(
+        *,
+        input_ids: torch.Tensor,
+        inputs_embeds: torch.Tensor,
+        token_id: int,
+        features: torch.Tensor,
+        label: str,
+    ) -> torch.Tensor:
+        token_mask = input_ids == token_id
+        token_count = int(token_mask.sum().item())
+        expected_numel = token_count * int(inputs_embeds.shape[-1])
+        actual_numel = int(features.numel())
+        feature_rows = int(features.shape[0]) if features.ndim > 0 else 0
+        if expected_numel != actual_numel:
+            raise ValueError(
+                f"{label} features and {label.lower()} tokens do not match, "
+                f"tokens: {token_count}, features: {feature_rows}"
+            )
+
+        expanded_mask = token_mask.unsqueeze(-1).expand_as(inputs_embeds).to(device=inputs_embeds.device)
+        return inputs_embeds.masked_scatter(
+            expanded_mask,
+            features.to(device=inputs_embeds.device, dtype=inputs_embeds.dtype),
+        )
+
+    @staticmethod
+    def _prepare_first_layer_position_inputs(
+        *,
+        language_model,
+        inputs_embeds: torch.Tensor,
+        position_ids: Optional[torch.Tensor],
+        past_key_values: Any,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor], tuple[torch.Tensor, torch.Tensor]]:
+        layer_position_ids = position_ids
+        if layer_position_ids is None:
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            layer_position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            layer_position_ids = layer_position_ids.view(1, 1, -1).expand(3, inputs_embeds.shape[0], -1)
+        elif layer_position_ids.ndim == 2:
+            layer_position_ids = layer_position_ids[None, ...].expand(3, layer_position_ids.shape[0], -1)
+
+        text_position_ids = None
+        if layer_position_ids.ndim == 3 and layer_position_ids.shape[0] == 4:
+            text_position_ids = layer_position_ids[0]
+            layer_position_ids = layer_position_ids[1:]
+
+        position_embeddings = language_model.rotary_emb(inputs_embeds, layer_position_ids)
+        return layer_position_ids, text_position_ids, position_embeddings
+
+    @staticmethod
+    def _resolve_token_id(model_config, primary: str, secondary: str) -> int:
+        if model_config is None:
+            raise AttributeError(f"Missing model config while resolving `{primary}`.")
+
+        value = getattr(model_config, primary, None)
+        if value is None:
+            value = getattr(model_config, secondary, None)
+        if value is None:
+            raise AttributeError(f"Neither `{primary}` nor `{secondary}` exists in model config.")
+        return int(value)
+
+    def run_input_capture(self, example, use_cache: bool, data_device):
+        input_ids = example.get("input_ids")
+        pixel_values = example.get("pixel_values")
+        pixel_values_videos = example.get("pixel_values_videos")
+        if input_ids is None or (pixel_values is None and pixel_values_videos is None):
+            return super().run_input_capture(example, use_cache=use_cache, data_device=data_device)
+
+        _, core_model = self._resolve_multimodal_layout(self.model)
+        language_model = core_model.language_model
+
+        attention_mask = example.get("attention_mask")
+        position_ids = example.get("position_ids")
+        past_key_values = example.get("past_key_values")
+        image_grid_thw = example.get("image_grid_thw")
+        video_grid_thw = example.get("video_grid_thw")
+        mm_token_type_ids = example.get("mm_token_type_ids")
+        moe_mm_token_type_ids = example.get("moe_mm_token_type_ids")
+
+        input_embedder = core_model.get_input_embeddings() if hasattr(core_model, "get_input_embeddings") else None
+        if input_embedder is None:
+            input_embedder = language_model.embed_tokens
+        inputs_embeds = input_embedder(input_ids)
+
+        model_config = getattr(self.model, "config", None)
+        print_module_tree(core_model)
+        if pixel_values is not None and hasattr(core_model, "get_image_features"):
+            image_outputs = core_model.get_image_features(
+                pixel_values=pixel_values,
+                image_grid_thw=image_grid_thw,
+            )
+            image_features = self._flatten_multimodal_features(image_outputs.pooler_output)
+            image_token_id = self._resolve_token_id(model_config, "image_token_id", "image_token_index")
+            inputs_embeds = self._merge_placeholder_features(
+                input_ids=input_ids,
+                inputs_embeds=inputs_embeds,
+                token_id=image_token_id,
+                features=image_features,
+                label="Image",
+            )
+
+        if pixel_values_videos is not None and hasattr(core_model, "get_video_features"):
+            video_outputs = core_model.get_video_features(
+                pixel_values_videos=pixel_values_videos,
+                video_grid_thw=video_grid_thw,
+            )
+            video_features = self._flatten_multimodal_features(video_outputs.pooler_output)
+            video_token_id = self._resolve_token_id(model_config, "video_token_id", "video_token_index")
+            inputs_embeds = self._merge_placeholder_features(
+                input_ids=input_ids,
+                inputs_embeds=inputs_embeds,
+                token_id=video_token_id,
+                features=video_features,
+                label="Video",
+            )
+
+        if position_ids is None and hasattr(core_model, "compute_3d_position_ids"):
+            position_ids = core_model.compute_3d_position_ids(
+                input_ids=input_ids,
+                inputs_embeds=inputs_embeds,
+                image_grid_thw=image_grid_thw,
+                video_grid_thw=video_grid_thw,
+                attention_mask=attention_mask,
+                past_key_values=past_key_values,
+                mm_token_type_ids=mm_token_type_ids,
+            )
+
+        passthrough_kwargs = {}
+        consumed = {
+            "input_ids",
+            "attention_mask",
+            "position_ids",
+            "past_key_values",
+            "pixel_values",
+            "pixel_values_videos",
+            "image_grid_thw",
+            "video_grid_thw",
+            "mm_token_type_ids",
+            "moe_mm_token_type_ids",
+            "rope_deltas",
+        }
+        for key, value in example.items():
+            if key not in consumed:
+                passthrough_kwargs[key] = value
+
+        layer_position_ids, text_position_ids, position_embeddings = self._prepare_first_layer_position_inputs(
+            language_model=language_model,
+            inputs_embeds=inputs_embeds,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+        )
+        causal_mask = create_causal_mask(
+            config=language_model.config,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            position_ids=text_position_ids,
+        )
+
+        return language_model.layers[0](
+            inputs_embeds,
+            attention_mask=causal_mask,
+            position_ids=layer_position_ids,
+            moe_mm_token_type_ids=moe_mm_token_type_ids,
+            past_key_values=past_key_values,
+            position_embeddings=position_embeddings,
+            **passthrough_kwargs,
+        )
+
+    @staticmethod
+    def process_vision_info(
+            conversations: list[dict] | list[list[dict]],
+    ) -> Optional[list[Image.Image]]:
+        vision_infos = extract_vision_info(conversations)
+        image_inputs = []
+        for vision_info in vision_infos:
+            if "image" in vision_info or "image_url" in vision_info:
+                image_inputs.append(fetch_image(vision_info))
+            else:
+                raise ValueError("image, image_url should in content.")
+
+        if len(image_inputs) == 0:
+            image_inputs = None
+        return image_inputs
+
+    def preprocess_dataset(self, sample: Dict) -> Dict:
+        return sample
+
+    def load_processor(self) -> ProcessorMixin:
+        return AutoProcessor.from_pretrained(self.model_local_path, trust_remote_code=self.trust_remote_code)
+
+    def prepare_dataset(self, calibration_dataset, batch_size: int = 1, **kwargs):
+        processor = self.load_processor()
+        calib_data = []
+        for batch in batched(calibration_dataset, batch_size, process_func=self.preprocess_dataset):
+            text = processor.apply_chat_template(
+                batch, tokenize=False, add_generation_prompt=True
+            )
+            image_inputs = self.process_vision_info(batch)
+            inputs = processor(
+                text=text,
+                images=image_inputs,
+                videos=None,
+                padding=True,
+                return_tensors="pt",
+            )
+            calib_data.append(inputs)
+        del processor
+        return calib_data
+
+    def before_model_load(self, model_local_path: str, load_quantized_model: bool):
+        from transformers.dynamic_module_utils import get_class_from_dynamic_module
+
+        try:
+            decoder_cls = get_class_from_dynamic_module(
+                "modeling_ernie4_5_vl.Ernie4_5_DecoderLayer",
+                model_local_path,
+            )
+        except Exception:
+            return
+
+        if getattr(decoder_cls, "_gptqmodel_vl_moe_patched", False):
+            return
+
+        if not hasattr(decoder_cls, "mlp_text"):
+            def mlp_text(self):
+                return self.mlp
+
+            decoder_cls.mlp_text = mlp_text
+
+        decoder_cls._gptqmodel_vl_moe_patched = True
+
+
+__all__ = ["Ernie4_5_VLMoeQModel"]

--- a/gptqmodel/models/definitions/ernie4_5_vl_moe.py
+++ b/gptqmodel/models/definitions/ernie4_5_vl_moe.py
@@ -12,14 +12,13 @@ from PIL import Image
 from transformers import AutoModelForImageTextToText, AutoProcessor, ProcessorMixin
 from transformers.masking_utils import create_causal_mask
 
-from ..base import BaseQModel
 from ...utils.calibration import batched
 from ...utils.image import extract_vision_info, fetch_image
 from ...utils.model import MODALITY, get_module, get_module_by_name_prefix, move_to
 from ...utils.offload import offload_to_disk
-from .._const import CPU
-from .ernie4_5_moe import Ernie4_5_MoeQModel
 from ...utils.structure import print_module_tree
+from .._const import CPU
+from ..base import BaseQModel
 
 
 class Ernie4_5_VLMoeQModel(BaseQModel):

--- a/gptqmodel/models/definitions/falcon_mamba.py
+++ b/gptqmodel/models/definitions/falcon_mamba.py
@@ -64,7 +64,6 @@ class FalconMambaQModel(BaseQModel):
         self._restore_falcon_mamba_rms_buffers(self.model)
 
     def monkey_patch(self):
-        from gptqmodel.nn_modules.qlinear import BaseQuantLinear
         from transformers.models.falcon_mamba.modeling_falcon_mamba import (
             causal_conv1d_fn,
             causal_conv1d_update,
@@ -73,6 +72,8 @@ class FalconMambaQModel(BaseQModel):
             selective_scan_fn,
             selective_state_update,
         )
+
+        from gptqmodel.nn_modules.qlinear import BaseQuantLinear
 
         is_fast_path_available = all(
             (

--- a/gptqmodel/models/definitions/glmasr.py
+++ b/gptqmodel/models/definitions/glmasr.py
@@ -4,6 +4,7 @@
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 
 from transformers import AutoModel
+
 from ..base import BaseQModel
 
 

--- a/gptqmodel/quantization/config.py
+++ b/gptqmodel/quantization/config.py
@@ -22,6 +22,7 @@ from packaging import version
 from ..adapter.adapter import Lora, normalize_adapter
 from ..utils.logger import setup_logger
 
+
 log = setup_logger()
 
 

--- a/gptqmodel/utils/structure.py
+++ b/gptqmodel/utils/structure.py
@@ -673,6 +673,47 @@ class _LazyWeightRenaming:
         return renamed_key, source_pattern_that_matched
 
 
+@dataclass
+class _LazyWeightConverter:
+    """Runtime->checkpoint key hints for HF `WeightConverter` entries.
+
+    LazyTurtle only materializes the tensors needed by the current shell module,
+    so it cannot run HF's full many-key conversion pipeline eagerly. This stores
+    enough metadata to resolve direct converted tensors and ERNIE split expert
+    leaves back to their checkpoint sources.
+    """
+
+    source_patterns: list[str] | str
+    target_patterns: list[str] | str
+    operations: list[Any]
+
+    def __post_init__(self) -> None:
+        self.source_patterns = _LazyWeightRenaming._coerce_patterns(self.source_patterns)
+        self.target_patterns = _LazyWeightRenaming._coerce_patterns(self.target_patterns)
+        self.operations = list(self.operations or [])
+
+    @property
+    def operation_names(self) -> tuple[str, ...]:
+        return tuple(type(operation).__name__ for operation in self.operations)
+
+    def iter_direct_renamings(self) -> Iterable[_LazyWeightRenaming]:
+        if not self.operations:
+            return
+
+        if len(self.source_patterns) == 1 and len(self.target_patterns) == 1:
+            yield _LazyWeightRenaming(self.source_patterns[0], self.target_patterns[0])
+            return
+
+        if len(self.target_patterns) == 1:
+            for source_pattern in self.source_patterns:
+                yield _LazyWeightRenaming(source_pattern, self.target_patterns[0])
+            return
+
+        if len(self.source_patterns) == len(self.target_patterns):
+            for source_pattern, target_pattern in zip(self.source_patterns, self.target_patterns):
+                yield _LazyWeightRenaming(source_pattern, target_pattern)
+
+
 class LazyTurtle:
     """Checkpoint-backed shell materializer for local dense checkpoints.
 
@@ -712,14 +753,16 @@ class LazyTurtle:
         # Lazy checkpoint name resolution must come from model-definition truth.
         self._module_tree = copy.deepcopy(module_tree)
         self._module_tree_layer_prefix, self._moe_alias_specs = self._build_moe_alias_specs(self._module_tree)
-        # Resolve runtime->checkpoint renamings once up front so per-tensor
-        # lookups can apply the same renaming order as HF loading.
-        alias_items = self._normalize_runtime_to_checkpoint_renamings(
+        # Resolve runtime->checkpoint aliases once up front so per-tensor
+        # lookups can apply the same mapping order as HF loading.
+        conversion_aliases = (
             hf_conversion_map_reversed
             if hf_conversion_map_reversed is not None
-            else self.infer_hf_conversion_map_reversed(target_model=target_model),
+            else self.infer_hf_conversion_map_reversed(target_model=target_model)
         )
+        alias_items = self._normalize_runtime_to_checkpoint_renamings(conversion_aliases)
         self._runtime_to_checkpoint_renamings = tuple(alias_items)
+        self._runtime_to_checkpoint_converters = self._normalize_runtime_to_checkpoint_converters(conversion_aliases)
         self._lock = threading.RLock()
 
     @classmethod
@@ -968,6 +1011,20 @@ class LazyTurtle:
         return source_patterns[0], target_patterns[0]
 
     @classmethod
+    def _extract_weight_converter_patterns(cls, entry: Any) -> Optional[tuple[list[str], list[str], list[Any]]]:
+        operations = getattr(entry, "operations", None)
+        if not operations:
+            return None
+
+        source_patterns = getattr(entry, "_original_source_patterns", getattr(entry, "source_patterns", None))
+        target_patterns = getattr(entry, "_original_target_patterns", getattr(entry, "target_patterns", None))
+        source_patterns = cls._coerce_patterns(source_patterns)
+        target_patterns = cls._coerce_patterns(target_patterns)
+        if not source_patterns or not target_patterns:
+            return None
+        return source_patterns, target_patterns, list(operations)
+
+    @classmethod
     def _normalize_runtime_to_checkpoint_renamings(cls, raw_aliases: Optional[Any]) -> tuple[_LazyWeightRenaming, ...]:
         renamings: list[_LazyWeightRenaming] = []
         if raw_aliases is None:
@@ -999,6 +1056,25 @@ class LazyTurtle:
         return tuple(renamings)
 
     @classmethod
+    def _normalize_runtime_to_checkpoint_converters(cls, raw_aliases: Optional[Any]) -> tuple[_LazyWeightConverter, ...]:
+        converters: list[_LazyWeightConverter] = []
+        if raw_aliases is None or isinstance(raw_aliases, dict) or not isinstance(raw_aliases, (list, tuple)):
+            return ()
+
+        for entry in raw_aliases:
+            if isinstance(entry, _LazyWeightConverter):
+                converters.append(entry)
+                continue
+
+            patterns = cls._extract_weight_converter_patterns(entry)
+            if patterns is None:
+                continue
+            runtime_patterns, checkpoint_patterns, operations = patterns
+            converters.append(_LazyWeightConverter(runtime_patterns, checkpoint_patterns, operations))
+
+        return tuple(converters)
+
+    @classmethod
     def _iter_hf_conversion_pairs(cls, conversion_mapping: Optional[Any]) -> Iterable[tuple[str, str]]:
         if isinstance(conversion_mapping, dict):
             for checkpoint_pattern, runtime_prefix in conversion_mapping.items():
@@ -1015,12 +1091,29 @@ class LazyTurtle:
                 yield patterns
 
     @classmethod
-    def reverse_hf_conversion_map(cls, conversion_mapping: Optional[Any]) -> Optional[list[_LazyWeightRenaming]]:
-        """Invert simple HF checkpoint renames into reversed `WeightRenaming`-style rules."""
-        reversed_map: list[_LazyWeightRenaming] = []
-        for checkpoint_pattern, runtime_prefix in cls._iter_hf_conversion_pairs(conversion_mapping):
-            reversed_map.append(_LazyWeightRenaming(runtime_prefix, checkpoint_pattern))
+    def reverse_hf_conversion_map(cls, conversion_mapping: Optional[Any]) -> Optional[list[_LazyWeightRenaming | _LazyWeightConverter]]:
+        """Invert HF checkpoint conversion entries for LazyTurtle lookup."""
+        reversed_map: list[_LazyWeightRenaming | _LazyWeightConverter] = []
+        if isinstance(conversion_mapping, dict):
+            for checkpoint_pattern, runtime_prefix in cls._iter_hf_conversion_pairs(conversion_mapping):
+                reversed_map.append(_LazyWeightRenaming(runtime_prefix, checkpoint_pattern))
+            return reversed_map or None
 
+        if not isinstance(conversion_mapping, (list, tuple)):
+            return None
+
+        for entry in conversion_mapping:
+            converter_patterns = cls._extract_weight_converter_patterns(entry)
+            if converter_patterns is not None:
+                checkpoint_patterns, runtime_patterns, operations = converter_patterns
+                reversed_map.append(_LazyWeightConverter(runtime_patterns, checkpoint_patterns, operations))
+                continue
+
+            renaming_patterns = cls._extract_weight_renaming_patterns(entry)
+            if renaming_patterns is None:
+                continue
+            checkpoint_pattern, runtime_prefix = renaming_patterns
+            reversed_map.append(_LazyWeightRenaming(runtime_prefix, checkpoint_pattern))
         return reversed_map or None
 
     @classmethod
@@ -1283,6 +1376,35 @@ class LazyTurtle:
             candidates.append(renamed)
         return candidates
 
+    def _converter_direct_alias_candidates(self, name: str) -> list[str]:
+        if not name:
+            return []
+
+        candidates: list[str] = []
+        for converter in self._runtime_to_checkpoint_converters:
+            # This ERNIE op is many-to-many; it needs expert-index math instead
+            # of a direct string rewrite.
+            if "ErnieFuseAndSplitTextVisionExperts" in converter.operation_names:
+                continue
+            for renaming in converter.iter_direct_renamings():
+                renamed, _ = renaming.rename_source_key(name)
+                if renamed != name and renamed not in candidates:
+                    candidates.append(renamed)
+        return candidates
+
+    def _all_runtime_to_checkpoint_candidates(self, name: str) -> list[str]:
+        candidates = self._runtime_to_checkpoint_alias_candidates(name)
+        for candidate in tuple(candidates):
+            # Include aliases derived from simple WeightConverter entries
+            # such as Transpose-backed one-to-one gate renames.
+            for converted in self._converter_direct_alias_candidates(candidate):
+                if converted not in candidates:
+                    candidates.append(converted)
+                for aliased in self._runtime_to_checkpoint_alias_candidates(converted):
+                    if aliased not in candidates:
+                        candidates.append(aliased)
+        return candidates
+
     def _resolve_checkpoint_module_path(self, module_path: str) -> str:
         """Resolve a shell module path to the checkpoint path when wrappers add extra roots."""
 
@@ -1328,9 +1450,9 @@ class LazyTurtle:
                 candidates.append(alias)
 
         for candidate_path in self._candidate_module_paths(module_path, allow_empty=True):
-            for aliased_path in self._runtime_to_checkpoint_alias_candidates(candidate_path):
+            for aliased_path in self._all_runtime_to_checkpoint_candidates(candidate_path):
                 candidate_name = self._join_tensor_name(aliased_path, rel_name)
-                for aliased_name in self._runtime_to_checkpoint_alias_candidates(candidate_name):
+                for aliased_name in self._all_runtime_to_checkpoint_candidates(candidate_name):
                     add_candidate(aliased_name)
 
         for candidate in candidates:
@@ -1413,6 +1535,129 @@ class LazyTurtle:
                     return candidate_name, expert_index, split_index, split_dim
 
             return None, None, None, None
+
+        return None, None, None, None
+
+    def _checkpoint_indices_for_wildcard_pattern(self, wildcard_name: str) -> list[int]:
+        aliases = self._all_runtime_to_checkpoint_candidates(wildcard_name)
+        indices: set[int] = set()
+        for alias in aliases:
+            # HF expert mappings use one `*` for the expert index.
+            pattern = "^" + re.escape(alias).replace(r"\*", r"(\d+)") + "$"
+            compiled = re.compile(pattern)
+            for checkpoint_name in self._weight_map:
+                match = compiled.match(checkpoint_name)
+                if match is not None:
+                    indices.add(int(match.group(1)))
+        return sorted(indices)
+
+    def _resolve_ernie_text_vision_expert_tensor_name(
+        self,
+        module_path: str,
+        rel_name: str,
+    ) -> tuple[Optional[str], Optional[int], Optional[int], Optional[int]]:
+        combined_name = self._join_tensor_name(module_path, rel_name)
+        for converter in self._runtime_to_checkpoint_converters:
+            if "ErnieFuseAndSplitTextVisionExperts" not in converter.operation_names:
+                continue
+
+            target_count = len(converter.source_patterns)
+            if target_count == 0:
+                continue
+
+            for modality_index, runtime_pattern in enumerate(converter.source_patterns):
+                marker = ".experts."
+                if marker not in runtime_pattern:
+                    continue
+                modality_prefix = runtime_pattern.split(marker, 1)[0]
+                runtime_marker = f"{modality_prefix}.experts."
+                marker_index = combined_name.find(runtime_marker)
+                if marker_index < 0:
+                    continue
+
+                prefix = combined_name[:marker_index]
+                suffix = combined_name[marker_index + len(runtime_marker):]
+                expert_index_text, sep, leaf_name = suffix.partition(".")
+                if not sep or not expert_index_text.isdigit():
+                    continue
+
+                runtime_expert_index = int(expert_index_text)
+                source_pattern = None
+                if leaf_name.startswith("gate_proj."):
+                    source_pattern = next(
+                        (pattern for pattern in converter.target_patterns if ".gate_proj." in pattern),
+                        None,
+                    )
+                elif leaf_name.startswith("up_proj."):
+                    source_pattern = next(
+                        (pattern for pattern in converter.target_patterns if ".up_proj." in pattern),
+                        None,
+                    )
+                elif leaf_name.startswith("down_proj."):
+                    source_pattern = next(
+                        (pattern for pattern in converter.target_patterns if ".down_proj." in pattern),
+                        None,
+                    )
+                if source_pattern is None or "*" not in source_pattern:
+                    continue
+
+                wildcard_name = f"{prefix}{source_pattern}"
+                source_indices = self._checkpoint_indices_for_wildcard_pattern(wildcard_name)
+                if not source_indices:
+                    continue
+
+                # HF splits the original expert list into text and vision halves
+                # before fusing gate/up. Map the runtime modality-local index
+                # back to the original checkpoint expert index.
+                chunk_size = (len(source_indices) + target_count - 1) // target_count
+                source_position = modality_index * chunk_size + runtime_expert_index
+                if source_position >= len(source_indices):
+                    continue
+
+                checkpoint_expert_index = source_indices[source_position]
+                checkpoint_name = f"{prefix}{source_pattern.replace('*', str(checkpoint_expert_index))}"
+                for candidate in self._all_runtime_to_checkpoint_candidates(checkpoint_name):
+                    if candidate in self._weight_map:
+                        return candidate, None, None, None
+
+        return None, None, None, None
+
+    def _resolve_converter_tensor_source(
+        self,
+        module_path: str,
+        rel_name: str,
+    ) -> tuple[Optional[str], Optional[int], Optional[int], Optional[int]]:
+        combined_name = self._join_tensor_name(module_path, rel_name)
+        for converter in self._runtime_to_checkpoint_converters:
+            if "ErnieFuseAndSplitTextVisionExperts" in converter.operation_names:
+                continue
+
+            for source_index, runtime_pattern in enumerate(converter.source_patterns):
+                if len(converter.target_patterns) == 1:
+                    checkpoint_pattern = converter.target_patterns[0]
+                elif source_index < len(converter.target_patterns):
+                    checkpoint_pattern = converter.target_patterns[source_index]
+                else:
+                    continue
+
+                renamed, matched_pattern = _LazyWeightRenaming(
+                    runtime_pattern,
+                    checkpoint_pattern,
+                ).rename_source_key(combined_name)
+                if matched_pattern is None or renamed == combined_name:
+                    continue
+
+                split_index = None
+                split_dim = None
+                if converter.operation_names[:1] == ("Chunk",) and len(converter.source_patterns) > 1:
+                    # Chunk converters share one checkpoint tensor across
+                    # multiple runtime tensors; preserve the selected slice.
+                    split_index = source_index
+                    split_dim = getattr(converter.operations[0], "dim", 0)
+
+                for candidate in self._runtime_to_checkpoint_alias_candidates(renamed):
+                    if candidate in self._weight_map:
+                        return candidate, None, split_index, split_dim
 
         return None, None, None, None
 
@@ -1523,6 +1768,15 @@ class LazyTurtle:
         """Resolve a target tensor name to its checkpoint source and optional fused split index."""
 
         full_name = self._resolve_checkpoint_tensor_name(module_path, rel_name)
+
+        resolved = self._resolve_converter_tensor_source(module_path, rel_name)
+        if resolved[0] is not None:
+            return resolved
+
+        resolved = self._resolve_ernie_text_vision_expert_tensor_name(module_path, rel_name)
+        if resolved[0] is not None:
+            return resolved
+
         if full_name in self._weight_map:
             return full_name, None, None, None
 

--- a/tests/eval.py
+++ b/tests/eval.py
@@ -14,6 +14,7 @@ from gptqmodel.utils.backend import BACKEND
 from gptqmodel.utils.inspect import safe_kwargs_call
 from gptqmodel.utils.logger import render_table
 
+
 _MMLU_LOCAL_DATASET = Path("/monster/data/model/dataset/hails-mmlu_no_train")
 _GSM8K_LOCAL_DATASET = Path("/monster/data/model/dataset/gsm8k")
 _ENGINE_OPTION_KEYS = {

--- a/tests/models/ovis/image_to_test_dataset.py
+++ b/tests/models/ovis/image_to_test_dataset.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
 # SPDX-License-Identifier: Apache-2.0
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
-
+from gptqmodel.models.definitions.ernie4_5_vl_moe import Ernie4_5_VLMoeQModel
 from gptqmodel.models.definitions.base_qwen2_5_omni import BaseQwen2_5_OmniGPTQ
 from gptqmodel.models.definitions.base_qwen2_vl import BaseQwen2VLGPTQ
 from gptqmodel.models.definitions.minicpm_o import MiniCPMOQModel
@@ -99,6 +99,7 @@ def get_calib_dataset(model):
         or isinstance(model, MiniCPMOQModel)
         or isinstance(model, MiniCPMVQModel)
         or isinstance(model, InternVLChatQModel)
+        or isinstance(model, Ernie4_5_VLMoeQModel)
     ):
         return prepare_dataset(format_qwen2_vl_dataset, n_sample=20)
 

--- a/tests/models/ovis/image_to_test_dataset.py
+++ b/tests/models/ovis/image_to_test_dataset.py
@@ -2,14 +2,14 @@
 # SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
 # SPDX-License-Identifier: Apache-2.0
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
-from gptqmodel.models.definitions.ernie4_5_vl_moe import Ernie4_5_VLMoeQModel
 from gptqmodel.models.definitions.base_qwen2_5_omni import BaseQwen2_5_OmniGPTQ
 from gptqmodel.models.definitions.base_qwen2_vl import BaseQwen2VLGPTQ
+from gptqmodel.models.definitions.ernie4_5_vl_moe import Ernie4_5_VLMoeQModel
+from gptqmodel.models.definitions.internvl_chat import InternVLChatQModel
 from gptqmodel.models.definitions.minicpm_o import MiniCPMOQModel
 from gptqmodel.models.definitions.minicpm_v import MiniCPMVQModel
 from gptqmodel.models.definitions.ovis import OvisQModel
 from gptqmodel.models.definitions.ovis2 import Ovis2QModel
-from gptqmodel.models.definitions.internvl_chat import InternVLChatQModel
 from gptqmodel.models.definitions.qwen3_vl import Qwen3_VLQModel
 
 

--- a/tests/models/test_ernie4_5_moe_vl.py
+++ b/tests/models/test_ernie4_5_moe_vl.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from model_test import ModelTest
+
+from gptqmodel.models.definitions.qwen3_vl import Qwen3_VLQModel
+
+
+class TestQwen3_VL(ModelTest):
+    NATIVE_MODEL_ID = "/monster/data/model/ERNIE-4.5-VL-28B-A3B-PT"
+    EVAL_TASKS_SLOW = {
+        "arc_challenge": {
+            "chat_template": True,
+            "acc": {"value": 0.3618, "floor_pct": 0.04},
+            "acc_norm": {"value": 00.3882, "floor_pct": 0.04},
+        },
+    }
+    EVAL_TASKS_FAST = ModelTest.derive_fast_eval_tasks(EVAL_TASKS_SLOW)
+    TRUST_REMOTE_CODE = False
+    EVAL_BATCH_SIZE = 6
+    USE_FLASH_ATTN = False
+    MODEL_COMPAT_FAST_LAYER_POSITION = "first"
+
+    def test_qwen3_vl(self):
+        with self.model_compat_test_context():
+            model, tokenizer, processor = self.quantModel(self.NATIVE_MODEL_ID, trust_remote_code=self.TRUST_REMOTE_CODE,
+                                                          dtype=self.TORCH_DTYPE)
+
+        # check image to text
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "image": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg",
+                    },
+                    {"type": "text", "text": "Describe this image."},
+                ],
+            }
+        ]
+        # Preparation for inference
+        text = processor.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+
+        image_inputs = Qwen3_VLQModel.process_vision_info(messages)
+        inputs = processor(
+            text=[text],
+            images=image_inputs,
+            videos=None,
+            padding=True,
+            return_tensors="pt",
+        )
+        inputs = inputs.to("cuda")
+
+        # Inference: Generation of the output
+        output_text = self.generate_stable_with_limit(
+            model,
+            processor,
+            inputs=inputs,
+            max_new_tokens=128,
+            batch_decode=True,
+            clean_up_tokenization_spaces=False,
+        )
+        print("output_text:", output_text)
+
+        self.assertIn("dog", output_text)
+
+
+        # check evaluation results
+        self.check_kernel(model, self.KERNEL_INFERENCE)
+
+        with self.model_compat_test_context():
+            task_results = self.evaluate_model(model=model,
+                                        trust_remote_code=self.TRUST_REMOTE_CODE,
+                                        delete_quantized_model=self.DELETE_QUANTIZED_MODEL)
+        self.check_results(task_results)

--- a/tests/models/test_ernie4_5_moe_vl.py
+++ b/tests/models/test_ernie4_5_moe_vl.py
@@ -2,10 +2,10 @@
 # SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
 # SPDX-License-Identifier: Apache-2.0
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
+import os
 
 from model_test import ModelTest
-
-from gptqmodel.models.definitions.qwen3_vl import Qwen3_VLQModel
+from PIL import Image
 
 
 class TestQwen3_VL(ModelTest):
@@ -13,13 +13,12 @@ class TestQwen3_VL(ModelTest):
     EVAL_TASKS_SLOW = {
         "arc_challenge": {
             "chat_template": True,
-            "acc": {"value": 0.3618, "floor_pct": 0.04},
-            "acc_norm": {"value": 00.3882, "floor_pct": 0.04},
+            "acc": {"value": 0.5094, "floor_pct": 0.04},
+            "acc_norm": {"value": 0.4991, "floor_pct": 0.04},
         },
     }
     EVAL_TASKS_FAST = ModelTest.derive_fast_eval_tasks(EVAL_TASKS_SLOW)
     TRUST_REMOTE_CODE = False
-    EVAL_BATCH_SIZE = 6
     USE_FLASH_ATTN = False
     MODEL_COMPAT_FAST_LAYER_POSITION = "first"
 
@@ -28,46 +27,31 @@ class TestQwen3_VL(ModelTest):
             model, tokenizer, processor = self.quantModel(self.NATIVE_MODEL_ID, trust_remote_code=self.TRUST_REMOTE_CODE,
                                                           dtype=self.TORCH_DTYPE)
 
-        # check image to text
         messages = [
             {
                 "role": "user",
                 "content": [
-                    {
-                        "type": "image",
-                        "image": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg",
-                    },
-                    {"type": "text", "text": "Describe this image."},
-                ],
-            }
+                    {"type": "text",
+                     "text": "Only use English during your responses and describe the following image."},
+                    {"type": "image"},
+                ]
+            },
         ]
-        # Preparation for inference
-        text = processor.apply_chat_template(
-            messages, tokenize=False, add_generation_prompt=True
+        text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        image_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ovis/10016.jpg")
+        image = Image.open(image_path)
+        inputs = processor(text=[text], images=[image], return_tensors="pt").to(model.device)
+
+        generated_ids = model.generate(
+            **inputs,
+            max_new_tokens=64,
+            do_sample=False,
         )
 
-        image_inputs = Qwen3_VLQModel.process_vision_info(messages)
-        inputs = processor(
-            text=[text],
-            images=image_inputs,
-            videos=None,
-            padding=True,
-            return_tensors="pt",
-        )
-        inputs = inputs.to("cuda")
-
-        # Inference: Generation of the output
-        output_text = self.generate_stable_with_limit(
-            model,
-            processor,
-            inputs=inputs,
-            max_new_tokens=128,
-            batch_decode=True,
-            clean_up_tokenization_spaces=False,
-        )
+        output_text = processor.decode(generated_ids[0][len(inputs['input_ids'][0]):])
         print("output_text:", output_text)
 
-        self.assertIn("dog", output_text)
+        self.assertIn("snow", output_text)
 
 
         # check evaluation results

--- a/tests/models/test_falcon_mamba.py
+++ b/tests/models/test_falcon_mamba.py
@@ -4,9 +4,9 @@
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 
 import torch  # noqa: E402
+from model_test import ModelTest
 
 from gptqmodel import BACKEND
-from model_test import ModelTest
 
 
 class TestFalcon(ModelTest):

--- a/tests/test_awq_inference_llm_awq.py
+++ b/tests/test_awq_inference_llm_awq.py
@@ -4,9 +4,10 @@
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 
 import pytest
-
 from awq_test_utils import run_inference_only_generation_test
+
 from gptqmodel import BACKEND
+
 
 pytestmark = [pytest.mark.model, pytest.mark.slow]
 

--- a/tests/test_causal_conv1d_port.py
+++ b/tests/test_causal_conv1d_port.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
 # SPDX-License-Identifier: Apache-2.0
 
+import causal_conv1d
 import torch
 import torch.nn.functional as F
 
-import causal_conv1d
 import gptqmodel.hf_kernels.mamba_ssm as local_mamba_ssm
 
 

--- a/tests/test_lazy_turtle_conversion_mapping.py
+++ b/tests/test_lazy_turtle_conversion_mapping.py
@@ -89,6 +89,32 @@ class _WeightRenamingStub:
         self.operations = []
 
 
+# Minimal operation stubs: LazyTurtle only inspects operation names and small
+# attributes, so tests do not need to import Transformers internals.
+class Transpose:
+    def __init__(self, dim0: int = 0, dim1: int = 1):
+        self.dim0 = dim0
+        self.dim1 = dim1
+
+
+class Chunk:
+    def __init__(self, dim: int = 0):
+        self.dim = dim
+
+
+class ErnieFuseAndSplitTextVisionExperts:
+    def __init__(self, stack_dim: int = 0, concat_dim: int = 1):
+        self.stack_dim = stack_dim
+        self.concat_dim = concat_dim
+
+
+class _WeightConverterStub:
+    def __init__(self, source_patterns: str | list[str], target_patterns: str | list[str], operations: list[object]):
+        self.source_patterns = [source_patterns] if isinstance(source_patterns, str) else source_patterns
+        self.target_patterns = [target_patterns] if isinstance(target_patterns, str) else target_patterns
+        self.operations = operations
+
+
 class _ConvertibleCheckpointModel(nn.Module):
     from_pretrained_calls = []
     save_pretrained_calls = []
@@ -338,6 +364,116 @@ def test_lazy_turtle_applies_reversed_weight_renamings_inside_module_relative_na
             "spatial_linear.ln.weight",
         )
         == "model.resampler_model.spatial_linear.3.weight"
+    )
+
+
+def test_lazy_turtle_applies_one_to_one_weight_converter_aliases(tmp_path):
+    # Transpose converters still need a runtime->checkpoint key alias; shape
+    # handling is verified later during tensor materialization.
+    reversed_map = LazyTurtle.reverse_hf_conversion_map(
+        [
+            _WeightConverterStub(
+                source_patterns="mlp.gate.weight",
+                target_patterns="mlp.text_moe.gate.weight",
+                operations=[Transpose(dim0=0, dim1=1)],
+            )
+        ]
+    )
+
+    turtle = _build_lazy_turtle(
+        tmp_path,
+        {
+            "model.layers.0.mlp.gate.weight": torch.zeros(4, 2),
+        },
+        hf_conversion_map_reversed=reversed_map,
+    )
+
+    assert (
+        turtle._resolve_checkpoint_tensor_name(
+            "model.layers.0.mlp.text_moe.gate",
+            "weight",
+        )
+        == "model.layers.0.mlp.gate.weight"
+    )
+
+
+def test_lazy_turtle_preserves_chunk_weight_converter_split_info(tmp_path):
+    # Chunk maps multiple runtime tensors to slices of the same checkpoint key.
+    reversed_map = LazyTurtle.reverse_hf_conversion_map(
+        [
+            _WeightConverterStub(
+                source_patterns="mlp.moe_statics.e_score_correction_bias",
+                target_patterns=[
+                    "mlp.text_moe.gate.moe_statics.e_score_correction_bias",
+                    "mlp.vision_moe.gate.moe_statics.e_score_correction_bias",
+                ],
+                operations=[Chunk(dim=0)],
+            )
+        ]
+    )
+
+    turtle = _build_lazy_turtle(
+        tmp_path,
+        {
+            "model.layers.0.mlp.moe_statics.e_score_correction_bias": torch.zeros(2, 4),
+        },
+        hf_conversion_map_reversed=reversed_map,
+    )
+
+    assert turtle._resolve_checkpoint_tensor_source(
+        "model.layers.0.mlp.vision_moe.gate.moe_statics",
+        "e_score_correction_bias",
+    ) == (
+        "model.layers.0.mlp.moe_statics.e_score_correction_bias",
+        None,
+        1,
+        0,
+    )
+
+
+def test_lazy_turtle_resolves_ernie_text_vision_defused_experts_from_converter(tmp_path):
+    # ERNIE VL stores experts as one checkpoint list; runtime exposes separate
+    # text and vision expert lists.
+    reversed_map = LazyTurtle.reverse_hf_conversion_map(
+        [
+            _WeightConverterStub(
+                source_patterns=[
+                    "experts.*.gate_proj.weight",
+                    "experts.*.up_proj.weight",
+                ],
+                target_patterns=[
+                    "text_moe.experts.gate_up_proj",
+                    "vision_moe.experts.gate_up_proj",
+                ],
+                operations=[ErnieFuseAndSplitTextVisionExperts(stack_dim=0, concat_dim=1)],
+            )
+        ]
+    )
+
+    checkpoint_tensors = {}
+    for index in range(4):
+        checkpoint_tensors[f"model.layers.0.mlp.experts.{index}.gate_proj.weight"] = torch.zeros(2, 2)
+        checkpoint_tensors[f"model.layers.0.mlp.experts.{index}.up_proj.weight"] = torch.zeros(2, 2)
+
+    turtle = _build_lazy_turtle(
+        tmp_path,
+        checkpoint_tensors,
+        hf_conversion_map_reversed=reversed_map,
+    )
+
+    assert (
+        turtle._resolve_checkpoint_tensor_source(
+            "model.layers.0.mlp.text_moe.experts.1.gate_proj",
+            "weight",
+        )[0]
+        == "model.layers.0.mlp.experts.1.gate_proj.weight"
+    )
+    assert (
+        turtle._resolve_checkpoint_tensor_source(
+            "model.layers.0.mlp.vision_moe.experts.1.up_proj",
+            "weight",
+        )[0]
+        == "model.layers.0.mlp.experts.3.up_proj.weight"
     )
 
 

--- a/tests/test_npu_support.py
+++ b/tests/test_npu_support.py
@@ -12,11 +12,10 @@ from gptqmodel.nn_modules.qlinear.fp8 import TorchFP8Linear
 from gptqmodel.nn_modules.qlinear.gguf import GGUFTorchLinear
 from gptqmodel.nn_modules.qlinear.paroquant import ParoLinear
 from gptqmodel.nn_modules.qlinear.qqq import QQQTorchLinear
-from gptqmodel.nn_modules.qlinear.torch import TorchLinear
-from gptqmodel.nn_modules.qlinear.torch import _right_shift_unpack
+from gptqmodel.nn_modules.qlinear.torch import TorchLinear, _right_shift_unpack
 from gptqmodel.nn_modules.qlinear.torch_awq import AwqTorchLinear
-from gptqmodel.quantization.awq.utils.packing_utils import unpack_awq
 from gptqmodel.quantization import FORMAT, METHOD
+from gptqmodel.quantization.awq.utils.packing_utils import unpack_awq
 from gptqmodel.utils import importer
 from gptqmodel.utils.backend import BACKEND
 from gptqmodel.utils.importer import auto_select_device, get_kernel_for_backend, select_quant_linear

--- a/tests/test_quant_and_eora_transformers.py
+++ b/tests/test_quant_and_eora_transformers.py
@@ -6,6 +6,7 @@
 # -- do not touch
 import os
 
+
 os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
 # -- end do not touch
 
@@ -25,6 +26,7 @@ from gptqmodel.adapter.adapter import HF_ADAPTER_FILE_NAME, HF_ADAPTER_WEIGHT_KE
 from gptqmodel.utils.logger import render_table  # noqa: E402
 from gptqmodel.utils.torch import torch_empty_cache  # noqa: E402
 from tests.eval import evaluate, format_eval_result_table  # noqa: E402
+
 
 log = LogBar.shared()
 


### PR DESCRIPTION
## Summary
1.Added `ERNIE 4.5 VL MoE` model support
2.  Fix LazyTurtle HF converter checkpoint aliases
  Preserve HF `WeightConverter` metadata in LazyTurtle and use it to resolve
  runtime tensor names back to checkpoint keys for nested aliases, Chunk
  splits, and ERNIE text/vision expert mappings.