### PR TITLE
fix: per-module dynamic kernel selection for mixed-bitwidth models

### DIFF
--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -34,6 +34,7 @@ from transformers.utils import is_flash_attn_2_available
 from ..adapter.adapter import Adapter
 from ..nn_modules.exllamav3 import ExllamaV3Linear
 from ..nn_modules.exllamav3_torch import ExllamaV3TorchLinear
+from ..nn_modules.qlinear import BaseQuantLinear
 from ..nn_modules.qlinear.exllamav2 import ExllamaV2Linear
 from ..nn_modules.qlinear.gguf import GGUFTorchLinear
 from ..quantization import QuantizeConfig
@@ -1519,7 +1520,10 @@ def ModelLoader(cls):
                         f"Format: Loading of a sym=False model with format={FORMAT.GPTQ} is only supported if produced by gptqmodel version >= {MIN_VERSION_WITH_V2}"
                     )
 
-                if preload_qlinear_kernel.REQUIRES_FORMAT_V2:
+                if any(
+                    isinstance(m, BaseQuantLinear) and getattr(m, "REQUIRES_FORMAT_V2", False)
+                    for m in model.modules()
+                ):
                     model = convert_gptq_v1_to_v2_format(
                         model,
                         cfg=qcfg,

--- a/gptqmodel/utils/importer.py
+++ b/gptqmodel/utils/importer.py
@@ -42,6 +42,71 @@ def _supports_pack_api(cls: Type[BaseQuantLinear]) -> bool:
     )
 
 
+def _iter_dynamic_contracts(
+    dynamic,
+    bits: int,
+    group_size: int,
+    desc_act: bool,
+    sym: bool,
+    pack_dtype: torch.dtype,
+    format_value: FORMAT,
+):
+    """Yield distinct effective quantization configs from base + optional dynamic overrides.
+
+    When `dynamic` is provided, auto-selection tests each kernel against the union of
+    effective (bits, group_size, desc_act, sym, pack_dtype) contracts. This lets a
+    mixed-bitwidth model use a kernel that only supports 4-bit weights for its 4-bit
+    layers even when the base `bits` is 3.
+    """
+
+    base_contract = {
+        "bits": bits,
+        "group_size": group_size,
+        "desc_act": desc_act,
+        "sym": sym,
+        "pack_dtype": pack_dtype,
+    }
+    if not dynamic:
+        yield base_contract
+        return
+
+    seen = {(bits, group_size, desc_act, sym, pack_dtype)}
+    yield base_contract
+
+    for pattern, overrides in dynamic.items():
+        if not isinstance(overrides, dict):
+            continue
+        if isinstance(pattern, str) and pattern.startswith("-"):
+            continue
+        if overrides is None:
+            continue
+
+        contract_bits = overrides.get("bits", bits)
+        if contract_bits is not None:
+            contract_bits = quant_bits_width(_normalize_quant_bits(contract_bits, format_value=format_value))
+        else:
+            contract_bits = bits
+
+        contract = {
+            "bits": contract_bits,
+            "group_size": overrides.get("group_size", group_size),
+            "desc_act": overrides.get("desc_act", desc_act),
+            "sym": overrides.get("sym", sym),
+            "pack_dtype": overrides.get("pack_dtype", pack_dtype),
+        }
+        key = (
+            contract["bits"],
+            contract["group_size"],
+            contract["desc_act"],
+            contract["sym"],
+            contract["pack_dtype"],
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        yield contract
+
+
 def iter_quant_linear_kernels() -> List[Type[BaseQuantLinear]]:
     kernels = []
     seen = set()
@@ -473,53 +538,76 @@ def select_quant_linear(
         if not allow_quant_linears:
             raise ValueError(f"No auto-select kernels found for `{quant_method}` with format `{format}`.")
 
-        err = None
+        last_err = None
         global message_logged
-        # Suppose all quant linears in the model should have the same backend.
+        # For multi-select (used by make_quant/create_quant_layer) we test each kernel
+        # against the union of effective quant contracts (base + dynamic). This lets
+        # mixed-bitwidth models pick different kernels per layer, e.g. a 4-bit-only
+        # kernel for 4-bit dynamic layers while the base bits is 3. For single-select
+        # we keep the original base contract with the full dynamic map so callers
+        # asking for one representative kernel get a model-wide-compatible answer.
+        if multi_select:
+            contracts = list(_iter_dynamic_contracts(dynamic, bits, group_size, desc_act, sym, pack_dtype, format))
         for k, cls in allow_quant_linears:
             if DEVICE.ALL not in cls.SUPPORTS_DEVICES and device is not None and device not in cls.SUPPORTS_DEVICES:
                 if os.environ.get("DEBUG"):
                     log.info(f"skip {k} for unsupported device `{device}`")
                 continue
-            validate, err = cls.validate(
-                bits=bits,
-                group_size=group_size,
-                desc_act=desc_act,
-                sym=sym,
-                pack_dtype=pack_dtype,
-                dtype=dtype,
-                dynamic=dynamic,
-                device=device,
-                trainable=trainable,
-                adapter=adapter,
-            )
-            if os.environ.get("DEBUG") and not validate:
-                log.info(f"skip {k} for {str(err)}")
-            if validate:
-                if pack:
-                    if _supports_pack_api(cls):
-                        #if not message_logged:
-                        #    logger.info(f"Auto pick kernel based on compatibility: {cls}")
-                        #    message_logged = True
-                        log.info(f"{'Packing ' if pack else ''}Kernel: Auto-selection: adding candidate `{cls.__name__}`")
-                        validated_qlinears.append(cls)
-                        if not multi_select:
-                            log.info(f"Kernel: selected -> `{cls.__name__}`.")
-                            return cls
-                else:
-                    #if not message_logged:
-                    #    logger.info(f"Auto pick kernel based on compatibility: {cls}")
-                    #    message_logged = True
+
+            validated = False
+            contract_err = None
+            if multi_select:
+                for contract in contracts:
+                    validated, contract_err = cls.validate(
+                        bits=contract["bits"],
+                        group_size=contract["group_size"],
+                        desc_act=contract["desc_act"],
+                        sym=contract["sym"],
+                        pack_dtype=contract["pack_dtype"],
+                        dtype=dtype,
+                        dynamic=None,
+                        device=device,
+                        trainable=trainable,
+                        adapter=adapter,
+                    )
+                    if validated:
+                        break
+            else:
+                validated, contract_err = cls.validate(
+                    bits=bits,
+                    group_size=group_size,
+                    desc_act=desc_act,
+                    sym=sym,
+                    pack_dtype=pack_dtype,
+                    dtype=dtype,
+                    dynamic=dynamic,
+                    device=device,
+                    trainable=trainable,
+                    adapter=adapter,
+                )
+            if not validated:
+                last_err = contract_err
+                if os.environ.get("DEBUG"):
+                    log.info(f"skip {k} for {str(contract_err)}")
+                continue
+
+            if pack:
+                if _supports_pack_api(cls):
                     log.info(f"{'Packing ' if pack else ''}Kernel: Auto-selection: adding candidate `{cls.__name__}`")
                     validated_qlinears.append(cls)
                     if not multi_select:
                         log.info(f"Kernel: selected -> `{cls.__name__}`.")
                         return cls
-
-        if err:
-            raise err
+            else:
+                log.info(f"{'Packing ' if pack else ''}Kernel: Auto-selection: adding candidate `{cls.__name__}`")
+                validated_qlinears.append(cls)
+                if not multi_select:
+                    log.info(f"Kernel: selected -> `{cls.__name__}`.")
+                    return cls
 
         if len(validated_qlinears) == 0:
+            if last_err:
+                raise last_err
             raise ValueError("No valid quant linear")
 
         return validated_qlinears

--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -32,7 +32,6 @@ from transformers import PretrainedConfig
 from transformers.pytorch_utils import id_tensor_storage
 from transformers.utils.hub import cached_file
 
-from gptqmodel.nn_modules.qlinear.marlin import MarlinLinear
 
 from ..adapter.adapter import Adapter
 from ..looper.named_module import NamedModule
@@ -449,42 +448,28 @@ def make_quant(
 
     log.info(f"Kernel: candidates -> `[{', '.join(cls.__name__ for cls in quant_linear_candidates)}]`")
 
-    # loop over actual QLinear init, catch errors and use fallbacks if applicable
-    for cls in quant_linear_candidates:
-        try:
-            # if linear is not selectedQLinear:
-            #     logger.info(f"make_quant: Faild linear: `{selectedQLinear}` failed, trying to use fallback: `{linear}`")
-            # else:
-            #     logger.info("make_quant: Testing linear: {linear}")
-
-            linear_cls = create_quant_layer(
-                linear_cls=cls,
-                bits=bits,
-                desc_act=desc_act,
-                dynamic=dynamic,
-                group_size=group_size,
-                module=module,
-                sym=sym,
-                device=device,
-                quant_result=quant_result,
-                lm_head_name=lm_head_name,
-                pack_dtype=pack_dtype,
-                backend=backend,
-                adapter=qcfg.adapter,
-                format=format,
-                init_kwargs=init_kwargs,
-                dtype=dtype,
-            )
-            log.info(f"Kernel: selected -> `{linear_cls.__name__}`.")
-            return linear_cls
-        except NotImplementedError as e:
-            log.info(f"Kernel: skipped -> `{cls}`.")
-
-            # only fallback to other quant linears when backend is auto.
-            if backend not in [BACKEND.AUTO, BACKEND.AUTO_TRAINABLE]:
-                raise e
-
-    raise ValueError(f"No compatible quant linear was found for this module: {module.__class__.__name__}")
+    # Per-module kernel selection: each submodule picks the first candidate that
+    # validates against its effective (possibly dynamic-overridden) quant config.
+    linear_cls = create_quant_layer(
+        linear_candidates=quant_linear_candidates,
+        bits=bits,
+        desc_act=desc_act,
+        dynamic=dynamic,
+        group_size=group_size,
+        module=module,
+        sym=sym,
+        device=device,
+        quant_result=quant_result,
+        lm_head_name=lm_head_name,
+        pack_dtype=pack_dtype,
+        backend=backend,
+        adapter=qcfg.adapter,
+        format=format,
+        init_kwargs=init_kwargs,
+        dtype=dtype,
+    )
+    log.info(f"Kernel: selected -> `{linear_cls.__name__}`.")
+    return linear_cls
 
 def create_quant_module(
     name: str,
@@ -658,7 +643,7 @@ def create_quant_module(
     recurse_setattr(module, name, new_layer.to(ori_layer_device))
 
 def create_quant_layer(
-        linear_cls: Type[BaseQuantLinear],
+        linear_candidates: List[Type[BaseQuantLinear]],
         bits,
         desc_act: bool,
         dynamic,
@@ -676,36 +661,64 @@ def create_quant_layer(
         dtype: Optional[torch.dtype] = None,
 
 ) -> Type[BaseQuantLinear]:
-    if isinstance(module, linear_cls):
-        return linear_cls
+    if any(isinstance(module, candidate) for candidate in linear_candidates):
+        return type(module)
+
+    selected_counts = {candidate: 0 for candidate in linear_candidates}
+    selected_counts[TorchQuantEmbeddings] = 0
     for name, submodule in module.named_modules():
         # skip non-quantized modules
         if name not in quant_result:
             continue
 
-        qlinear_cls = TorchQuantEmbeddings if isinstance(submodule, nn.Embedding) else linear_cls
+        candidates = [TorchQuantEmbeddings] if isinstance(submodule, nn.Embedding) else linear_candidates
+        last_error = None
+        for qlinear_cls in candidates:
+            try:
+                create_quant_module(
+                    name=name,
+                    linear_cls=qlinear_cls,
+                    bits=bits,
+                    desc_act=desc_act,
+                    dynamic=dynamic,
+                    group_size=group_size,
+                    module=module,
+                    submodule=submodule,
+                    sym=sym,
+                    device=device,
+                    lm_head_name=lm_head_name,
+                    pack_dtype=pack_dtype,
+                    format=format,
+                    backend=backend,
+                    adapter=adapter,
+                    init_kwargs=init_kwargs,
+                    dtype=dtype,
+                )
+            except NotImplementedError as error:
+                last_error = error
+                if backend not in [BACKEND.AUTO, BACKEND.AUTO_TRAINABLE]:
+                    raise
+                continue
 
-        create_quant_module(
-            name=name,
-            linear_cls=qlinear_cls,
-            bits=bits,
-            desc_act=desc_act,
-            dynamic=dynamic,
-            group_size=group_size,
-            module=module,
-            submodule=submodule,
-            sym=sym,
-            device=device,
-            lm_head_name=lm_head_name,
-            pack_dtype=pack_dtype,
-            format=format,
-            backend=backend,
-            adapter=adapter,
-            init_kwargs=init_kwargs,
-            dtype=dtype,
-        )
+            selected_counts[qlinear_cls] = selected_counts.get(qlinear_cls, 0) + 1
+            break
+        else:
+            if last_error is not None:
+                raise last_error
+            raise ValueError(f"No compatible quant linear was found for module `{name}`.")
 
-    return linear_cls
+    selected_counts = {candidate: count for candidate, count in selected_counts.items() if count}
+    if not selected_counts:
+        raise ValueError(f"No compatible quant linear was found for this module: {module.__class__.__name__}")
+
+    summary = ", ".join(f"{candidate.__name__}={count}" for candidate, count in selected_counts.items())
+    log.info(f"Kernel: per-module selections -> `[{summary}]`")
+    non_embedding_counts = {
+        candidate: count
+        for candidate, count in selected_counts.items()
+        if candidate is not TorchQuantEmbeddings
+    }
+    return max(non_embedding_counts or selected_counts, key=(non_embedding_counts or selected_counts).get)
 
 # public/stable api exposed to transformer/optimum
 def hf_convert_gptq_v1_to_v2_format(
@@ -716,8 +729,11 @@ def hf_convert_gptq_v1_to_v2_format(
     meta: Optional[Dict[str, any]],
 ) -> Tuple[nn.Module, bool]:
     if checkpoint_format == "gptq":
-        # skip v1 to v2 conversion for kernels that can only operate on sym=True (gptq_v1)
-        if qlinear_kernel is MarlinLinear:
+        # Skip v1 to v2 conversion when no loaded quant module requires v2.
+        if not any(
+            isinstance(m, BaseQuantLinear) and getattr(m, "REQUIRES_FORMAT_V2", False)
+            for m in model.modules()
+        ):
             return model, False
 
         cfg = QuantizeConfig(bits=bits)
@@ -818,10 +834,13 @@ def convert_gptq_v1_to_v2_format(
     cfg: QuantizeConfig,
     qlinear_kernel: Type[BaseQuantLinear],
 ):
-    # skip v2 to v1 conversion for gptq_v1 kernels
-    if cfg.export_quant_method() == METHOD.GPTQ and not qlinear_kernel.REQUIRES_FORMAT_V2:
+    # skip v2 to v1 conversion when no loaded quant module requires v2
+    if cfg.export_quant_method() == METHOD.GPTQ and not any(
+        isinstance(m, BaseQuantLinear) and getattr(m, "REQUIRES_FORMAT_V2", False)
+        for m in model.modules()
+    ):
         log.info(
-            f"Format: Skipped v1 to v2 conversion due to Kernel  `{qlinear_kernel}`.")
+            f"Format: Skipped v1 to v2 conversion; no selected kernel requires v2 (`{qlinear_kernel}`).")
         return model
 
     # Limit thread usage to avoid auto-parallizataion regression
@@ -835,7 +854,7 @@ def convert_gptq_v1_to_v2_format(
         # additions here do not overflow.
         # v1 checkpoint format with sym=False saved via convert_gptq_v2_to_v1_format() will
         # overflow ~<=13% based on testing
-        if isinstance(submodule, qlinear_kernel):
+        if isinstance(submodule, BaseQuantLinear) and getattr(submodule, "REQUIRES_FORMAT_V2", False):
             convert_gptq_v1_to_v2_format_module(
                 module=submodule,
                 bits=getattr(submodule, "bits", cfg.bits),
@@ -907,15 +926,18 @@ def convert_gptq_v2_to_v1_format(
     qlinear_kernel: Type[BaseQuantLinear],
 ):
 
-    # skip v2 to v1 conversion for gptq_v1 kernels
-    if quantize_config.export_quant_method() == METHOD.GPTQ and not qlinear_kernel.REQUIRES_FORMAT_V2:
+    # skip v2 to v1 conversion when no loaded quant module requires v2
+    if quantize_config.export_quant_method() == METHOD.GPTQ and not any(
+        isinstance(m, BaseQuantLinear) and getattr(m, "REQUIRES_FORMAT_V2", False)
+        for m in model.modules()
+    ):
         return model
 
     # Limit thread usage to avoid auto-parallizataion regression
     # with tctl.threadpool_limits(limits=1):
     for _, submodule in model.named_modules():
         # sym=False has underflow probability of ~<=13% during testing. No underflow possible for sym=True.
-        if isinstance(submodule, qlinear_kernel):
+        if isinstance(submodule, BaseQuantLinear) and getattr(submodule, "REQUIRES_FORMAT_V2", False):
             convert_gptq_v2_to_v1_format_module(module=submodule, quantize_config=quantize_config)
 
     return model
@@ -978,8 +1000,12 @@ def pack_module(
         layers[name] = layer
         qModules[name] = module
 
+    # Use the module's actual class when it is a real BaseQuantLinear; otherwise
+    # fall back to the caller-supplied representative class (e.g. unit-test mocks).
+    module_cls = type(module) if isinstance(module, BaseQuantLinear) else quant_linear_cls
+
     # TODO FIX ME..remove hard coded qqq pack
-    if quant_linear_cls.QUANT_TYPE == "qqq":
+    if module_cls.QUANT_TYPE == "qqq":
         if q_scales_extra is not None:
             q_scales_extra = q_scales_extra.to(CPU)
         packer_label = "module.pack"
@@ -989,7 +1015,7 @@ def pack_module(
             module_name=name,
         ):
             module.pack(linear=layer, scales=q_scales, s_extra=q_scales_extra)
-    elif quant_linear_cls.QUANT_TYPE.startswith("awq_") or quant_linear_cls.QUANT_TYPE == "llm-awq":
+    elif module_cls.QUANT_TYPE.startswith("awq_") or module_cls.QUANT_TYPE == "llm-awq":
         packer_label = "module.pack"
         with log_time_block(
             packer_label,
@@ -1064,7 +1090,7 @@ def pack_module(
             quantize_config is not None
             and quantize_config.export_quant_method() == METHOD.GPTQ
             and resolve_quant_format(quantize_config.format, quantize_config.method) == FORMAT.GPTQ
-            and getattr(quant_linear_cls, "REQUIRES_FORMAT_V2", False)
+            and getattr(module_cls, "REQUIRES_FORMAT_V2", False)
         ):
             with log_time_block(
                 "convert_v2_to_v1",
@@ -1124,9 +1150,13 @@ def pack_model(
         device=DEVICE.CPU,
     )
 
-    qModules = find_modules(model, [quant_linear_cls])
+    qModules = {
+        name: quant_module
+        for name, quant_module in find_modules(model, [BaseQuantLinear]).items()
+        if name in quant_result
+    }
 
-    assert len(qModules) > 0, f"No quantizeed modules[{quant_linear_cls}] found in the model."
+    assert len(qModules) > 0, "No quantized modules found in the model."
 
     names = list(qModules.keys())
     lock = threading.Lock()

--- a/tests/kernels/test_selection.py
+++ b/tests/kernels/test_selection.py
@@ -13,17 +13,21 @@ from gptqmodel.nn_modules.qlinear import BaseQuantLinear
 from gptqmodel.nn_modules.qlinear.gguf import GGUFTorchLinear
 from gptqmodel.nn_modules.qlinear.gguf_cpp import GGUFCppKernel, GGUFCudaKernel
 from gptqmodel.nn_modules.qlinear.gguf_triton import GGUFTritonKernel
+from gptqmodel.nn_modules.qlinear.exllamav2 import ExllamaV2Linear
 from gptqmodel.nn_modules.qlinear.machete import MacheteLinear
 from gptqmodel.nn_modules.qlinear.machete_awq import AwqMacheteLinear
+from gptqmodel.nn_modules.qlinear.marlin import MarlinLinear
 from gptqmodel.nn_modules.qlinear.marlin_awq import AwqMarlinLinear
-from gptqmodel.nn_modules.qlinear.torch import TorchQuantEmbeddings
+from gptqmodel.nn_modules.qlinear.torch import TorchLinear, TorchQuantEmbeddings
 from gptqmodel.nn_modules.qlinear.torch_aten_kernel import TorchAtenLinear
+from gptqmodel.nn_modules.qlinear.tritonv2 import TritonV2Linear
 from gptqmodel.nn_modules.qlinear.torch_aten_kernel_awq import TorchAtenAwqLinear
 from gptqmodel.quantization import FORMAT, METHOD
 from gptqmodel.utils import importer
 from gptqmodel.utils.backend import BACKEND
 from gptqmodel.utils.importer import (
     AUTO_BACKEND_KERNEL_MAPPING,
+    _iter_dynamic_contracts,
     auto_select_device,
     build_kernel_support_maps,
     iter_quant_linear_kernels,
@@ -526,3 +530,85 @@ def test_gguf_does_not_accept_generic_torch_backend():
             quant_method=METHOD.GGUF,
             pack_dtype=torch.int32,
         )
+
+
+def test_iter_dynamic_contracts_yields_base_and_distinct_overrides():
+    dynamic = {
+        "+:^lm_head$": {"bits": 4, "group_size": 64},
+        "+:^embed_tokens$": {"bits": 4, "group_size": 64},
+        "model.layers.0.self_attn.q_proj": {"bits": 2, "sym": False},
+    }
+    contracts = list(
+        _iter_dynamic_contracts(
+            dynamic=dynamic,
+            bits=3,
+            group_size=32,
+            desc_act=True,
+            sym=True,
+            pack_dtype=torch.int32,
+            format_value=FORMAT.GPTQ,
+        )
+    )
+    assert len(contracts) == 3
+    assert {"bits": 3, "group_size": 32, "desc_act": True, "sym": True, "pack_dtype": torch.int32} in contracts
+    assert {"bits": 4, "group_size": 64, "desc_act": True, "sym": True, "pack_dtype": torch.int32} in contracts
+    assert {"bits": 2, "group_size": 32, "desc_act": True, "sym": False, "pack_dtype": torch.int32} in contracts
+
+
+def test_select_quant_linear_multi_select_expands_dynamic_contracts(monkeypatch):
+    """A 4-bit dynamic override must be visible to kernels that only support 4-bit weights,
+    even when the base quantize config is 3-bit."""
+    _force_auto_candidates_valid(monkeypatch, METHOD.GPTQ, FORMAT.GPTQ)
+    # Marlin validates device compute capability before accepting the contract.
+    monkeypatch.setattr(MarlinLinear, "validate_device", classmethod(lambda cls, _device: None))
+
+    dynamic = {
+        "model.layers.0.mlp.down_proj": {"bits": 4, "group_size": 128, "sym": True, "desc_act": False},
+        "model.layers.0.mlp.up_proj": {"bits": 3, "group_size": 128, "sym": True, "desc_act": False},
+    }
+    candidates = select_quant_linear(
+        bits=3,
+        group_size=128,
+        desc_act=False,
+        sym=True,
+        device=DEVICE.CUDA,
+        backend=BACKEND.AUTO,
+        format=FORMAT.GPTQ,
+        quant_method=METHOD.GPTQ,
+        pack_dtype=torch.int32,
+        dtype=torch.float16,
+        dynamic=dynamic,
+        multi_select=True,
+    )
+    # The 4-bit contract enables 4-bit-only kernels; the 3-bit contract and base
+    # config keep 3-bit-capable kernels; Torch covers all widths.
+    assert MarlinLinear in candidates
+    assert ExllamaV2Linear in candidates
+    assert TritonV2Linear in candidates
+    assert TorchLinear in candidates
+
+
+def test_select_quant_linear_single_select_keeps_model_wide_kernel(monkeypatch):
+    """Single-select must return one kernel that is compatible with the whole model,
+    including the base bits, so 4-bit-only kernels are not chosen here."""
+    _force_auto_candidates_valid(monkeypatch, METHOD.GPTQ, FORMAT.GPTQ)
+
+    dynamic = {
+        "model.layers.0.mlp.down_proj": {"bits": 4, "group_size": 128, "sym": True, "desc_act": False},
+    }
+    selected = select_quant_linear(
+        bits=3,
+        group_size=128,
+        desc_act=False,
+        sym=True,
+        device=DEVICE.CUDA,
+        backend=BACKEND.AUTO,
+        format=FORMAT.GPTQ,
+        quant_method=METHOD.GPTQ,
+        pack_dtype=torch.int32,
+        dtype=torch.float16,
+        dynamic=dynamic,
+    )
+    # Marlin/Exllama/Triton do not support base bits=3, so the model-wide kernel
+    # must be TorchLinear, which supports both the base 3-bit and dynamic 4-bit layers.
+    assert selected is TorchLinear


### PR DESCRIPTION
## Summary

This PR fixes kernel auto-selection for models that use `QuantizeConfig.dynamic` to assign different bit widths to different modules. Previously `make_quant` / `create_quant_layer` picked one kernel for the whole module tree, and `select_quant_linear` only validated each candidate against the base quant config. A base `bits` of 2/3 therefore filtered out higher-bit-only kernels (e.g. `MarlinLinear`) even when the affected modules were overridden to 4/8 bits.

### Changes

1. **`gptqmodel/utils/importer.py`**: `select_quant_linear(..., multi_select=True)` now expands `dynamic` into distinct effective `(bits, group_size, desc_act, sym, pack_dtype)` contracts and validates each candidate against every contract. Single-select mode is unchanged.

2. **`gptqmodel/utils/model.py`**: `create_quant_layer` receives the full `linear_candidates` list and picks a compatible kernel **per submodule** using that module's effective quant config. `make_quant` returns the most common non-embedding class.

3. **`gptqmodel/utils/model.py`**: `pack_model` / `pack_module` operate over all `BaseQuantLinear` modules and use each module's actual class for pack-path and V2 conversion decisions.

4. **`gptqmodel/utils/model.py`**: `convert_gptq_v1_to_v2_format` and `convert_gptq_v2_to_v1_format` now convert any `BaseQuantLinear` module that declares `REQUIRES_FORMAT_V2`, not only modules matching the representative kernel class.

5. **`gptqmodel/models/loader.py`**: the `from_pretrained` v1→v2 conversion guard triggers when any loaded quant module requires V2, not just when the representative kernel does.

### Tests

Added to `tests/kernels/test_selection.py`:

- `test_iter_dynamic_contracts_yields_base_and_distinct_overrides`
- `test_select_quant_linear_multi_select_expands_dynamic_contracts` — base `bits=3`, dynamic 4-bit layer, asserts 4-bit-only kernels are included
- `test_select_quant_linear_single_select_keeps_model_wide_kernel` — asserts single-select still returns a kernel that supports the base `bits`

Also verified `tests/test_format_conversion_flow.py` and `tests/test_pack_gpu_alignment.py` still pass.
