### PR TITLE
[FIX] AWQ device placement to follow planner target devices

### DIFF
--- a/gptqmodel/looper/awq_processor.py
+++ b/gptqmodel/looper/awq_processor.py
@@ -27,7 +27,6 @@ from ..nn_modules.qlinear.gemv_fast_awq import AwqGEMVFastLinear, LLMAwqLinear
 from ..nn_modules.qlinear.torch_awq import AwqTorchLinear
 from ..quantization.awq.quantize.scale import apply_clip, apply_scale
 from ..quantization.awq.utils.module import append_str_prefix, get_op_name, get_op_by_name
-from ..quantization.awq.utils.utils import get_best_device
 from ..quantization.config import FORMAT, METHOD, QuantizeConfig, resolve_quant_format
 from ..utils.attn_mask import normalize_seq_mask
 from ..utils.ctx import ctx
@@ -39,6 +38,18 @@ from ..utils.module_locks import parent_module_lock
 from ..utils.torch import CPU
 
 log = setup_logger()
+
+
+def _resolve_module_exec_device(module: nn.Module) -> torch.device:
+    """Prefer a module's planned target device, then fall back to its current device."""
+
+    target_device = getattr(module, "target_device", None)
+    if target_device is not None:
+        try:
+            return torch.device(target_device)
+        except (TypeError, RuntimeError, ValueError):
+            pass
+    return get_device(module)
 
 
 @dataclass
@@ -1210,13 +1221,16 @@ class AWQProcessor(LoopProcessor):
             if any([_ in name for _ in avoid_clipping]):
                 continue
 
-            named_linears[name].to(get_best_device())
+            linear = named_linears[name]
+            original_device = get_device(linear)
+            target_device = _resolve_module_exec_device(linear)
+            move_to(linear, device=target_device)
 
             max_val = self._compute_best_clip(
-                named_linears[name].weight, input_feat[name]
+                linear.weight, input_feat[name]
             )
             clip_list.append((name, max_val))
-            named_linears[name].cpu()
+            move_to(linear, device=original_device)
 
         return clip_list
 
@@ -1692,7 +1706,7 @@ class AWQProcessor(LoopProcessor):
             self.draw_progress(base_title)
 
             linear_layer = self.resolve_quant_source_module(named_module)
-            linear_layer = linear_layer.to(get_best_device())
+            move_to(linear_layer, device=_resolve_module_exec_device(linear_layer))
 
             tp_info = named_module.state.get("tp_pad_info")
             pad_cols = 0

--- a/gptqmodel/nn_modules/qlinear/gemm_awq.py
+++ b/gptqmodel/nn_modules/qlinear/gemm_awq.py
@@ -13,7 +13,6 @@ from ...adapter.adapter import Adapter, Lora
 from ...models._const import DEVICE, PLATFORM
 from ...nn_modules.qlinear import AWQuantLinear
 from ...quantization import FORMAT, METHOD
-from ...quantization.awq.utils.utils import get_best_device
 from ...utils.awq import awq_dequantize_weights, awq_gemm_forward, awq_runtime_available, awq_runtime_error
 from ...utils.backend import BACKEND
 from ...utils.env import env_flag
@@ -229,7 +228,7 @@ class AwqGEMMLinear(AWQuantLinear):
         intweight = intweight.t().contiguous()
         intweight = intweight.to(dtype=torch.int32)
 
-        best_device = get_best_device()
+        best_device = str(linear.weight.device)
 
         # Avoid: The operator 'aten::__lshift__.Scalar' is not currently implemented for the MPS device
         if "mps" in best_device:

--- a/gptqmodel/quantization/awq/quantize/scale.py
+++ b/gptqmodel/quantization/awq/quantize/scale.py
@@ -24,7 +24,8 @@ from transformers.models.llama.modeling_llama import LlamaRMSNorm
 
 from gptqmodel.quantization.awq.modules.act import ScaledActivation
 from gptqmodel.quantization.awq.utils.module import get_op_by_name, set_op_by_name
-from gptqmodel.quantization.awq.utils.utils import get_best_device
+from gptqmodel.utils.device import get_device
+from gptqmodel.utils.model import move_to
 
 
 try:
@@ -46,16 +47,31 @@ allowed_act_fns = [
 
 
 @torch.inference_mode()
+def _resolve_module_exec_device(module: nn.Module) -> torch.device:
+    """Prefer a module's planned target device, then fall back to its current device."""
+
+    target_device = getattr(module, "target_device", None)
+    if target_device is not None:
+        try:
+            return torch.device(target_device)
+        except (TypeError, RuntimeError, ValueError):
+            pass
+    return get_device(module)
+
+
+@torch.inference_mode()
 def apply_clip(module, clip_list: Tuple[str, torch.Tensor]):
     for name, max_val in clip_list:
         layer: nn.Linear = get_op_by_name(module, name)
-        layer.to(get_best_device())
+        original_device = get_device(layer)
+        target_device = _resolve_module_exec_device(layer)
+        move_to(layer, device=target_device)
         max_val = max_val.to(layer.weight.device)
         org_shape = layer.weight.shape
         layer.weight.data = layer.weight.data.reshape(*max_val.shape[:2], -1)
         layer.weight.data = torch.clamp(layer.weight.data, -max_val, max_val)
         layer.weight.data = layer.weight.data.reshape(org_shape)
-        layer.cpu()
+        move_to(layer, device=original_device)
 
 
 def apply_scale(module, scales_list, input_feat_dict=None):
@@ -63,11 +79,14 @@ def apply_scale(module, scales_list, input_feat_dict=None):
         prev_op = get_op_by_name(module, prev_op_name)
         layers = [get_op_by_name(module, name) for name in layer_names]
 
-        best_device = get_best_device()
-        prev_op.to(best_device)
+        original_prev_device = get_device(prev_op)
+        original_layer_devices = [get_device(layer) for layer in layers]
+        target_device = _resolve_module_exec_device(layers[0] if layers else prev_op)
+
+        move_to(prev_op, device=target_device)
         for layer in layers:
-            layer.to(best_device)
-        scales.to(best_device)
+            move_to(layer, device=target_device)
+        scales = scales.to(target_device)
 
         if (
             isinstance(prev_op, nn.Linear)
@@ -102,10 +121,9 @@ def apply_scale(module, scales_list, input_feat_dict=None):
                     inp = input_feat_dict[layer_name]
                     inp.div_(scales.view(1, -1).to(inp.device))
 
-        prev_op.cpu()
-        for layer in layers:
-            layer.cpu()
-        scales.cpu()
+        move_to(prev_op, device=original_prev_device)
+        for layer, original_device in zip(layers, original_layer_devices):
+            move_to(layer, device=original_device)
 
 
 @torch.inference_mode()

--- a/gptqmodel/quantization/awq/utils/utils.py
+++ b/gptqmodel/quantization/awq/utils/utils.py
@@ -8,8 +8,6 @@ import importlib
 import accelerate
 import torch
 
-from gptqmodel.utils.torch import HAS_NPU
-
 
 ipex_available = importlib.util.find_spec("intel_extension_for_pytorch") is not None
 try:
@@ -89,21 +87,6 @@ def compute_memory_used_pct(device):
         * 100
     )
     return memory_pct
-
-
-def get_best_device():
-    if torch.backends.mps.is_available():
-        return "mps"
-    elif torch.cuda.is_available():
-        return "cuda:0"
-    elif hasattr(torch, "xpu") and torch.xpu.is_available():
-        return "xpu:0"
-    elif HAS_NPU:
-        return "npu:0"
-    else:
-        return "cpu"
-
-
 def get_lowest_memory_device_index():
     device = None
     curr_device_memory_pct = 0


### PR DESCRIPTION
## Summary

  Fix AWQ device placement so it follows GPTQModel's current layer/subset planning logic instead of forcing modules onto `get_best_device()`.

  This change addresses `qwen3_5_moe` AWQ failures where layer replay could hit mixed-device execution, such as `input_layernorm` staying on CPU while `post_attention_layernorm` had already been moved to CUDA.
  
  ### Root Cause
  AWQ still used `to(get_best_device())` in several paths (`apply_scale`, `apply_clip`, clipping search, and quant application), which bypassed the planner's device assignments.