### PR TITLE
Fix Mllama (Llama3.2-11B-Vision) quantization

### DIFF
--- a/gptqmodel/models/definitions/mllama.py
+++ b/gptqmodel/models/definitions/mllama.py
@@ -20,6 +20,8 @@ class MLlamaQModel(BaseQModel):
     loader = AutoModelForPreTraining
 
     pre_lm_head_norm_module = "model.language_model.norm"
+    # Current Transformers shells use `model.language_model.*`, while the
+    # released Mllama checkpoints store those tensors under `language_model.model.*`.
     HF_CONVERSION_MAP_REVERSED = (
         SimpleNamespace(
             source_patterns=[r"model\.language_model"],
@@ -71,21 +73,16 @@ class MLlamaQModel(BaseQModel):
     ]
 
     @classmethod
-    def _resolve_multimodal_layout(cls, model):
-        for prefix in ("model", "language_model"):
-            core_model = get_module(model, prefix)
-            if core_model is None:
-                continue
-            if hasattr(core_model, "language_model"):
-                return prefix, core_model, core_model.language_model
-            if hasattr(core_model, "model"):
-                return prefix, core_model, core_model.model
+    def _resolve_language_model(cls, model):
+        for prefix in ("model.language_model", "language_model.model"):
+            language_model = get_module(model, prefix)
+            if language_model is not None:
+                return language_model
 
         raise AttributeError("Unable to resolve an Mllama language model layout.")
 
     def _core_language_model(self):
-        _, _, language_model = self._resolve_multimodal_layout(self.model)
-        return language_model
+        return self._resolve_language_model(self.model)
 
     def _materialize_language_module(self, language_model, attr_name: str):
         module = getattr(language_model, attr_name, None)
@@ -148,6 +145,9 @@ class MLlamaQModel(BaseQModel):
         if torch.is_tensor(embedding_weight) and input_ids.device != embedding_weight.device:
             input_ids = input_ids.to(device=embedding_weight.device)
 
+        # Input capture only needs the tensors entering the first decoder layer.
+        # Calling it directly avoids the multimodal wrapper's mask construction
+        # path, which can inspect meta tensors during lazy quantization.
         inputs_embeds = language_model.embed_tokens(input_ids)
         if getattr(inputs_embeds, "is_meta", False):
             raise RuntimeError("Mllama input capture produced meta inputs_embeds after materializing embed_tokens.")

--- a/gptqmodel/models/definitions/mllama.py
+++ b/gptqmodel/models/definitions/mllama.py
@@ -3,8 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 
+from types import SimpleNamespace
+
+import torch
 from transformers import AutoModelForPreTraining
 
+from ...utils.model import get_module, move_to
+from ...utils.offload import offload_to_disk
+from .._const import CPU
 from ..base import BaseQModel
 
 
@@ -13,17 +19,154 @@ class MLlamaQModel(BaseQModel):
     # AutoModelForPreTraining return a correct MLlamaForConditionalGeneration for mllama.
     loader = AutoModelForPreTraining
 
-    pre_lm_head_norm_module = "language_model.model.norm"
+    pre_lm_head_norm_module = "model.language_model.norm"
+    HF_CONVERSION_MAP_REVERSED = (
+        SimpleNamespace(
+            source_patterns=[r"model\.language_model"],
+            target_patterns=[r"^language_model.model"],
+            operations=[],
+        ),
+        SimpleNamespace(
+            source_patterns=[r"lm_head"],
+            target_patterns=[r"^language_model.lm_head"],
+            operations=[],
+        ),
+        SimpleNamespace(
+            source_patterns=[r"model\.vision_model"],
+            target_patterns=[r"^vision_model"],
+            operations=[],
+        ),
+        SimpleNamespace(
+            source_patterns=[r"model\.multi_modal_projector"],
+            target_patterns=[r"^multi_modal_projector"],
+            operations=[],
+        ),
+    )
 
     module_tree = [
-        "language_model",
-        "model",
-        "layers",
-        "#",
-        {
-            "input_layernorm": ("input_layernorm:!",),
-            "self_attn": ("q_proj:0", "k_proj:0", "v_proj:0", "o_proj:1"),
-            "post_attention_layernorm": ("post_attention_layernorm:!",),
-            "mlp": ("gate_proj:0", "up_proj:0", "down_proj:1"),
-        }
+        [
+            "model",
+            "language_model",
+            "layers",
+            "#",
+            {
+                "input_layernorm": ("input_layernorm:!",),
+                "self_attn": ("q_proj:0", "k_proj:0", "v_proj:0", "o_proj:1"),
+                "post_attention_layernorm": ("post_attention_layernorm:!",),
+                "mlp": ("gate_proj:0", "up_proj:0", "down_proj:1"),
+            },
+        ],
+        [
+            "language_model",
+            "model",
+            "layers",
+            "#",
+            {
+                "input_layernorm": ("input_layernorm:!",),
+                "self_attn": ("q_proj:0", "k_proj:0", "v_proj:0", "o_proj:1"),
+                "post_attention_layernorm": ("post_attention_layernorm:!",),
+                "mlp": ("gate_proj:0", "up_proj:0", "down_proj:1"),
+            },
+        ],
     ]
+
+    @classmethod
+    def _resolve_multimodal_layout(cls, model):
+        for prefix in ("model", "language_model"):
+            core_model = get_module(model, prefix)
+            if core_model is None:
+                continue
+            if hasattr(core_model, "language_model"):
+                return prefix, core_model, core_model.language_model
+            if hasattr(core_model, "model"):
+                return prefix, core_model, core_model.model
+
+        raise AttributeError("Unable to resolve an Mllama language model layout.")
+
+    def _core_language_model(self):
+        _, _, language_model = self._resolve_multimodal_layout(self.model)
+        return language_model
+
+    def _materialize_language_module(self, language_model, attr_name: str):
+        module = getattr(language_model, attr_name, None)
+        if module is None:
+            return
+
+        if "_turtle_lock" not in self.__dict__ and "shell_module_materialize" not in self.__dict__:
+            setattr(language_model, attr_name, move_to(module, device=self.quantize_config.device))
+            return
+
+        setattr(
+            language_model,
+            attr_name,
+            self.shell_module_materialize(module, self.quantize_config.device),
+        )
+
+    def pre_quantize_generate_hook_start(self):
+        language_model = self._core_language_model()
+        self._materialize_language_module(language_model, "embed_tokens")
+        self._materialize_language_module(language_model, "rotary_emb")
+
+    def pre_quantize_generate_hook_end(self):
+        language_model = self._core_language_model()
+
+        for attr_name in ("embed_tokens", "rotary_emb"):
+            module = getattr(language_model, attr_name, None)
+            if module is None:
+                continue
+
+            if self.quantize_config.offload_to_disk:
+                offload_to_disk(
+                    model=language_model,
+                    module=module,
+                    disk_path=self.quantize_config.offload_to_disk_path,
+                )
+            else:
+                setattr(language_model, attr_name, move_to(module, device=CPU))
+
+    @staticmethod
+    def _prepare_first_layer_attention_mask(attention_mask):
+        if attention_mask is None or not torch.is_tensor(attention_mask):
+            return attention_mask
+
+        if attention_mask.ndim <= 2 and bool(attention_mask.to(dtype=torch.bool).all().item()):
+            return None
+
+        return attention_mask
+
+    def run_input_capture(self, example, use_cache: bool, data_device):
+        input_ids = example.get("input_ids")
+        if input_ids is None:
+            return super().run_input_capture(example, use_cache=use_cache, data_device=data_device)
+
+        language_model = self._core_language_model()
+        attention_mask = example.get("attention_mask")
+        position_ids = example.get("position_ids")
+        past_key_values = example.get("past_key_values")
+
+        embedding_weight = getattr(language_model.embed_tokens, "weight", None)
+        if torch.is_tensor(embedding_weight) and input_ids.device != embedding_weight.device:
+            input_ids = input_ids.to(device=embedding_weight.device)
+
+        inputs_embeds = language_model.embed_tokens(input_ids)
+        if getattr(inputs_embeds, "is_meta", False):
+            raise RuntimeError("Mllama input capture produced meta inputs_embeds after materializing embed_tokens.")
+
+        if position_ids is None:
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            position_ids = position_ids.unsqueeze(0)
+        elif position_ids.device != inputs_embeds.device:
+            position_ids = position_ids.to(device=inputs_embeds.device)
+
+        position_embeddings = language_model.rotary_emb(inputs_embeds, position_ids=position_ids)
+        first_layer_attention_mask = self._prepare_first_layer_attention_mask(attention_mask)
+
+        return language_model.layers[0](
+            inputs_embeds,
+            attention_mask=first_layer_attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            position_embeddings=position_embeddings,
+        )

--- a/tests/test_mllama_support.py
+++ b/tests/test_mllama_support.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+from gptqmodel.models.definitions.mllama import MLlamaQModel
+from gptqmodel.utils.structure import LazyTurtle
+from gptqmodel.utils.model import get_layers_with_prefixes
+
+
+class _Attention(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.q_proj = nn.Linear(4, 4, bias=False)
+        self.k_proj = nn.Linear(4, 4, bias=False)
+        self.v_proj = nn.Linear(4, 4, bias=False)
+        self.o_proj = nn.Linear(4, 4, bias=False)
+
+
+class _MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.gate_proj = nn.Linear(4, 4, bias=False)
+        self.up_proj = nn.Linear(4, 4, bias=False)
+        self.down_proj = nn.Linear(4, 4, bias=False)
+
+
+class _DecoderLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.input_layernorm = nn.LayerNorm(4)
+        self.self_attn = _Attention()
+        self.post_attention_layernorm = nn.LayerNorm(4)
+        self.mlp = _MLP()
+        self.last_kwargs = None
+
+    def forward(self, hidden_states, **kwargs):
+        self.last_kwargs = kwargs
+        return hidden_states
+
+
+class _Rotary(nn.Module):
+    def forward(self, x, position_ids=None):
+        shape = (*x.shape[:2], x.shape[-1] // 2)
+        return x.new_zeros(shape), x.new_zeros(shape)
+
+
+class _LanguageModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(8, 4)
+        self.layers = nn.ModuleList([_DecoderLayer(), _DecoderLayer()])
+        self.norm = nn.LayerNorm(4)
+        self.rotary_emb = _Rotary()
+
+
+class _CurrentMllamaWrapper(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model = nn.Module()
+        self.model.language_model = _LanguageModel()
+        self.model.vision_model = nn.Identity()
+        self.model.multi_modal_projector = nn.Linear(4, 4, bias=False)
+        self.lm_head = nn.Linear(4, 4, bias=False)
+
+
+class _LegacyMllamaWrapper(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.language_model = nn.Module()
+        self.language_model.model = _LanguageModel()
+        self.lm_head = nn.Linear(4, 4, bias=False)
+
+
+def test_mllama_module_tree_supports_current_transformers_layout():
+    model = _CurrentMllamaWrapper()
+
+    layers, layer_names = get_layers_with_prefixes(
+        model,
+        MLlamaQModel.extract_layers_node(),
+    )
+
+    assert MLlamaQModel.extract_layers_node()[0] == "model.language_model.layers"
+    assert len(layers) == 2
+    assert layer_names == [
+        "model.language_model.layers.0",
+        "model.language_model.layers.1",
+    ]
+    assert MLlamaQModel.pre_lm_head_norm_module == "model.language_model.norm"
+    base_modules = set(MLlamaQModel.get_base_modules(model))
+    assert "model.vision_model" in base_modules
+    assert "model.multi_modal_projector" in base_modules
+
+
+def test_mllama_module_tree_keeps_legacy_language_model_layout():
+    model = _LegacyMllamaWrapper()
+
+    layers, layer_names = get_layers_with_prefixes(
+        model,
+        MLlamaQModel.extract_layers_node(),
+    )
+
+    assert len(layers) == 2
+    assert layer_names == [
+        "language_model.model.layers.0",
+        "language_model.model.layers.1",
+    ]
+
+
+def test_mllama_pre_quantize_hooks_materialize_text_input_modules():
+    instance = object.__new__(MLlamaQModel)
+    nn.Module.__init__(instance)
+    instance.model = _CurrentMllamaWrapper()
+    instance.quantize_config = SimpleNamespace(
+        device="cpu",
+        offload_to_disk=False,
+        offload_to_disk_path="/tmp/unused",
+    )
+
+    instance.pre_quantize_generate_hook_start()
+    instance.pre_quantize_generate_hook_end()
+
+    language_model = instance.model.model.language_model
+    assert language_model.embed_tokens.weight.device.type == "cpu"
+    assert next(language_model.rotary_emb.parameters(), None) is None
+
+
+def test_mllama_run_input_capture_calls_first_decoder_layer_directly():
+    instance = object.__new__(MLlamaQModel)
+    nn.Module.__init__(instance)
+    instance.model = _CurrentMllamaWrapper()
+    instance.quantize_config = SimpleNamespace(
+        device="cpu",
+        offload_to_disk=False,
+        offload_to_disk_path="/tmp/unused",
+    )
+
+    example = {
+        "input_ids": torch.tensor([[1, 2, 3]], dtype=torch.long),
+        "attention_mask": torch.ones((1, 3), dtype=torch.bool),
+    }
+
+    instance.pre_quantize_generate_hook_start()
+    instance.run_input_capture(example, use_cache=False, data_device=torch.device("cpu"))
+
+    first_layer = instance.model.model.language_model.layers[0]
+    assert first_layer.last_kwargs["attention_mask"] is None
+    assert first_layer.last_kwargs["position_ids"].shape == (1, 3)
+    assert first_layer.last_kwargs["position_embeddings"][0].shape == (1, 3, 2)
+
+
+def test_mllama_lazy_turtle_conversion_map_matches_checkpoint_prefixes():
+    renamings = LazyTurtle._normalize_runtime_to_checkpoint_renamings(
+        MLlamaQModel.resolve_hf_conversion_map_reversed(target_model=_CurrentMllamaWrapper())
+    )
+
+    def convert(path):
+        out = [path]
+        for renaming in renamings:
+            renamed, _ = renaming.rename_source_key(path)
+            out.append(renamed)
+        return out
+
+    assert "language_model.model.embed_tokens" in convert("model.language_model.embed_tokens")
+    assert "language_model.model.layers.0" in convert("model.language_model.layers.0")
+    assert "language_model.lm_head" in convert("lm_head")
+    assert "vision_model" in convert("model.vision_model")
+    assert "multi_modal_projector" in convert("model.multi_modal_projector")
+
+
+def test_mllama_run_input_capture_moves_input_ids_to_embedding_device():
+    instance = object.__new__(MLlamaQModel)
+    nn.Module.__init__(instance)
+    instance.model = _CurrentMllamaWrapper()
+    instance.quantize_config = SimpleNamespace(
+        device="meta",
+        offload_to_disk=False,
+        offload_to_disk_path="/tmp/unused",
+    )
+
+    language_model = instance.model.model.language_model
+    language_model.embed_tokens = language_model.embed_tokens.to("meta")
+
+    example = {
+        "input_ids": torch.tensor([[1, 2, 3]], dtype=torch.long),
+        "attention_mask": torch.ones((1, 3), dtype=torch.bool),
+    }
+
+    try:
+        instance.run_input_capture(example, use_cache=False, data_device=torch.device("cpu"))
+    except RuntimeError as exc:
+        assert "produced meta inputs_embeds" in str(exc)

--- a/tests/test_mllama_support.py
+++ b/tests/test_mllama_support.py
@@ -8,8 +8,8 @@ import torch
 from torch import nn
 
 from gptqmodel.models.definitions.mllama import MLlamaQModel
-from gptqmodel.utils.structure import LazyTurtle
 from gptqmodel.utils.model import get_layers_with_prefixes
+from gptqmodel.utils.structure import LazyTurtle
 
 
 class _Attention(nn.Module):
@@ -47,6 +47,17 @@ class _Rotary(nn.Module):
     def forward(self, x, position_ids=None):
         shape = (*x.shape[:2], x.shape[-1] // 2)
         return x.new_zeros(shape), x.new_zeros(shape)
+
+
+class _RecordingEmbedding(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(8, 4, device="meta"))
+        self.last_input_device = None
+
+    def forward(self, input_ids):
+        self.last_input_device = input_ids.device
+        return torch.zeros((*input_ids.shape, 4))
 
 
 class _LanguageModel(nn.Module):
@@ -182,15 +193,15 @@ def test_mllama_run_input_capture_moves_input_ids_to_embedding_device():
         offload_to_disk_path="/tmp/unused",
     )
 
+    embedding = _RecordingEmbedding()
     language_model = instance.model.model.language_model
-    language_model.embed_tokens = language_model.embed_tokens.to("meta")
+    language_model.embed_tokens = embedding
 
     example = {
         "input_ids": torch.tensor([[1, 2, 3]], dtype=torch.long),
         "attention_mask": torch.ones((1, 3), dtype=torch.bool),
     }
 
-    try:
-        instance.run_input_capture(example, use_cache=False, data_device=torch.device("cpu"))
-    except RuntimeError as exc:
-        assert "produced meta inputs_embeds" in str(exc)
+    instance.run_input_capture(example, use_cache=False, data_device=torch.device("cpu"))
+
+    assert embedding.last_input_device == torch.device("meta")


### PR DESCRIPTION
## Summary

Fix Mllama quantization for current Transformers Mllama layouts

Bugs:
- Mllama definition in GPTQModel pointed at the old decoder path `language_model.model.layers`, but this is now exposed as `model.language_model.layers` in Transformers, so no layers were found for quantization
- LazyTurtle shell names did not match checkpoint names
- Calibration input capture ran through the full HF multimodal wrapper, which builds masks and can call `.item()` on meta tensors.
- Some calibration tensors could end up on a different device from the embedding module.

## What Changed

- Update `MLlamaQModel` to find decoder layers under the current `model.language_model.layers` layout while keeping the legacy `language_model.model.layers` path.
- Add an Mllama LazyTurtle conversion map for runtime shell paths such as `model.language_model.*` to checkpoint paths such as `language_model.model.*`.
- Materialize `embed_tokens` and `rotary_emb` before calibration input capture, then move/offload them back after capture.
- Override Mllama input capture to call the first language decoder layer directly with computed embeddings, position ids, rotary embeddings, and a normalized all-true attention mask.
- Add fast unit coverage for Mllama layout resolution, base-module discovery, LazyTurtle path conversion, input-capture routing, and input-id device handling.

## Tests

Every working PR must include at least one new simple, fast, targeted unit test when the change affects behavior, a bug fix, or a regression path.

- [x] I added a new simple/fast unit test for this change, or documented why that is not applicable.
- [x] I ran the new targeted test locally before opening this PR.
- [x] I ran any other directly relevant local tests.

Paste the exact test commands and results here:

```bash
python -m pytest tests/test_mllama_support.py -q
# 6 passed, 14 warnings in 1.95s
```

## Review Requirements

AI-assisted code is welcome.

Every changed file must still be properly reviewed by a human before the PR is opened as ready for review.

We will not accept PRs that are effectively unreviewed AI output. Non-human-reviewed changes often introduce obscure structure, mismatched APIs, project-inconsistent code patterns, or unnecessary monkeypatching instead of a correct fix or clean feature expansion.

- [x] I personally reviewed every file in this diff.
- [x] I checked that the code matches existing project structure, APIs, and conventions.
- [x] I avoided unnecessary monkeypatching and used the project's normal extension points where possible.