### PR TITLE
feat(models): register gemma4_unified GPTQ definition (#2920)

### DIFF
--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -97,6 +97,7 @@ from .definitions.gemma2 import Gemma2QModel  # noqa: E402
 from .definitions.gemma3 import Gemma3ForConditionalGenerationGPTQ, Gemma3QModel  # noqa: E402
 from .definitions.gemma3n import Gemma3nForConditionalGenerationGPTQ, Gemma3nTextQModel  # noqa: E402
 from .definitions.gemma4 import Gemma4ForConditionalGenerationGPTQ, Gemma4TextQModel  # noqa: E402
+from .definitions.gemma4_unified import Gemma4UnifiedForConditionalGenerationGPTQ, Gemma4UnifiedTextQModel  # noqa: E402
 from .definitions.glm import GlmQModel  # noqa: E402
 from .definitions.glm4_moe import GLM4MoEGPTQ  # noqa: E402
 from .definitions.glm4_moe_lite import Glm4MoeLiteQModel  # noqa: E402
@@ -255,6 +256,8 @@ MODEL_MAP = {
     "gemma3n": Gemma3nForConditionalGenerationGPTQ,
     "gemma4_text": Gemma4TextQModel,
     "gemma4": Gemma4ForConditionalGenerationGPTQ,
+    "gemma4_unified_text": Gemma4UnifiedTextQModel,
+    "gemma4_unified": Gemma4UnifiedForConditionalGenerationGPTQ,
     "phi": PhiQModel,
     "phi3": Phi3QModel,
     "phi4mm": Phi4MMGPTQ,

--- a/gptqmodel/models/definitions/__init__.py
+++ b/gptqmodel/models/definitions/__init__.py
@@ -30,6 +30,7 @@ from .gemma2 import Gemma2QModel
 from .gemma3 import Gemma3QModel
 from .gemma3n import Gemma3nForConditionalGenerationGPTQ, Gemma3nTextQModel
 from .gemma4 import Gemma4ForConditionalGenerationGPTQ, Gemma4TextQModel
+from .gemma4_unified import Gemma4UnifiedForConditionalGenerationGPTQ, Gemma4UnifiedTextQModel
 from .glm import GlmQModel
 from .glmasr import GlmASRGPTQ
 from .glm_ocr import GlmOCRGPTQ

--- a/gptqmodel/models/definitions/gemma4_unified.py
+++ b/gptqmodel/models/definitions/gemma4_unified.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from ..base import BaseQModel
+from . import LlamaQModel
+from .gemma4 import _prepare_gemma4_replay_kwargs
+
+
+# Gemma 4 unified drops the per-layer-input (PLE) feature that base Gemma 4 carries:
+# Gemma4UnifiedTextConfig deletes vocab_size_per_layer_input/hidden_size_per_layer_input,
+# so the decoder has no per_layer_input_gate / per_layer_projection / post_per_layer_input_norm
+# modules and no project_per_layer_inputs capture hook. The quantizable layout is therefore the
+# standard Gemma sandwich-norm decoder. It still uses per-layer-type rotary frequencies
+# (sliding vs full attention), so cached-replay must refresh position_embeddings per layer.
+_GEMMA4_UNIFIED_DECODER = {
+    "input_layernorm": ("input_layernorm:!",),
+    "self_attn": (
+        "q_norm:!",
+        "q_proj:0",
+        "k_norm:!",
+        "k_proj:0",
+        "v_norm:!",
+        "v_proj:0",
+        "o_proj:1",
+    ),
+    "post_attention_layernorm": ("post_attention_layernorm:!",),
+    "pre_feedforward_layernorm": ("pre_feedforward_layernorm:!",),
+    "mlp": ("gate_proj:0", "up_proj:0", "down_proj:1"),
+    "post_feedforward_layernorm": ("post_feedforward_layernorm:!",),
+}
+
+
+class Gemma4UnifiedTextQModel(LlamaQModel):
+    """Quantization definition for text-only Gemma 4 unified checkpoints."""
+
+    # Variants may share or omit KV projections (attention_k_eq_v / num_kv_shared_layers).
+    layer_modules_strict = False
+    # Per-layer-type rotary means cached replay must refresh position_embeddings per layer.
+    support_batch_quantize = False
+    pre_lm_head_norm_module = "model.norm"
+    rotary_embedding = "model.rotary_emb"
+    module_tree = ["model", "layers", "#", _GEMMA4_UNIFIED_DECODER]
+
+    def prepare_layer_replay_kwargs(self, layer, layer_input, additional_inputs, target_device):
+        """Refresh sliding/full rotary kwargs during cached replay (no PLE reconstruction)."""
+
+        return _prepare_gemma4_replay_kwargs(self, layer, layer_input, additional_inputs, target_device)
+
+
+class Gemma4UnifiedForConditionalGenerationGPTQ(BaseQModel):
+    """Quantization definition for composite (multimodal) Gemma 4 unified checkpoints."""
+
+    layer_modules_strict = False
+    support_batch_quantize = False
+    pre_lm_head_norm_module = "model.language_model.norm"
+    rotary_embedding = "model.language_model.rotary_emb"
+    module_tree = ["model", "language_model", "layers", "#", _GEMMA4_UNIFIED_DECODER]
+
+    def prepare_layer_replay_kwargs(self, layer, layer_input, additional_inputs, target_device):
+        """Refresh sliding/full rotary kwargs during cached replay (no PLE reconstruction)."""
+
+        return _prepare_gemma4_replay_kwargs(self, layer, layer_input, additional_inputs, target_device)


### PR DESCRIPTION
## Summary

`gemma4_unified` checkpoints (`Gemma4UnifiedForConditionalGeneration`, e.g. `OpenYourMind/gemma-4-12B-it-abliterated-uncensored`) currently fail with:

```
ValueError: Unsupport model_type gemma4_unified, and failed to auto-detect module tree for model
```

This adds quantization definitions for the text-only (`gemma4_unified_text`) and composite (`gemma4_unified`) variants and registers them in `MODEL_MAP`.

Fixes #2920.

## Why a new definition instead of reusing `gemma4`

`gemma4_unified` is **not** a drop-in alias for `gemma4`:

- `Gemma4UnifiedTextConfig` explicitly removes the per-layer-input (PLE) feature (`vocab_size_per_layer_input` / `hidden_size_per_layer_input` set to `AttributeError()`). So the decoder has **no** `per_layer_input_gate` / `per_layer_projection` / `post_per_layer_input_norm` modules and **no** `project_per_layer_inputs` hook.
- Reusing `Gemma4ForConditionalGenerationGPTQ` would therefore crash in `pre_quantize_generate_hook_start` → `_patch_gemma4_per_layer_input_capture` (no `project_per_layer_inputs`), and its positional-input capture assumes a `per_layer_input` arg the unified decoder does not have.

The quantizable layout is the standard Gemma sandwich-norm decoder (`q/k/v/o_proj` + `gate/up/down_proj`, with `q/k/v_norm` and the four sandwich norms non-quantized).

`gemma4_unified` **does** keep per-layer-type rotary frequencies (sliding vs full attention via `Gemma4UnifiedTextRotaryEmbedding`), so cached replay reuses the proven `_prepare_gemma4_replay_kwargs` helper to refresh `position_embeddings` per layer — the PLE-reconstruction tail in that helper is an inert no-op here since no per-layer inputs are captured.

## Test plan

- [ ] `from gptqmodel.models import auto; auto.check_and_get_model_definition(<gemma4_unified ckpt>)` returns `Gemma4UnifiedForConditionalGenerationGPTQ`.
- [ ] End-to-end 4-bit quantization of a `gemma4_unified` checkpoint.

I don't have local access to a `gemma4_unified` checkpoint to run the full quantization, so maintainer validation on real hardware is appreciated. The definition deliberately mirrors the existing (tested) `gemma4.py` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
