### PR TITLE
Clamp reconstructed quantization codes before packing

### DIFF
--- a/gptqmodel/nn_modules/qlinear/__init__.py
+++ b/gptqmodel/nn_modules/qlinear/__init__.py
@@ -1091,8 +1091,12 @@ class PackableQuantLinear(GPTQQuantLinear):
             s_blk_T = scales.index_select(0, gsel).T  # [out, blk]
 
             # int_block = round((W + scale_zeros[g_idx]^T) / scales[g_idx]^T)
-            int_block = t.round((Wblk + sz_blk_T) / s_blk_T).to(t.int32)  # [out, blk]
-            int_block = int_block.T.contiguous()  # [blk, out]
+            int_block = t.round((Wblk + sz_blk_T) / s_blk_T)  # [out, blk]
+            # Values that drift outside the representable range must saturate.
+            # Bit-packing an unchecked value wraps it modulo 2**bits and turns
+            # a small reconstruction error into a full-range weight error.
+            int_block.clamp_(0, self.maxq)
+            int_block = int_block.to(t.int32).T.contiguous()  # [blk, out]
 
             groups32 = blk // word_bits
             base_group = (i0 // word_bits)
@@ -1288,8 +1292,9 @@ class PackableQuantLinear(GPTQQuantLinear):
             sz_blk_T = scale_zeros_dev.index_select(0, gsel).T
             s_blk_T = scales_dev.index_select(0, gsel).T
 
-            int_block = t.round((Wblk + sz_blk_T) / s_blk_T).to(t.int32)
-            int_block = int_block.T.contiguous()
+            int_block = t.round((Wblk + sz_blk_T) / s_blk_T)
+            int_block.clamp_(0, self.maxq)
+            int_block = int_block.to(t.int32).T.contiguous()
 
             groups32 = blk // word_bits
             base_group = (i0 // word_bits)
@@ -1362,8 +1367,9 @@ class PackableQuantLinear(GPTQQuantLinear):
                 # self.bias = linear.bias.clone().to(dtype=t.float16)
                 self.register_buffer("bias", linear.bias.to(dtype=t.float16))
 
-            int_weight = t.round((W + scale_zeros[self.g_idx].T) / scales[self.g_idx].T).to(t.int32)
-            int_weight = int_weight.T.contiguous()
+            int_weight = t.round((W + scale_zeros[self.g_idx].T) / scales[self.g_idx].T)
+            int_weight.clamp_(0, self.maxq)
+            int_weight = int_weight.to(t.int32).T.contiguous()
             int_weight = int_weight.numpy().astype(self.pack_np_math_dtype)
 
             qweight = np.zeros((int_weight.shape[0] // self.pack_dtype_bits * self.bits, int_weight.shape[1]),

--- a/gptqmodel_ext/pack_block_cpu.cpp
+++ b/gptqmodel_ext/pack_block_cpu.cpp
@@ -127,8 +127,8 @@ std::tuple<at::Tensor, at::Tensor> pack_block_cpu(
                         scale = 1e-6f;
                     }
                     float qf = std::nearbyint((w + offset) / scale);
+                    qf = std::max<float>(0.0f, std::min<float>(qf, static_cast<float>(max_q)));
                     int32_t q = static_cast<int32_t>(qf);
-                    q = std::max<int32_t>(0, std::min<int32_t>(q, max_q));
                     qvals[lane] = q;
                 }
 

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -3,8 +3,10 @@
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 
 import math
+import os
 import time
 import unittest
+from unittest.mock import patch
 
 import torch
 import torch.nn as nn
@@ -170,3 +172,61 @@ class TestPackAccuracy(unittest.TestCase):
         self.assertTrue(torch.equal(pack_cpu["qzeros"], baseline["qzeros"]))
         self.assertTrue(torch.equal(pack_cpu["scales"], baseline["scales"]))
         self.assertTrue(torch.equal(pack_cpu["g_idx"].to(dtype=baseline["g_idx"].dtype), baseline["g_idx"]))
+
+    def test_pack_clamps_reconstructed_codes(self):
+        group_size = 32
+        in_features = 32
+        out_features = 32
+
+        for bits in (2, 3, 4, 8):
+            with self.subTest(bits=bits):
+                max_q = 2 ** bits - 1
+                zero = 2 ** (bits - 1)
+                raw_codes = torch.arange(-8, 24, dtype=torch.float32).view(in_features, 1)
+                raw_codes = raw_codes.expand(in_features, out_features).contiguous()
+                # Exercise saturation before integer conversion as well as the
+                # ordinary one-code boundary drift that triggered the regression.
+                raw_codes[0].fill_(-1e20)
+                raw_codes[-1].fill_(1e20)
+                linear = nn.Linear(in_features, out_features, bias=False)
+                linear.weight.data.copy_((raw_codes - zero).T)
+                scales = torch.ones(1, out_features, dtype=torch.float32)
+                zeros = torch.full((1, out_features), zero, dtype=torch.int32)
+                g_idx = torch.zeros(in_features, dtype=torch.int32)
+                expected = (raw_codes.clamp(0, max_q) - zero).to(torch.float16)
+
+                implementations = ["original", "pack_block", "pack_block_python"]
+                if torch.cuda.is_available():
+                    implementations.append("gpu")
+
+                packed = {}
+                for implementation in implementations:
+                    qlinear = TorchLinear(
+                        bits=bits,
+                        group_size=group_size,
+                        sym=True,
+                        desc_act=False,
+                        in_features=in_features,
+                        out_features=out_features,
+                        pack_dtype=torch.int32,
+                        backend=BACKEND.TORCH,
+                        bias=False,
+                    )
+                    scales_t = scales.T.contiguous()
+                    zeros_t = zeros.T.contiguous()
+                    if implementation == "original":
+                        qlinear.pack_original(linear, scales_t, zeros_t, g_idx=g_idx)
+                    elif implementation == "pack_block":
+                        qlinear.pack_block(linear, scales_t, zeros_t, g_idx=g_idx)
+                    elif implementation == "pack_block_python":
+                        with patch.dict(os.environ, {"GPTQMODEL_DISABLE_PACK_EXT": "1"}):
+                            qlinear.pack_block(linear, scales_t, zeros_t, g_idx=g_idx)
+                    else:
+                        qlinear.pack_gpu(linear, scales_t, zeros_t, g_idx=g_idx)
+                    qlinear.post_init()
+
+                    torch.testing.assert_close(qlinear.dequantize_weight(), expected, rtol=0, atol=0)
+                    packed[implementation] = qlinear.qweight
+
+                for implementation, qweight in packed.items():
+                    torch.testing.assert_close(qweight, packed["original"], rtol=0, atol=0, msg=implementation)


### PR DESCRIPTION
## What changed

- Saturate reconstructed quantization codes to the logical bit range after rounding and before integer conversion in the block, GPU, and original packers.
- Saturate in floating point before the native CPU packer's integer cast, including for very large finite excursions.
- Add adversarial 2-, 3-, 4-, and 8-bit regression coverage across native CPU, forced Python fallback, original, and GPU packing.

## Root cause

Post-quantization weight replay can reconstruct values just outside `[0, 2**bits - 1]`. The affected packers narrowed or shifted those values without saturation, so endpoint drift wrapped modulo the code width. 
## Impact

Packing now treats representable-range enforcement as part of the quantization boundary. Valid in-range checkpoints are unchanged, while out-of-range reconstructed codes saturate instead of wrapping to the opposite endpoint.

