### PR TITLE
fix(cpp/tests): C++20 JIT flags for PyTorch 2.14 nightly

### DIFF
--- a/gptqmodel/exllamav3/ext.py
+++ b/gptqmodel/exllamav3/ext.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
+from typing import Optional
 
 import torch
 
 from ..utils.cpp import (
     TorchOpsJitExtension,
+    _jit_cxx_standard,
     cuda_include_paths_with_fallback,
     default_jit_cflags,
     default_jit_cuda_cflags,
@@ -113,7 +115,7 @@ def _exllamav3_include_paths() -> list[str]:
 
 def _extra_cflags() -> list[str]:
     if windows:
-        flags = ["/O2", "/std:c++17"]
+        flags = ["/O2", f"/std:{_jit_cxx_standard()}"]
     else:
         flags = default_jit_cflags(opt_level="O2")
 

--- a/gptqmodel/utils/cpp.py
+++ b/gptqmodel/utils/cpp.py
@@ -526,6 +526,19 @@ def resolved_jit_opt_level(opt_level: str | None = "O3") -> str | None:
     )
 
 
+def _jit_cxx_standard() -> str:
+    """Return the C++ standard required by the installed PyTorch headers."""
+
+    try:
+        import re
+
+        match = re.match(r"(\d+)\.(\d+)", torch.__version__)
+        major, minor = int(match.group(1)), int(match.group(2)) if match else (0, 0)
+        return "c++20" if (major, minor) >= (2, 14) else "c++17"
+    except Exception:
+        return "c++17"
+
+
 def default_jit_cflags(
     *,
     opt_level: str | None = "O3",
@@ -535,7 +548,7 @@ def default_jit_cflags(
     """Return the common C++ compiler flags for torch.ops JIT extensions."""
 
     resolved_opt_level = resolved_jit_opt_level(opt_level)
-    flags = ["-std=c++17"]
+    flags = [f"-std={_jit_cxx_standard()}"]
     if resolved_opt_level is not None:
         flags.insert(0, f"-{resolved_opt_level}")
     if enable_bf16:
@@ -1104,7 +1117,7 @@ def _pack_block_extension() -> TorchOpsJitExtension:
             build_root_env="GPTQMODEL_EXT_BUILD",
             default_build_root=lambda: default_torch_ops_build_root("pack_block_cpu"),
             display_name="pack_block_cpu",
-            extra_cflags=["-O3", "-std=c++17"],
+            extra_cflags=["-O3", f"-std={_jit_cxx_standard()}"],
             extra_ldflags=[],
             verbose_env="GPTQMODEL_EXT_VERBOSE",
             requires_cuda=False,
@@ -1125,7 +1138,7 @@ def _floatx_cpu_extension() -> TorchOpsJitExtension:
             build_root_env="GPTQMODEL_EXT_BUILD",
             default_build_root=lambda: default_torch_ops_build_root("floatx_cpu"),
             display_name="floatx_cpu",
-            extra_cflags=["-O3", "-std=c++17"],
+            extra_cflags=["-O3", f"-std={_jit_cxx_standard()}"],
             extra_ldflags=[],
             verbose_env="GPTQMODEL_EXT_VERBOSE",
             requires_cuda=False,

--- a/tests/kernels/test_selection.py
+++ b/tests/kernels/test_selection.py
@@ -166,6 +166,8 @@ def test_role_only_kernel_is_excluded_from_backend_discovery():
 
 CASES = []
 for kernel_cls in sorted(_iter_kernel_classes(), key=lambda cls: cls.__name__):
+    if not getattr(kernel_cls, "SUPPORTS_BACKEND_SELECTION", True):
+        continue
     for method in _infer_quant_methods(kernel_cls):
         for fmt in kernel_cls.SUPPORTS_FORMATS:
             CASES.append((kernel_cls, method, fmt))

--- a/tests/test_torch_ops_jit_extension.py
+++ b/tests/test_torch_ops_jit_extension.py
@@ -64,7 +64,7 @@ def test_default_jit_cflags_allow_noopt(monkeypatch):
 
     flags = cpp_module.default_jit_cflags(opt_level=None)
 
-    assert "-std=c++17" in flags
+    assert any(flag.startswith("-std=c++") for flag in flags)
     assert not any(flag.startswith("-O") for flag in flags)
 
 


### PR DESCRIPTION
## Summary
PyTorch 2.14 nightly enforces C++20 in `ATen/ATen.h` and `torch/all.h`, so `torch.utils.cpp_extension` JIT builds that pass `-std=c++17` fail to compile. This change upgrades the default JIT C++ standard to `c++20` for Torch >= 2.14 while keeping `c++17` for older releases.

- `gptqmodel/utils/cpp.py`: add `_jit_cxx_standard()` and use it in `default_jit_cflags()`, `pack_block_cpu`, and `floatx_cpu` extra flags.
- `gptqmodel/exllamav3/ext.py`: use the same helper for the MSVC `/std:` flag and add the missing `Optional` import.
- `tests/test_torch_ops_jit_extension.py`: relax the `default_jit_cflags` assertion to accept any `-std=c++*` flag.
- `tests/kernels/test_selection.py`: skip `SUPPORTS_BACKEND_SELECTION=False` kernels (e.g. `TorchQuantEmbeddings`) in `test_select_quant_linear_smoke`.

## Validation
Ran the JIT extension and kernel selection tests on `torch 2.14.0.dev20260723+cu132` / `triton 3.8.0` / CUDA 13.2:

```
tests/test_torch_ops_jit_extension.py: 29 passed, 3 warnings
tests/kernels/test_selection.py::test_select_quant_linear_smoke: 34 passed, 11 skipped, 3 warnings
```

All JIT extension builds that previously failed with `-std=c++17` now compile with `-std=c++20` and the smoke tests select the expected kernel classes.