### PR TITLE
fix: fence parallel calibration workers before completion

### DIFF
--- a/gptqmodel/utils/looper_helpers.py
+++ b/gptqmodel/utils/looper_helpers.py
@@ -374,7 +374,8 @@ def forward_batch_worker(
     # TODO: rehome was done during cloning, is it still needed there?
     rehome_module_to_device(module, module_device, move_parameters=True, move_buffers=True)
 
-    torch_sync() # try to avoid torch.AcceleratorError: CUDA error: unspecified launch failure
+    # Replica preparation may enqueue non-blocking parameter or buffer copies.
+    torch_sync(device=module_device)
     inputs = [move_to(inp, device=module_device) for inp in layer_input]
 
     attn_tensor = None
@@ -449,6 +450,11 @@ def forward_batch_worker(
         # Replay only consumes the hidden-state tensor that feeds the next
         # layer.
         result_output = module_output[0] if isinstance(module_output, tuple) else module_output
+
+    # A worker future must not resolve until its accelerator work is complete.
+    # Balanced calibration keeps outputs on-device, so there is no blocking
+    # device-to-host copy to provide this fence before GC or replica teardown.
+    torch_sync(device=module_device)
 
     # Promptly release VRAM to reduce peak memory usage.
     del inputs

--- a/tests/test_looper_helpers.py
+++ b/tests/test_looper_helpers.py
@@ -1,5 +1,6 @@
 import torch
 
+import gptqmodel.utils.looper_helpers as looper_helpers
 from gptqmodel.utils.looper_helpers import forward_batch_worker
 
 
@@ -31,6 +32,49 @@ class _ReturnsAuxState(torch.nn.Module):
     def forward(self, hidden_states, use_cache=False):
         aux_state = hidden_states + 2
         return hidden_states + 1, aux_state
+
+
+class _RecordsForward(torch.nn.Module):
+    def __init__(self, events):
+        super().__init__()
+        self.events = events
+
+    def forward(self, hidden_states, use_cache=False):
+        self.events.append(("forward", hidden_states.device))
+        return hidden_states + 1
+
+
+def test_forward_batch_worker_waits_for_device_before_future_completion(monkeypatch):
+    events = []
+    processor = _DummyProcessor()
+    module = _RecordsForward(events)
+    hidden_states = torch.randn(1, 2, 4)
+    monkeypatch.setattr(
+        looper_helpers,
+        "torch_sync",
+        lambda device=None: events.append(("sync", device)),
+    )
+
+    forward_batch_worker(
+        module=module,
+        processor=processor,
+        batch_index=0,
+        layer_input=[hidden_states],
+        layer_input_kwargs={},
+        attention_mask=None,
+        position_ids=None,
+        support_batch_quantize=True,
+        is_lm_head_module=False,
+        need_output=True,
+        reuse_kv=False,
+        prev_kv=None,
+    )
+
+    assert events == [
+        ("sync", hidden_states.device),
+        ("forward", hidden_states.device),
+        ("sync", hidden_states.device),
+    ]
 
 
 def test_forward_batch_worker_passes_none_attention_mask_when_module_requires_it():

--- a/tests/test_looper_helpers.py
+++ b/tests/test_looper_helpers.py
@@ -1,7 +1,6 @@
 import torch
 
 import gptqmodel.utils.looper_helpers as looper_helpers
-from gptqmodel.utils.looper_helpers import forward_batch_worker
 
 
 class _DummyProcessor:
@@ -55,7 +54,7 @@ def test_forward_batch_worker_waits_for_device_before_future_completion(monkeypa
         lambda device=None: events.append(("sync", device)),
     )
 
-    forward_batch_worker(
+    looper_helpers.forward_batch_worker(
         module=module,
         processor=processor,
         batch_index=0,
@@ -82,7 +81,7 @@ def test_forward_batch_worker_passes_none_attention_mask_when_module_requires_it
     module = _RequiresAttentionMask()
     hidden_states = torch.randn(1, 2, 4)
 
-    batch_index, module_output, kv_next = forward_batch_worker(
+    batch_index, module_output, kv_next = looper_helpers.forward_batch_worker(
         module=module,
         processor=processor,
         batch_index=3,
@@ -108,7 +107,7 @@ def test_forward_batch_worker_skips_attention_mask_for_modules_without_the_kwarg
     module = _IgnoresAttentionMask()
     hidden_states = torch.randn(1, 2, 4)
 
-    batch_index, module_output, kv_next = forward_batch_worker(
+    batch_index, module_output, kv_next = looper_helpers.forward_batch_worker(
         module=module,
         processor=processor,
         batch_index=1,
@@ -134,7 +133,7 @@ def test_forward_batch_worker_only_returns_primary_tensor_for_tuple_outputs():
     module = _ReturnsAuxState()
     hidden_states = torch.randn(1, 2, 4)
 
-    batch_index, module_output, kv_next = forward_batch_worker(
+    batch_index, module_output, kv_next = looper_helpers.forward_batch_worker(
         module=module,
         processor=processor,
         batch_index=2,


### PR DESCRIPTION
## Summary

Fixes #2967.

Balanced calibration keeps replay outputs on the worker GPU. That makes the result-device move a no-op, so `forward_batch_worker` could return while its CUDA work was still pending. The device-pool future then resolved, its per-device read lock was released, and its completed-task counter could wake the 512-task cache janitor before the GPU was actually idle. Replica teardown had the same lifetime gap. The CPU calibration path masks this because its blocking device-to-host result copy supplies the missing fence.

## What Changed

- Keep the replica-readiness fence, but scope it to the worker device instead of synchronizing every visible accelerator.
- Synchronize the worker device before returning so a completed future now means its accelerator work is complete.
- Add a focused regression test that verifies device-scoped fences occur before and after replay.
- No public API changes.

## Tests

- [x] I added a new simple/fast unit test for this change, or documented why that is not applicable.
- [x] I ran the new targeted test locally before opening this PR.
- [x] I ran any other directly relevant local tests.

```bash
CUDA_VISIBLE_DEVICES=0,1 PYTHON_GIL=0 .venv/bin/python -m pytest -q tests/test_looper_helpers.py
# 4 passed

uvx --from ruff==0.14.2 ruff check gptqmodel/utils/looper_helpers.py tests/test_looper_helpers.py
# All checks passed
```

Stress validation uses Python 3.14.5t with `PYTHON_GIL=0` (`sys._is_gil_enabled() == False`), torch 2.13.0+cu130, Triton 3.7.1, and Transformers 5.14.1:

- Pre-fix: physical GPUs 2-5, 64 x 65,536-token samples, 16 samples/device. One run reached layer 28 without reproducing the issue's nondeterministic fault.
- Fixed: physical GPUs 0-5, 96 x 65,536-token samples, 16 samples/device. Running now; healthy through layer 4. This PR will be updated after it completes layer 27 and performs a final all-device synchronize.
- ECC was enabled with zero volatile corrected or uncorrected errors on all six test GPUs.

A wider nearby unit selection produced 41 passes and 8 existing fixture/API-drift failures (fake models missing `get_modules_with_direct_meta_tensors` and tests passing removed `run_layer_stage` arguments); none exercised the changed helper.

## Review Requirements

AI-assisted code is welcome.

Every changed file must still be properly reviewed by a human before the PR is opened as ready for review.

- [ ] I personally reviewed every file in this diff.
- [ ] I checked that the code matches existing project structure, APIs, and conventions.
- [ ] I avoided unnecessary monkeypatching and used the project's normal extension points where possible.

## Notes

The original pre-forward global synchronization was not removed outright because it also fences non-blocking replica/rehome copies before the first replay. Scoping that fence to the replica device preserves the safety property without coupling unrelated GPU workers. The added completion fence executes while the pool still holds that device's read lock, restoring the lock and janitor's intended device-idle contract.