### PR TITLE
Fix Laguna Evalution runtime configuration

### DIFF
--- a/tests/eval.py
+++ b/tests/eval.py
@@ -37,6 +37,7 @@ _ENGINE_OPTION_KEYS = {
     "padding_side",
     "pp_size",
     "quantization",
+    "random_seed",
     "sampling_backend",
     "sampling_params",
     "seed",
@@ -490,7 +491,7 @@ def _build_evalution_runtime(
                 batch_size=batch_size,
                 trust_remote_code=trust_remote_code,
                 padding_side=engine_padding_side,
-                seed=engine_options.get("seed"),
+                seed=_evalution_engine_seed(engine_options),
                 tokenizer_mode=engine_options.get("tokenizer_mode", "auto"),
                 tensor_parallel_size=int(tensor_parallel_size),
                 gpu_memory_utilization=float(gpu_memory_utilization),
@@ -526,7 +527,7 @@ def _build_evalution_runtime(
             "attn_implementation": engine_attn,
             "device": engine_device,
             "device_map": engine_device_map,
-            "seed": engine_options.get("seed"),
+            "seed": _evalution_engine_seed(engine_options),
             "batch_size": batch_size,
             "trust_remote_code": trust_remote_code,
             "padding_side": engine_padding_side,
@@ -553,7 +554,7 @@ def _build_evalution_runtime(
             attn_implementation=engine_attn,
             device=engine_device,
             device_map=engine_device_map,
-            seed=engine_options.get("seed"),
+            seed=_evalution_engine_seed(engine_options),
             batch_size=batch_size,
             trust_remote_code=trust_remote_code,
             padding_side=engine_padding_side,
@@ -730,6 +731,15 @@ def _split_evalution_model_args(model_args: Dict[str, Any]) -> tuple[dict[str, A
             load_kwargs[key] = value
     return engine_options, load_kwargs
 
+
+def _evalution_engine_seed(engine_options: Mapping[str, Any]) -> int | None:
+    """Resolve Evalution's canonical seed while accepting the legacy random_seed alias."""
+    seed = engine_options.get("seed")
+    if seed is None:
+        seed = engine_options.get("random_seed")
+    return int(seed) if seed is not None else None
+
+
 def _build_sglang_engine_kwargs(
         *,
         engine_options: Dict[str, Any],
@@ -748,7 +758,7 @@ def _build_sglang_engine_kwargs(
     return {
         "dtype": engine_dtype,
         "device": engine_options.get("device"),
-        "seed": engine_options.get("seed"),
+        "seed": _evalution_engine_seed(engine_options),
         "trust_remote_code": trust_remote_code,
         "padding_side": padding_side,
         "base_url": engine_options.get("base_url"),

--- a/tests/models/model_test.py
+++ b/tests/models/model_test.py
@@ -1800,7 +1800,6 @@ class ModelTest(unittest.TestCase):
                     # Keep evalution-backed generation reproducible even when a task opts
                     # into sampling or an engine backend introduces RNG-sensitive paths.
                     task_model_args.setdefault("seed", RAND_SEED)
-                    task_model_args.setdefault("random_seed", RAND_SEED)
                     task_suite_kwargs = dict(suite_kwargs_lookup.get(normalized_name, {}) or {})
                     task_batch_size = eval_batch_size_lookup.get(normalized_name)
                     if task_batch_size is None:

--- a/tests/models/test_laguna.py
+++ b/tests/models/test_laguna.py
@@ -134,6 +134,9 @@ class TestLagunaS21(_LagunaModelTest):
     # post-quant reload for Evalution.
     EVAL_SINGLE_GPU = False
     EVAL_TASKS_FAST = copy.deepcopy(_LagunaModelTest.EVAL_TASKS_FAST)
+    # Laguna's reasoning mode is selected by its chat template and defaults to enabled in
+    # generation_config.json, so this model must evaluate through the template-aware path.
+    EVAL_TASKS_FAST["gsm8k_platinum_cot"]["chat_template"] = True
     EVAL_TASKS_FAST["gsm8k_platinum_cot"]["evalution_suite_kwargs"]["max_rows"] = 8
     EVAL_TASKS_FAST["gsm8k_platinum_cot"]["acc,num"]["value"] = 0.125
     EVAL_TASKS_FAST["arc_challenge"]["evalution_suite_kwargs"]["max_rows"] = 8

--- a/tests/test_eval_loader_args.py
+++ b/tests/test_eval_loader_args.py
@@ -169,7 +169,7 @@ def test_build_evalution_runtime_supports_sglang_engine_options():
     assert session == "session"
     assert engine is not None
     assert model_config.kwargs["path"] == "/tmp/model"
-    assert model_config.kwargs["model_kwargs"] == {"foo": "bar", "random_seed": '123'}
+    assert model_config.kwargs["model_kwargs"] == {"foo": "bar"}
     assert captured["engine_kwargs"]["dtype"] == "float16"
     assert captured["engine_kwargs"]["device"] == "cuda"
     assert captured["engine_kwargs"]["batch_size"] == 2
@@ -183,6 +183,7 @@ def test_build_evalution_runtime_supports_sglang_engine_options():
     assert captured["engine_kwargs"]["max_running_requests"] == 16
     assert captured["engine_kwargs"]["max_total_tokens"] == 32768
     assert captured["engine_kwargs"]["sampling_params"] == {"top_p": 0.9}
+    assert captured["engine_kwargs"]["seed"] == 123
 
 
 def test_build_evalution_runtime_supports_gptqmodel_seed():
@@ -217,7 +218,7 @@ def test_build_evalution_runtime_supports_gptqmodel_seed():
         trust_remote_code=True,
         model_args={
             "dtype": "float16",
-            "seed": 898,
+            "random_seed": "898",
             "device": "cuda:0",
             "foo": "bar",
         },

--- a/tests/test_model_test_helpers.py
+++ b/tests/test_model_test_helpers.py
@@ -218,7 +218,7 @@ def test_evalution_threads_seed_and_explicit_greedy_gen_kwargs(monkeypatch):
     assert results == {"arc_challenge": {"accuracy,loglikelihood": 1.0}}
     assert captured["model_args"]["device"] == "cuda:0"
     assert captured["model_args"]["seed"] == model_test_module.RAND_SEED
-    assert captured["model_args"]["random_seed"] == model_test_module.RAND_SEED
+    assert "random_seed" not in captured["model_args"]
     assert captured["gen_kwargs"] == "do_sample=false,temperature=0.0,top_p=1.0,top_k=50"
 
 


### PR DESCRIPTION
## Summary

- treat legacy `random_seed` as an Evalution engine option and normalize it to Evalution's canonical `seed`
- stop the model-test loader from passing both `seed` and `random_seed`, preventing `random_seed` from leaking into `LagunaForCausalLM.__init__`
- run Laguna S 2.1 GSM8K Platinum through the chat-template path so the checkpoint's required thinking default is active

## Root cause

The Evalution adapter recognized `seed` but not `random_seed`, so the latter remained in `Model.model_kwargs` and was forwarded through `GPTQModel.load()` to the Hugging Face model constructor. Separately, Laguna S 2.1's evaluation config used a plain prompt even though its reasoning mode is selected by the chat template and declared as `default_chat_template_kwargs={"enable_thinking": true}` in `generation_config.json`.

This change keeps `seed` canonical, accepts `random_seed` only as a backwards-compatible engine alias, and enables chat-template evaluation specifically for Laguna S 2.1.

## Validation

- `CUDA_VISIBLE_DEVICES=2,3 PYTHON_GIL=0 pytest -q tests/test_eval_loader_args.py tests/test_model_test_helpers.py tests/test_laguna_support.py` — 18 passed
- `ruff check` on all changed files — passed
- `git diff --check` — passed
- live Laguna S 2.1 GPTQModel checkpoint load/request-preparation smoke on physical GPUs 2 and 3 with CPU spill — engine seed `38`, empty model kwargs, EOS `[2, 24]`, `</assistant>` token `[24]`, and prompt suffix `<assistant><think>`

Companion Evalution fix: https://github.com/ModelCloud/Evalution/pull/128
