### PR TITLE
Fix Mllama GPTQ loading for skipped cross-attention layers

### DIFF
--- a/gptqmodel/looper/stage_layer.py
+++ b/gptqmodel/looper/stage_layer.py
@@ -453,8 +453,12 @@ def run_layer_stage(
                 layer_title,
             )
 
-        if module.__class__.__name__.lower() == "MllamaCrossAttentionDecoderLayer".lower():
-            # TODO FIXME: currently we not support quantizing cross attention layer (pixel_values)
+        if not looper.gptq_model.should_quantize_layer(
+            module,
+            layer_name,
+            layer_index,
+            looper.gptq_model.quantize_config,
+        ):
             continue
 
         module = looper.gptq_model.pre_quantize(module)

--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -743,6 +743,35 @@ class BaseQModel(nn.Module):
         # print(f"full layer_modules: {full}")
         return full
 
+    @classmethod
+    def should_quantize_layer(
+        cls,
+        layer: nn.Module,
+        layer_name: str,
+        layer_index: int | None,
+        quantize_config: BaseQuantizeConfig,
+    ) -> bool:
+        """Return whether a decoder layer should be quantized during calibration."""
+        return True
+
+    @classmethod
+    def should_quantize_module(
+        cls,
+        model: nn.Module,
+        module_name: str,
+        module: nn.Module,
+        quantize_config: BaseQuantizeConfig,
+    ) -> bool:
+        """
+        Return whether a concrete module should be replaced with a quantized module.
+
+        `module_tree` describes reusable suffixes inside decoder layers, but some
+        model families use different layer subclasses under the same layer list.
+        Model definitions can override this hook when a suffix is quantizable only
+        for specific layer subclasses.
+        """
+        return True
+
     def prepare_dataset(
         self,
         calibration_dataset: Union[

--- a/gptqmodel/models/definitions/mllama.py
+++ b/gptqmodel/models/definitions/mllama.py
@@ -18,6 +18,7 @@ from ..base import BaseQModel
 class MLlamaQModel(BaseQModel):
     # AutoModelForPreTraining return a correct MLlamaForConditionalGeneration for mllama.
     loader = AutoModelForPreTraining
+    _cross_attention_decoder_layer = "MllamaCrossAttentionDecoderLayer"
 
     pre_lm_head_norm_module = "model.language_model.norm"
     # Current Transformers shells use `model.language_model.*`, while the
@@ -80,6 +81,45 @@ class MLlamaQModel(BaseQModel):
                 return language_model
 
         raise AttributeError("Unable to resolve an Mllama language model layout.")
+
+    @classmethod
+    def _decoder_layer_context_for_module_name(cls, model, module_name: str):
+        for layers_node in cls.extract_layers_node():
+            prefix = f"{layers_node}."
+            if not module_name.startswith(prefix):
+                continue
+
+            layer_index = module_name[len(prefix):].split(".", 1)[0]
+            if layer_index.isdigit():
+                layer_name = f"{layers_node}.{layer_index}"
+                return get_module(model, layer_name), layer_name, int(layer_index)
+
+        return None, "", None
+
+    @classmethod
+    def _is_cross_attention_decoder_layer(cls, layer):
+        return (
+            layer is not None
+            and layer.__class__.__name__.lower() == cls._cross_attention_decoder_layer.lower()
+        )
+
+    @classmethod
+    def should_quantize_layer(cls, layer, layer_name, layer_index, quantize_config):
+        # Mllama cross-attention decoder layers consume vision features. They are
+        # not quantized today, so their child modules must also stay dense when
+        # loading or re-saving a quantized checkpoint.
+        if cls._is_cross_attention_decoder_layer(layer):
+            return False
+
+        return super().should_quantize_layer(layer, layer_name, layer_index, quantize_config)
+
+    @classmethod
+    def should_quantize_module(cls, model, module_name, module, quantize_config):
+        decoder_layer, layer_name, layer_index = cls._decoder_layer_context_for_module_name(model, module_name)
+        if decoder_layer is not None:
+            return cls.should_quantize_layer(decoder_layer, layer_name, layer_index, quantize_config)
+
+        return super().should_quantize_module(model, module_name, module, quantize_config)
 
     def _core_language_model(self):
         return self._resolve_language_model(self.model)

--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -1234,6 +1234,11 @@ def ModelLoader(cls):
                     if name is not cls.lm_head:
                         log.info(f"The layer {name} is not quantized.")
                     del modules[name]
+                    continue
+
+                if not cls.should_quantize_module(model, name, modules[name], qcfg):
+                    log.info(f"The layer {name} is not quantized.")
+                    del modules[name]
 
             if format_code == FORMAT.EXL3:
                 if not isinstance(qcfg.tensor_storage, dict) or not qcfg.tensor_storage:

--- a/gptqmodel/models/writer.py
+++ b/gptqmodel/models/writer.py
@@ -958,7 +958,11 @@ def ModelWriter(cls):
                     if name is not self.lm_head:
                         log.info(f"The layer {name} is not quantized.")
                     del modules[name]
+                    continue
 
+                if not self.should_quantize_module(model, name, modules[name], qcfg):
+                    log.info(f"The layer {name} is not quantized.")
+                    del modules[name]
 
             make_quant(
                 model,

--- a/tests/test_mllama_support.py
+++ b/tests/test_mllama_support.py
@@ -8,7 +8,7 @@ import torch
 from torch import nn
 
 from gptqmodel.models.definitions.mllama import MLlamaQModel
-from gptqmodel.utils.model import get_layers_with_prefixes
+from gptqmodel.utils.model import find_modules, get_layers_with_prefixes
 from gptqmodel.utils.structure import LazyTurtle
 
 
@@ -43,6 +43,10 @@ class _DecoderLayer(nn.Module):
         return hidden_states
 
 
+class MllamaCrossAttentionDecoderLayer(_DecoderLayer):
+    pass
+
+
 class _Rotary(nn.Module):
     def forward(self, x, position_ids=None):
         shape = (*x.shape[:2], x.shape[-1] // 2)
@@ -61,30 +65,55 @@ class _RecordingEmbedding(nn.Module):
 
 
 class _LanguageModel(nn.Module):
-    def __init__(self):
+    def __init__(self, layers=None):
         super().__init__()
         self.embed_tokens = nn.Embedding(8, 4)
-        self.layers = nn.ModuleList([_DecoderLayer(), _DecoderLayer()])
+        self.layers = nn.ModuleList(layers or [_DecoderLayer(), _DecoderLayer()])
         self.norm = nn.LayerNorm(4)
         self.rotary_emb = _Rotary()
 
 
 class _CurrentMllamaWrapper(nn.Module):
-    def __init__(self):
+    def __init__(self, language_model=None):
         super().__init__()
         self.model = nn.Module()
-        self.model.language_model = _LanguageModel()
+        self.model.language_model = language_model or _LanguageModel()
         self.model.vision_model = nn.Identity()
         self.model.multi_modal_projector = nn.Linear(4, 4, bias=False)
         self.lm_head = nn.Linear(4, 4, bias=False)
 
 
 class _LegacyMllamaWrapper(nn.Module):
-    def __init__(self):
+    def __init__(self, language_model=None):
         super().__init__()
         self.language_model = nn.Module()
-        self.language_model.model = _LanguageModel()
+        self.language_model.model = language_model or _LanguageModel()
         self.lm_head = nn.Linear(4, 4, bias=False)
+
+
+def _loader_selected_modules(model):
+    qcfg = SimpleNamespace(lm_head=False, dynamic=None)
+    config = SimpleNamespace()
+    extract_layers_node = MLlamaQModel.extract_layers_node()
+    ignore_modules = [MLlamaQModel.lm_head] + MLlamaQModel.get_base_modules(model)
+    simple_layer_modules = MLlamaQModel.simple_layer_modules(config, qcfg)
+    modules = find_modules(model)
+
+    for name in list(modules.keys()):
+        if not any(name.startswith(prefix) for prefix in extract_layers_node) or any(
+            name.startswith(ignore_module) for ignore_module in ignore_modules
+        ) or all(
+            not name.endswith(ignore_module)
+            for sublist in simple_layer_modules
+            for ignore_module in sublist
+        ):
+            del modules[name]
+            continue
+
+        if not MLlamaQModel.should_quantize_module(model, name, modules[name], qcfg):
+            del modules[name]
+
+    return modules
 
 
 def test_mllama_module_tree_supports_current_transformers_layout():
@@ -120,6 +149,44 @@ def test_mllama_module_tree_keeps_legacy_language_model_layout():
         "language_model.model.layers.0",
         "language_model.model.layers.1",
     ]
+
+
+def test_mllama_loader_selection_skips_current_cross_attention_decoder_layers():
+    model = _CurrentMllamaWrapper(
+        _LanguageModel(layers=[_DecoderLayer(), MllamaCrossAttentionDecoderLayer()])
+    )
+
+    modules = _loader_selected_modules(model)
+
+    assert "model.language_model.layers.0.mlp.down_proj" in modules
+    assert "model.language_model.layers.0.self_attn.q_proj" in modules
+    assert "model.language_model.layers.1.mlp.down_proj" not in modules
+    assert "model.language_model.layers.1.self_attn.q_proj" not in modules
+
+
+def test_mllama_loader_selection_skips_legacy_cross_attention_decoder_layers():
+    model = _LegacyMllamaWrapper(
+        _LanguageModel(layers=[_DecoderLayer(), MllamaCrossAttentionDecoderLayer()])
+    )
+
+    modules = _loader_selected_modules(model)
+
+    assert "language_model.model.layers.0.mlp.down_proj" in modules
+    assert "language_model.model.layers.0.self_attn.q_proj" in modules
+    assert "language_model.model.layers.1.mlp.down_proj" not in modules
+    assert "language_model.model.layers.1.self_attn.q_proj" not in modules
+
+
+def test_mllama_quantize_layer_skips_cross_attention_decoder_layers():
+    qcfg = SimpleNamespace()
+
+    assert MLlamaQModel.should_quantize_layer(_DecoderLayer(), "layers.0", 0, qcfg)
+    assert not MLlamaQModel.should_quantize_layer(
+        MllamaCrossAttentionDecoderLayer(),
+        "layers.1",
+        1,
+        qcfg,
+    )
 
 
 def test_mllama_pre_quantize_hooks_materialize_text_input_modules():


### PR DESCRIPTION
## Summary

Fix Mllama quantized checkpoint loading for cross-attention decoder layers.

Mllama cross-attention decoder layers are intentionally skipped during quantization. However, when loading the quantized checkpoint, MLPs inside those skipped layers were still being converted to QuantLinear based on their names. Since the checkpoint contains dense weights for those skipped modules, not packed quantized weights, those QuantLinear modules were not loaded with the correct weights, hence producing garbage outputs.

This caused degraded behaviour. Example generations:
- `I don't see an image, ...`
- `\n\n**Final Answer:** \n\n**Final Answer:** \n\n**Final Answer:** \n\n**Final Answer:** \n\n**Final Answer:** \n\n**Final Answer:** \n\n**Final Answer:** \n\n**Final Answer:** \n\n ...`
- `5. Emperor penguin, Emperor penguin, Emperor penguin, Emperor penguin, Emperor p\u2026\n6. Emperor penguin is at the top of the food web.\n ...`

Benchmark results before and after the changes in this PR:

| Checkpoint | VQAv2 | ChartQA | DocVQA | AI2D | Avg |
|---|---|---|---|---|---|
| bfloat16 | 0.734 | 0.735 | 0.859 | 0.654 | 0.746 |
| GPTQ INT4 Before | 0.711 | 0.36 | 0.739 | 0.091 | 0.475 |
| GPTQ INT4 After | 0.75 | 0.712 | 0.841 | 0.626 | 0.732 |

Note: the same quantized checkpoint was used for the before and after comparison - only the code changed.

## What Changed

- Added model-definition hooks for deciding whether a decoder layer or concrete module should be quantized.
- Updated quantized load and re-save paths to respect the concrete module quantization hook.
- Moved the Mllama cross-attention decoder layer skip behind the Mllama model definition instead of hardcoding it in the generic layer looper.
- Out of scope (future work): adding GPTQ support for Mllama cross-attention layers themselves.

## Tests

Every working PR must include at least one new simple, fast, targeted unit test when the change affects behavior, a bug fix, or a regression path.

- [x] I added a new simple/fast unit test for this change, or documented why that is not applicable.
- [x] I ran the new targeted test locally before opening this PR.
- [x] I ran any other directly relevant local tests.

## Review Requirements

AI-assisted code is welcome.

Every changed file must still be properly reviewed by a human before the PR is opened as ready for review.

We will not accept PRs that are effectively unreviewed AI output. Non-human-reviewed changes often introduce obscure structure, mismatched APIs, project-inconsistent code patterns, or unnecessary monkeypatching instead of a correct fix or clean feature expansion.

- [x] I personally reviewed every file in this diff.
- [x] I checked that the code matches existing project structure, APIs, and conventions.
- [x] I avoided unnecessary monkeypatching and used the project's normal extension points where possible.