### PR TITLE
Support quantized embedding inference without backend misselection

### DIFF
--- a/gptqmodel/models/_const.py
+++ b/gptqmodel/models/_const.py
@@ -34,7 +34,7 @@ NPU_0 = _optional_torch_device("npu:0", CPU)
 MPS = device("mps")
 ROCM = device("cuda:0")  # rocm maps to fake cuda
 
-SUPPORTS_MODULE_TYPES = [nn.Linear, nn.Conv1d, nn.Conv2d, transformers.Conv1D]
+SUPPORTS_MODULE_TYPES = [nn.Embedding, nn.Linear, nn.Conv1d, nn.Conv2d, transformers.Conv1D]
 
 DEFAULT_MAX_SHARD_SIZE = "4GB"
 

--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -73,7 +73,9 @@ from ..utils.model import (
     get_checkpoints,
     get_layers_with_prefixes,
     get_module_by_name_prefix,
+    get_module_name,
     gptqmodel_post_init,
+    is_embeddings_module_quantized,
     load_checkpoint_in_model_then_tie_weights,
     make_quant,
     simple_dispatch_model,
@@ -1224,9 +1226,23 @@ def ModelLoader(cls):
 
             modules = find_modules(model)
             ignore_modules = [cls.lm_head] + cls.get_base_modules(model)
+            input_embeddings = model.get_input_embeddings()
+            output_embeddings = model.get_output_embeddings()
+            input_embed_name = get_module_name(model, input_embeddings) if input_embeddings is not None else None
+            output_embed_name = get_module_name(model, output_embeddings) if output_embeddings is not None else None
+            input_embed_quantized, output_embed_quantized = is_embeddings_module_quantized(
+                model_dir=model_local_path,
+                input_embed_name=input_embed_name,
+                output_embed_name=output_embed_name,
+            )
 
             simple_layer_modules = cls.simple_layer_modules(config, qcfg)
             for name in list(modules.keys()):
+                if input_embed_quantized and name == input_embed_name:
+                    continue
+                if output_embed_quantized and name == output_embed_name:
+                    continue
+
                 # allow loading of quantized lm_head
                 if qcfg.lm_head and name == cls.lm_head:
                     continue

--- a/gptqmodel/nn_modules/qlinear/__init__.py
+++ b/gptqmodel/nn_modules/qlinear/__init__.py
@@ -64,6 +64,9 @@ def _torch_left_shift(values: t.Tensor, shifts: int | t.Tensor) -> t.Tensor:
 
 class BaseQuantLinear(nn.Module):
     SUPPORTS_BACKENDS: List[BACKEND] = None
+    # False for role-specific modules that are instantiated explicitly and
+    # must never participate in general backend discovery.
+    SUPPORTS_BACKEND_SELECTION: bool = True
     SUPPORTS_METHODS: List[METHOD] = None
     SUPPORTS_FORMATS: Dict[FORMAT, int] = None
     SUPPORTS_BITS: List[int] = None

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from transformers import PreTrainedModel
 
 from ...adapter.adapter import Adapter, Lora
@@ -748,4 +749,40 @@ def dequantize_model(model: PreTrainedModel):
     return model
 
 
-__all__ = ["TorchLinear", "dequantize_model"]
+class TorchQuantEmbeddings(TorchLinear):
+    """Quantized embedding layer backed by the Torch GPTQ dequant path."""
+
+    SUPPORTS_BACKENDS = [BACKEND.GPTQ_TORCH]
+    SUPPORTS_METHODS = [METHOD.GPTQ]
+    SUPPORTS_FORMATS = {FORMAT.GPTQ: 20, FORMAT.GPTQ_V2: 20}
+    # Embeddings are selected by module role in create_quant_module(), and must
+    # not be discovered as a general backend: their forward contract accepts
+    # integer token IDs, not hidden states.
+    SUPPORTS_BACKEND_SELECTION = False
+    SUPPORTS_BITS = [2, 3, 4, 8]
+    SUPPORTS_GROUP_SIZE = [-1, 16, 32, 64, 128, 256, 512, 1024]
+    SUPPORTS_DESC_ACT = [True, False]
+    SUPPORTS_SYM = [True, False]
+    SUPPORTS_SHARDS = True
+    SUPPORTS_TRAINING = False
+    SUPPORTS_AUTO_PADDING = True
+    SUPPORTS_IN_FEATURES_DIVISIBLE_BY = [1]
+    SUPPORTS_OUT_FEATURES_DIVISIBLE_BY = [1]
+
+    SUPPORTS_DEVICES = [DEVICE.ALL]
+    SUPPORTS_PLATFORM = [PLATFORM.ALL]
+    SUPPORTS_PACK_DTYPES = [torch.int8, torch.int16, torch.int32]
+    SUPPORTS_ADAPTERS = []
+
+    SUPPORTS_DTYPES = [torch.float16, torch.bfloat16]
+
+    REQUIRES_FORMAT_V2 = True
+
+    # for transformers/optimum tests compat
+    QUANT_TYPE = "torch"
+
+    def forward(self, input_ids: torch.Tensor):
+        return F.embedding(input_ids, self.dequantize_weight())
+
+
+__all__ = ["TorchLinear", "TorchQuantEmbeddings", "dequantize_model"]

--- a/gptqmodel/utils/importer.py
+++ b/gptqmodel/utils/importer.py
@@ -52,7 +52,10 @@ def iter_quant_linear_kernels() -> List[Type[BaseQuantLinear]]:
                 continue
             seen.add(subcls)
             _walk(subcls)
-            if "SUPPORTS_FORMATS" in subcls.__dict__:
+            if (
+                "SUPPORTS_FORMATS" in subcls.__dict__
+                and getattr(subcls, "SUPPORTS_BACKEND_SELECTION", True)
+            ):
                 kernels.append(subcls)
 
     _walk(BaseQuantLinear)

--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -45,6 +45,7 @@ from ..models._const import (
 from ..nn_modules.qlinear import BaseQuantLinear
 from ..nn_modules.qlinear.exllamav2 import ExllamaV2Linear
 from ..nn_modules.qlinear.exllamav2_awq import AwqExllamaV2Linear
+from ..nn_modules.qlinear.torch import TorchQuantEmbeddings
 from ..quantization import FORMAT, QuantizeConfig
 from ..quantization.config import (
     FORMAT_FIELD_CODE,
@@ -511,6 +512,9 @@ def create_quant_module(
         # print(f"offloading named module: {module.full_name}")
         submodule = submodule.module
 
+    if isinstance(submodule, nn.Embedding):
+        linear_cls = TorchQuantEmbeddings
+
     # submodule may be BaseQuantLinear, and the next QuantLinear is selected because of in_features/out_features
     # mismatch and other reasons.
     # In this case, need to call list_buffer() to get the device.
@@ -531,6 +535,9 @@ def create_quant_module(
     elif isinstance(submodule, nn.Linear):
         in_features = submodule.in_features
         out_features = submodule.out_features
+    elif isinstance(submodule, nn.Embedding):
+        in_features = submodule.num_embeddings
+        out_features = submodule.embedding_dim
     elif isinstance(submodule, _ConvNd):
         in_features = submodule.in_channels
         out_features = submodule.out_channels
@@ -544,7 +551,7 @@ def create_quant_module(
     else:
         raise NotImplementedError(f"Unsupported module {submodule}")
 
-    bias = submodule.bias is not None
+    bias = submodule.bias is not None if hasattr(submodule, "bias") else False
 
     # need copies as dynamic config may override these in for loop
     tmp_bits = _normalize_quant_bits(bits, format_value=format)
@@ -676,9 +683,11 @@ def create_quant_layer(
         if name not in quant_result:
             continue
 
+        qlinear_cls = TorchQuantEmbeddings if isinstance(submodule, nn.Embedding) else linear_cls
+
         create_quant_module(
             name=name,
-            linear_cls=linear_cls,
+            linear_cls=qlinear_cls,
             bits=bits,
             desc_act=desc_act,
             dynamic=dynamic,
@@ -827,7 +836,11 @@ def convert_gptq_v1_to_v2_format(
         # v1 checkpoint format with sym=False saved via convert_gptq_v2_to_v1_format() will
         # overflow ~<=13% based on testing
         if isinstance(submodule, qlinear_kernel):
-            convert_gptq_v1_to_v2_format_module(module=submodule, bits=cfg.bits, pack_dtype=cfg.pack_dtype)
+            convert_gptq_v1_to_v2_format_module(
+                module=submodule,
+                bits=getattr(submodule, "bits", cfg.bits),
+                pack_dtype=getattr(submodule, "pack_dtype", cfg.pack_dtype),
+            )
 
         #log.info(f"Format: Conversion complete: {time.time() - t}s")
 
@@ -857,13 +870,15 @@ def convert_gptq_v2_to_v1_format_module(
 
     log.info.once("Format: Converting GPTQ v2 to v1")
 
-    if quantize_config.bits == 2:
+    bits = getattr(module, "bits", quantize_config.bits)
+    pack_dtype = getattr(module, "pack_dtype", quantize_config.pack_dtype)
+    if bits == 2:
         module.qzeros.data -= 0b01010101010101010101010101010101
-    elif quantize_config.bits == 3:
-        if quantize_config.pack_dtype == torch.int32:
+    elif bits == 3:
+        if pack_dtype == torch.int32:
             # Keep INT3 export symmetric with the load-side logical correction.
             module.qzeros.data.copy_(
-                _revert_gptq_v1_qzeros_correction(module.qzeros.data, quantize_config.bits)
+                _revert_gptq_v1_qzeros_correction(module.qzeros.data, bits)
             )
         else:
             module.qzeros.data[:, range(0, module.qzeros.data.shape[1], 3)] -= (
@@ -875,9 +890,9 @@ def convert_gptq_v2_to_v1_format_module(
             module.qzeros.data[:, range(2, module.qzeros.data.shape[1], 3)] -= (
                 0b01001001001001001001001001001001
             )
-    elif quantize_config.bits == 4:
+    elif bits == 4:
         module.qzeros.data -= 0b00010001000100010001000100010001
-    elif quantize_config.bits == 8:
+    elif bits == 8:
         module.qzeros.data -= 0b00000001000000010000000100000001
     else:
         raise NotImplementedError("Only 2,3,4,8 bits are supported.")
@@ -1965,6 +1980,60 @@ def find_config_seq_len(config_dict, target_keys):
             if found is not None:
                 return found
     return None
+
+
+def get_module_name(module: nn.Module, child_module: nn.Module) -> str:
+    for name, candidate in module.named_modules():
+        if candidate is child_module:
+            return name
+    raise ValueError(f"Cannot find child_module {child_module} in module {module}")
+
+
+def check_module_quantized_in_keys(keys, module_name: str) -> bool:
+    return any(
+        key.startswith(module_name + ".")
+        and (".qweight" in key or ".qzeros" in key or ".scales" in key)
+        for key in keys
+    )
+
+
+def is_embeddings_module_quantized(
+    model_dir: str,
+    input_embed_name: Optional[str],
+    output_embed_name: Optional[str],
+) -> Tuple[bool, bool]:
+    input_quantized = False
+    output_quantized = False
+
+    def inspect_keys(keys) -> Tuple[bool, bool]:
+        return (
+            bool(input_embed_name and check_module_quantized_in_keys(keys, input_embed_name)),
+            bool(output_embed_name and check_module_quantized_in_keys(keys, output_embed_name)),
+        )
+
+    index_path = os.path.join(model_dir, "model.safetensors.index.json")
+    if os.path.exists(index_path):
+        with open(index_path, "r", encoding="utf-8") as handle:
+            index = json.load(handle)
+        return inspect_keys(index.get("weight_map", {}).keys())
+
+    safetensor_files = [
+        os.path.join(model_dir, filename)
+        for filename in os.listdir(model_dir)
+        if filename.endswith(".safetensors")
+    ]
+    for safefile in safetensor_files:
+        try:
+            with safe_open(safefile, framework="pt") as handle:
+                found_input, found_output = inspect_keys(handle.keys())
+                input_quantized = input_quantized or found_input
+                output_quantized = output_quantized or found_output
+                if input_quantized and output_quantized:
+                    break
+        except Exception as exc:
+            log.warn(f"Failed to inspect {safefile}: {exc}")
+
+    return input_quantized, output_quantized
 
 
 def has_any_attr(obj, names):

--- a/tests/kernels/test_selection.py
+++ b/tests/kernels/test_selection.py
@@ -16,12 +16,19 @@ from gptqmodel.nn_modules.qlinear.gguf_triton import GGUFTritonKernel
 from gptqmodel.nn_modules.qlinear.machete import MacheteLinear
 from gptqmodel.nn_modules.qlinear.machete_awq import AwqMacheteLinear
 from gptqmodel.nn_modules.qlinear.marlin_awq import AwqMarlinLinear
+from gptqmodel.nn_modules.qlinear.torch import TorchQuantEmbeddings
 from gptqmodel.nn_modules.qlinear.torch_aten_kernel import TorchAtenLinear
 from gptqmodel.nn_modules.qlinear.torch_aten_kernel_awq import TorchAtenAwqLinear
 from gptqmodel.quantization import FORMAT, METHOD
 from gptqmodel.utils import importer
 from gptqmodel.utils.backend import BACKEND
-from gptqmodel.utils.importer import AUTO_BACKEND_KERNEL_MAPPING, auto_select_device, select_quant_linear
+from gptqmodel.utils.importer import (
+    AUTO_BACKEND_KERNEL_MAPPING,
+    auto_select_device,
+    build_kernel_support_maps,
+    iter_quant_linear_kernels,
+    select_quant_linear,
+)
 from gptqmodel.utils.rocm import IS_ROCM
 from gptqmodel.utils.torch import HAS_CUDA, HAS_MPS, HAS_XPU
 
@@ -140,6 +147,17 @@ def test_auto_select_normalizes_torch_device_before_device_prefilter(monkeypatch
     )
 
     assert qlinear_cls is CudaKernel
+
+
+def test_role_only_kernel_is_excluded_from_backend_discovery():
+    assert TorchQuantEmbeddings.SUPPORTS_BACKEND_SELECTION is False
+    assert TorchQuantEmbeddings not in iter_quant_linear_kernels()
+    auto_mapping, _ = build_kernel_support_maps()
+    assert all(
+        TorchQuantEmbeddings not in backend_mapping.values()
+        for format_mapping in auto_mapping.values()
+        for backend_mapping in format_mapping.values()
+    )
 
 
 CASES = []

--- a/tests/test_quantized_embeddings.py
+++ b/tests/test_quantized_embeddings.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+import json
+
+import torch
+import torch.nn as nn
+from safetensors.torch import save_file
+
+from gptqmodel.nn_modules.qlinear.torch import TorchQuantEmbeddings
+from gptqmodel.utils.model import find_modules, is_embeddings_module_quantized
+
+
+def test_find_modules_includes_embeddings():
+    model = nn.Module()
+    model.embed_tokens = nn.Embedding(16, 8)
+    model.proj = nn.Linear(8, 8)
+
+    modules = find_modules(model)
+
+    assert modules["embed_tokens"] is model.embed_tokens
+    assert modules["proj"] is model.proj
+
+
+def test_quantized_embedding_detection_reads_safetensors_keys(tmp_path):
+    save_file(
+        {
+            "model.embed_tokens.qweight": torch.zeros((2, 2), dtype=torch.int32),
+            "model.embed_tokens.scales": torch.ones((2, 2), dtype=torch.float16),
+            "lm_head.weight": torch.zeros((2, 2), dtype=torch.float16),
+        },
+        tmp_path / "model.safetensors",
+    )
+
+    assert is_embeddings_module_quantized(
+        model_dir=str(tmp_path),
+        input_embed_name="model.embed_tokens",
+        output_embed_name="lm_head",
+    ) == (True, False)
+
+
+def test_quantized_embedding_detection_reads_sharded_index(tmp_path):
+    index = {
+        "weight_map": {
+            "model.embed_tokens.weight": "model-00001-of-00002.safetensors",
+            "lm_head.qweight": "model-00002-of-00002.safetensors",
+            "lm_head.qzeros": "model-00002-of-00002.safetensors",
+        }
+    }
+    (tmp_path / "model.safetensors.index.json").write_text(json.dumps(index), encoding="utf-8")
+
+    assert is_embeddings_module_quantized(
+        model_dir=str(tmp_path),
+        input_embed_name="model.embed_tokens",
+        output_embed_name="lm_head",
+    ) == (False, True)
+
+
+def test_embedding_kernel_is_role_only():
+    assert TorchQuantEmbeddings.SUPPORTS_BACKEND_SELECTION is False

--- a/tests/test_qzero_offsets.py
+++ b/tests/test_qzero_offsets.py
@@ -11,6 +11,7 @@ from safetensors.torch import save_file
 from gptqmodel.nn_modules.qlinear import BaseQuantLinear
 from gptqmodel.quantization import FORMAT, METHOD
 from gptqmodel.utils.model import (
+    convert_gptq_v1_to_v2_format,
     convert_gptq_v1_to_v2_format_module,
     convert_gptq_v2_to_v1_format_module,
 )
@@ -158,6 +159,30 @@ def test_qzero_offsets_roundtrip(bits: int, pack_dtype: torch.dtype) -> None:
     )
 
     assert torch.equal(module.qzeros.data, original)
+
+
+@torch.inference_mode()
+def test_qzero_offsets_use_module_contract_for_mixed_width_checkpoint() -> None:
+    module = _make_module(bits=4, pack_dtype=torch.int32)
+    model = nn.Sequential(module)
+    global_decoder_config = SimpleNamespace(
+        bits=3,
+        pack_dtype=torch.int32,
+        export_quant_method=lambda: METHOD.GPTQ,
+    )
+
+    convert_gptq_v1_to_v2_format(
+        model=model,
+        cfg=global_decoder_config,
+        qlinear_kernel=_TestQuantLinear,
+    )
+    convert_gptq_v2_to_v1_format_module(
+        module=module,
+        quantize_config=global_decoder_config,
+    )
+
+    assert torch.count_nonzero(module.qzeros.data) == 0
+    assert module.qzero_format() == 1
 
 
 @torch.inference_mode()

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -7,12 +7,17 @@ from __future__ import annotations
 import pytest
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 import gptqmodel.utils.torch as torch_utils
+from gptqmodel.models._const import DEVICE
 from gptqmodel.nn_modules.qlinear import PackableQuantLinear
 from gptqmodel.nn_modules.qlinear.lookahead import configure_default_lookahead
-from gptqmodel.nn_modules.qlinear.torch import TorchLinear
+from gptqmodel.nn_modules.qlinear.torch import TorchLinear, TorchQuantEmbeddings
 from gptqmodel.nn_modules.qlinear.tritonv2 import TritonV2Linear
+from gptqmodel.quantization import FORMAT
+from gptqmodel.utils.backend import BACKEND
+from gptqmodel.utils.model import create_quant_module
 
 
 def _mock_gptq_linear(bits: int, group_size: int, in_features: int, out_features: int) -> tuple[nn.Linear, torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -51,6 +56,58 @@ def _mock_gptq_linear(bits: int, group_size: int, in_features: int, out_features
     )
 
     return linear, scales, zeros, g_idx
+
+
+def test_torch_quant_embeddings_forward_matches_dequantized_lookup():
+    bits = 4
+    group_size = 32
+    vocab_size = 64
+    embedding_dim = 32
+    linear, scales, zeros, g_idx = _mock_gptq_linear(bits, group_size, vocab_size, embedding_dim)
+    module = TorchQuantEmbeddings(
+        bits=bits,
+        group_size=group_size,
+        sym=True,
+        desc_act=False,
+        in_features=vocab_size,
+        out_features=embedding_dim,
+        pack_dtype=torch.int32,
+        bias=False,
+    )
+    module.pack_block(linear, scales.T, zeros.T, g_idx=g_idx)
+    module.optimize = lambda *args, **kwargs: None
+    module.post_init()
+
+    input_ids = torch.tensor([[0, 7, 63], [12, 31, 2]], dtype=torch.long)
+
+    torch.testing.assert_close(module(input_ids), F.embedding(input_ids, module.dequantize_weight()))
+
+
+def test_create_quant_module_uses_embedding_kernel_for_embedding_role():
+    model = nn.Module()
+    model.embed_tokens = nn.Embedding(64, 32, dtype=torch.float16)
+
+    create_quant_module(
+        name="embed_tokens",
+        linear_cls=TorchLinear,
+        bits=4,
+        desc_act=False,
+        dynamic=None,
+        group_size=32,
+        module=model,
+        submodule=model.embed_tokens,
+        sym=True,
+        device=DEVICE.CPU,
+        lm_head_name="lm_head",
+        pack_dtype=torch.int32,
+        format=FORMAT.GPTQ_V2,
+        backend=BACKEND.GPTQ_TORCH,
+        dtype=torch.float16,
+    )
+
+    assert isinstance(model.embed_tokens, TorchQuantEmbeddings)
+    assert model.embed_tokens.in_features == 64
+    assert model.embed_tokens.out_features == 32
 
 
 @pytest.mark.cuda


### PR DESCRIPTION
## Summary

- add `TorchQuantEmbeddings` for packed input-embedding inference
- select the embedding kernel by module role while keeping decoder and output-projection modules on compatible linear kernels
- detect quantized input/output endpoint tensors from checkpoint metadata during model-shell construction
- allow role-specific kernels to opt out of general automatic backend discovery
- use each packed module's own quantization contract during format conversion

## Why

Packed embedding tensors need a module with an embedding-lookup forward contract, while ordinary decoder projections require a matrix-multiplication contract. Treating both as general backend candidates can install a role-specific kernel in an incompatible module.

Endpoint discovery also needs to inspect checkpoint tensor metadata before loading so packed endpoint tensors are materialized instead of being ignored. Format conversion must follow each module's stored contract rather than assume every packed module shares one global width.

## Validation

- Ruff passed on all changed files
- endpoint discovery and role-selection tests passed
- embedding lookup matched the dequantized reference
- automatic backend selection retained the general Torch linear kernel for decoder projections
- mixed-width format-conversion regression passed
- save/load inference smoke validation produced finite outputs
