### PR TITLE
fix(logger): stop _AdaptiveLoggerProxy.__getattr__ from recursing on deepcopy (fixes #2966)

### DIFF
--- a/gptqmodel/utils/logger.py
+++ b/gptqmodel/utils/logger.py
@@ -82,6 +82,18 @@ class _AdaptiveLoggerProxy:
         return self._logger.spinner(title=title, interval=interval, tail_length=tail_length)
 
     def __getattr__(self, name):
+        # __getattr__ only runs when normal attribute lookup misses. If _logger
+        # itself is missing from the instance -- e.g. on a copy/pickle
+        # reconstructed proxy created via __new__ without __init__ -- then
+        # evaluating self._logger below re-enters __getattr__ and recurses
+        # forever (RecursionError). This happens in practice when an object that
+        # holds this proxy (see line ~223) is deepcopied: copy probes dunders
+        # such as __deepcopy__/__setstate__ on the freshly __new__'d instance
+        # before its __dict__ is restored. Raise a clean AttributeError for
+        # dunders and _logger so those probes fail normally and copy/pickle fall
+        # back to their default (which restores _logger).
+        if name == "_logger" or (name.startswith("__") and name.endswith("__")):
+            raise AttributeError(name)
         return getattr(self._logger, name)
 
 

--- a/tests/test_logger_proxy.py
+++ b/tests/test_logger_proxy.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+# -- do not touch
+# GPU=-1
+import os
+
+
+os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
+# -- end do not touch
+
+import copy  # noqa: E402
+import unittest  # noqa: E402
+
+from gptqmodel.utils.logger import _AdaptiveLoggerProxy  # noqa: E402
+
+
+class _StubLogger:
+    def info(self, *args, **kwargs):
+        return ("info", args, kwargs)
+
+
+class TestAdaptiveLoggerProxy(unittest.TestCase):
+    def test_forwards_attributes(self):
+        proxy = _AdaptiveLoggerProxy(_StubLogger())
+        self.assertEqual(proxy.info(1, k=2), ("info", (1,), {"k": 2}))
+
+    def test_deepcopy_does_not_recurse(self):
+        # Deepcopying an object that holds the proxy reconstructs the proxy via
+        # __new__ (without __init__); before the __getattr__ guard this looped
+        # through self._logger forever and raised RecursionError.
+        holder = {"log": _AdaptiveLoggerProxy(_StubLogger())}
+        clone = copy.deepcopy(holder)
+        self.assertEqual(clone["log"].info(3), ("info", (3,), {}))
+
+    def test_missing_logger_raises_attributeerror(self):
+        # A proxy with no _logger set (e.g. mid-reconstruction) must surface a
+        # clean AttributeError rather than recursing.
+        proxy = _AdaptiveLoggerProxy.__new__(_AdaptiveLoggerProxy)
+        with self.assertRaises(AttributeError):
+            _ = proxy.info
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Problem

Running the standard quantization example crashes with an infinite recursion right after the model loads (reported in #2966):

```
File ".../gptqmodel/utils/logger.py", line 85, in __getattr__
    return getattr(self._logger, name)
  [Previous line repeated 997 more times]
RecursionError: maximum recursion depth exceeded
```

### Root cause

`_AdaptiveLoggerProxy.__getattr__` unconditionally evaluates `self._logger`:

```python
def __getattr__(self, name):
    return getattr(self._logger, name)
```

`__getattr__` only runs when normal attribute lookup misses. If `_logger` is **not** present in the instance `__dict__`, evaluating `self._logger` inside `__getattr__` re-enters `__getattr__` for the name `_logger`, which evaluates `self._logger` again — recursing forever.

This is not hypothetical: the proxy is stored on objects as `self.logger`, and the codebase `deepcopy`s state during load/quantization. `copy.deepcopy` reconstructs the proxy via `cls.__new__(cls)` **without** calling `__init__`, then probes dunders such as `__deepcopy__` / `__setstate__` on the half-built instance (before its `__dict__` is restored). Each probe hits `__getattr__` → `self._logger` → recursion → `RecursionError`.

### Fix

Raise a clean `AttributeError` for dunder names and `_logger` inside `__getattr__`. The copy/pickle probes then fail normally, so `copy`/`pickle` fall back to their default protocol (which restores `_logger` from `__dict__`) and the deepcopy succeeds. Normal attribute forwarding (`log.info(...)`, etc.) is unchanged.

### Verification

Minimal standalone reproduction of the proxy semantics:

| variant | normal attribute access | `deepcopy` of a holder object |
|---|---|---|
| before | ok | **RecursionError** |
| after | ok | ok |

Added `tests/test_logger_proxy.py` (`GPU=-1`) covering attribute forwarding, deepcopy-without-recursion, and the clean-`AttributeError` path for a proxy with no `_logger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
