### PR TITLE
Fix unsafe EoRA wq aliasing

### DIFF
--- a/gptqmodel/looper/gptq_processor.py
+++ b/gptqmodel/looper/gptq_processor.py
@@ -30,6 +30,19 @@ log = setup_logger()
 lock = threading.Lock()
 
 
+def snapshot_eora_reconstructed_weight(weight: torch.Tensor) -> torch.Tensor:
+    """Keep EoRA's reconstructed weight independent from module rematerialization.
+
+    Sequential processors can reload the dense checkpoint into the module's
+    parameter storage before EoRA runs. A plain tensor alias would then stop
+    containing GPTQ's reconstruction and make the base packer derive different
+    logical codes. The CPU copy also avoids retaining a second full weight on
+    the quantization device.
+    """
+
+    return weight.detach().to(device=CPU, copy=True)
+
+
 def clone_gptq_config_for_module(
     qcfg: QuantizeConfig,
     module_full_name: str,
@@ -391,7 +404,10 @@ class GPTQProcessor(LoopProcessor):
             # logger.info(f"Quantizing module END: {name}, {gptq[name].shape()}")
             if self.calculate_w_wq_diff:
                 module.state.update({
-                    "wq": wq,  # fp16, quantized weight but not int4 (packed qweight)
+                    # The following EoRA pass rematerializes the dense module.
+                    # Preserve GPTQ's reconstructed weight in independent
+                    # storage before exposing ``wq`` through the parameter.
+                    "wq": snapshot_eora_reconstructed_weight(wq),
                 })
 
         # single largest deallocation of vram happens here

--- a/tests/test_eora_weight_lifecycle.py
+++ b/tests/test_eora_weight_lifecycle.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+from gptqmodel.looper.gptq_processor import snapshot_eora_reconstructed_weight
+
+
+def test_eora_reconstructed_weight_snapshot_survives_dense_rematerialization():
+    dense = torch.tensor(
+        [[1.0, -2.0, 3.0], [4.0, 5.0, -6.0]],
+        dtype=torch.bfloat16,
+    )
+    reconstructed = torch.tensor(
+        [[0.75, -1.5, 2.5], [3.5, 4.5, -5.5]],
+        dtype=torch.bfloat16,
+    )
+    module = torch.nn.Linear(3, 2, bias=False, dtype=torch.bfloat16)
+    module.weight.data = reconstructed
+
+    saved = snapshot_eora_reconstructed_weight(module.weight.data)
+    expected = reconstructed.clone()
+
+    assert saved.device.type == "cpu"
+    assert saved.data_ptr() != module.weight.data.data_ptr()
+
+    # Lazy checkpoint materialization copies the dense tensor into the existing
+    # parameter storage. The module and the original reconstructed tensor are
+    # overwritten, but EoRA's saved reconstruction must remain unchanged.
+    module.weight.data.copy_(dense)
+
+    torch.testing.assert_close(module.weight.data, dense, rtol=0, atol=0)
+    torch.testing.assert_close(saved, expected, rtol=0, atol=0)


### PR DESCRIPTION
fix unsafe view/aliasing of wq which may be overwritten due to module re-materialization lifecycle logic. This data sync bug was introduced in later gptqmmodel lifecycle changes to reduce cpu/vram memory usage. 

@nbasyl 

