### PR TITLE
fix(triton): bound-check checkpoint g_idx to prevent OOB dequant read (#2949)

### DIFF
--- a/gptqmodel/nn_modules/qlinear/tritonv2.py
+++ b/gptqmodel/nn_modules/qlinear/tritonv2.py
@@ -19,6 +19,37 @@ from .torch import TorchLinear
 log = setup_logger()
 
 
+def _validate_g_idx_bounds(
+    g_idx: Optional[torch.Tensor],
+    scales: Optional[torch.Tensor],
+    layer_name: str = "TritonV2Linear",
+) -> None:
+    """Reject checkpoint ``g_idx`` that would index the group buffers out of bounds.
+
+    The Triton dequant kernel resolves each row's group as
+    ``groups = where(g_idx < 0, g_idx + num_groups, g_idx)`` and then loads
+    ``scales``/``qzeros`` at that group with no upper-bound guard, where
+    ``num_groups = scales.shape[0]``. A value outside ``[-num_groups, num_groups)``
+    therefore indexes past the buffer, causing an out-of-bounds device read
+    (denial of service, possible adjacent-memory disclosure) when an untrusted
+    checkpoint is loaded. This mirrors the safe faulting of the Torch backend's
+    ``scales[g_idx]`` gather, but validates once at load rather than per forward.
+    """
+    if g_idx is None or scales is None or g_idx.numel() == 0:
+        return
+
+    num_groups = scales.shape[0]
+    g_min = int(g_idx.min())
+    g_max = int(g_idx.max())
+    if g_min < -num_groups or g_max >= num_groups:
+        raise ValueError(
+            f"{layer_name}: checkpoint g_idx is out of range for {num_groups} "
+            f"scale group(s) (got min={g_min}, max={g_max}, valid "
+            f"[{-num_groups}, {num_groups - 1}]); the group index would read "
+            f"scales/qzeros out of bounds."
+        )
+
+
 class TritonV2Linear(TorchLinear):
     SUPPORTS_BACKENDS = [BACKEND.GPTQ_TRITON]
     SUPPORTS_METHODS = [METHOD.GPTQ]
@@ -131,6 +162,16 @@ class TritonV2Linear(TorchLinear):
         #     self.g_idx = torch.tensor([i // self.group_size for i in range(self.padded_infeatures)], dtype=torch.int32,
         #                               device=self.g_idx.device)
         super().post_init()
+
+        # The Triton dequant kernel indexes the per-group scales/qzeros buffers
+        # with the checkpoint's g_idx and performs no upper-bound check (only a
+        # negative-value wrap), so a crafted g_idx entry >= num_groups reads out
+        # of bounds on the device (CWE-125). Validate once here at load — the
+        # Torch backend's scales[g_idx] gather already faults safely on the same
+        # input — instead of letting the raw value reach the kernel.
+        _validate_g_idx_bounds(
+            self.g_idx, self.scales, layer_name=type(self).__name__
+        )
 
     def forward(self, x):
         from ..triton_utils.dequant import QuantLinearFunction

--- a/tests/test_triton_g_idx_bounds.py
+++ b/tests/test_triton_g_idx_bounds.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU unit tests for the Triton g_idx bounds validation (see issue #2949).
+
+The Triton dequant kernel indexes scales/qzeros with the checkpoint's g_idx and
+performs no upper-bound check, so a crafted g_idx >= num_groups reads out of
+bounds on the device. ``_validate_g_idx_bounds`` rejects such checkpoints at
+load. These tests exercise the pure validator with small CPU tensors, so they
+need neither a GPU nor Triton.
+"""
+
+import pytest
+import torch
+
+from gptqmodel.nn_modules.qlinear.tritonv2 import _validate_g_idx_bounds
+
+
+def _scales(num_groups: int, out_features: int = 8) -> torch.Tensor:
+    return torch.zeros((num_groups, out_features), dtype=torch.float16)
+
+
+def test_valid_g_idx_passes():
+    num_groups = 2
+    g_idx = torch.tensor([0, 0, 1, 1], dtype=torch.int32)
+    # in-range values must not raise
+    _validate_g_idx_bounds(g_idx, _scales(num_groups))
+
+
+def test_negative_wrap_within_range_passes():
+    # The kernel wraps negative entries by + num_groups, so [-num_groups, -1]
+    # is still in range after the wrap.
+    num_groups = 2
+    g_idx = torch.tensor([-1, -2, 0, 1], dtype=torch.int32)
+    _validate_g_idx_bounds(g_idx, _scales(num_groups))
+
+
+def test_g_idx_above_num_groups_rejected():
+    num_groups = 2
+    g_idx = torch.tensor([0, 0, 1, 6], dtype=torch.int32)  # 6 >= num_groups
+    with pytest.raises(ValueError, match="out of range"):
+        _validate_g_idx_bounds(g_idx, _scales(num_groups))
+
+
+def test_g_idx_below_negative_num_groups_rejected():
+    num_groups = 2
+    g_idx = torch.tensor([0, 0, 1, -3], dtype=torch.int32)  # wraps to -1 -> OOB
+    with pytest.raises(ValueError, match="out of range"):
+        _validate_g_idx_bounds(g_idx, _scales(num_groups))
+
+
+def test_none_and_empty_are_noops():
+    # Missing buffers or an empty g_idx must not raise.
+    _validate_g_idx_bounds(None, _scales(2))
+    _validate_g_idx_bounds(torch.tensor([0], dtype=torch.int32), None)
+    _validate_g_idx_bounds(torch.empty(0, dtype=torch.int32), _scales(2))


### PR DESCRIPTION
## Summary

Fixes #2949 — an out-of-bounds device read (CWE-125) in the Triton dequant path when loading an untrusted GPTQ checkpoint.

The Triton dequant kernel (`gptqmodel/nn_modules/triton_utils/dequant.py`) resolves each row's group as `groups = where(g_idx < 0, g_idx + num_groups, g_idx)` and then indexes `scales`/`qzeros` with `groups` **with no upper-bound check**, where `num_groups = scales.shape[0]`. Because `TritonV2Linear.post_init` leaves g_idx regeneration disabled, a crafted `desc_act=True` checkpoint whose `g_idx` exceeds `num_groups` reaches the kernel verbatim and reads past the buffer — crashing the CUDA context (DoS) and potentially pulling adjacent GPU memory into the dequantized weights. The Torch backend's `scales[g_idx]` gather faults safely on the same input; only the Triton path reads raw.

## Fix

Validate `g_idx` once at load in `TritonV2Linear.post_init`, rejecting values outside `[-num_groups, num_groups)`. That range is **exactly** what the kernel's negative-wrap can resolve safely and what the Torch backend's `scales[g_idx]` gather accepts, so the guard only rejects inputs that already fault safely on the Torch path — no legitimate checkpoint is affected. It runs once at load, not on the per-forward hot path.

I kept the change to the load-side guard alone (rather than also masking the load inside the kernel) because rejecting at load fully prevents the bad `g_idx` from ever reaching the device; a kernel-side `groups < num_groups` mask would be reasonable defense-in-depth if you prefer it.

## Tests

`tests/test_triton_g_idx_bounds.py` — CPU-only unit tests for the pure validator (no GPU / Triton needed): in-range and negative-wrap-in-range pass; `g_idx >= num_groups` and `g_idx < -num_groups` are rejected; `None`/empty buffers are no-ops. The accept/reject boundaries were cross-checked against `torch.zeros((num_groups, n))[g_idx]` — they match the Torch backend's safe-fault semantics exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
