### PR TITLE
Downgrade defuser to 0.0.22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ datasets>=3.6.0
 pyarrow>=21.0
 dill>=0.3.8
 torchao>=0.16.0
-defuser>=0.0.23
+defuser>=0.0.22


### PR DESCRIPTION
Can not currently install GPTQModel from main because defuser 0.0.23 does not exist.