### PR TITLE
test(llama3_2): update fast-mode MARLIN baseline scores

### DIFF
--- a/tests/models/test_llama3_2.py
+++ b/tests/models/test_llama3_2.py
@@ -11,9 +11,9 @@ from model_test import ModelTest
 
 # | Metric                                             |   MARLIN |
 # |----------------------------------------------------|----------|
-# | arc_challenge :: acc,none                          |   0.3166 |
-# | arc_challenge :: acc_norm,none                     |   0.3430 |
-# | gsm8k_platinum_cot :: acc,num                      |   0.3906 |
+# | arc_challenge :: acc,none                          |   0.3140 |
+# | arc_challenge :: acc_norm,none                     |   0.3507 |
+# | gsm8k_platinum_cot :: acc,num                      |   0.4690 |
 # | mmlu_stem :: acc,none                              |   0.3942 |
 class TestLlama3_2(ModelTest):
     # Keep one stable saved checkpoint so eval-only repro runs can reuse the exact post-quant model.
@@ -68,7 +68,7 @@ class TestLlama3_2(ModelTest):
                 "stream": True,
             },
             "acc,num": {
-                "value": 0.390625,
+                "value": 0.4690,
                 "floor_pct": 0.04,
                 "ceil_pct": 1.0,
             },
@@ -85,12 +85,12 @@ class TestLlama3_2(ModelTest):
         "arc_challenge": {
             "chat_template": True,
             "acc": {
-                "value": 0.3166,
+                "value": 0.3140,
                 "floor_pct": 0.04,
                 "ceil_pct": 1.0,
             },
             "acc_norm": {
-                "value": 0.3430,
+                "value": 0.3507,
                 "floor_pct": 0.04,
                 "ceil_pct": 1.0,
             },


### PR DESCRIPTION
## Summary

Update the `Llama-3.2-1B-Instruct` fast-mode MARLIN evaluation baselines in `tests/models/test_llama3_2.py` to match the latest measured scores.

## What Changed

- `EVAL_TASKS_FAST` baseline values:
  - `gsm8k_platinum_cot :: acc,num`: `0.390625` -> `0.4690`
  - `arc_challenge :: acc`: `0.3166` -> `0.3140`
  - `arc_challenge :: acc_norm`: `0.3430` -> `0.3507`
- Updated the top-of-file comment score table for consistency.

## Tests

- [ ] I added a new simple/fast unit test for this change, or documented why that is not applicable. (Baseline update only; existing test covers it.)
- [x] I ran the new targeted test locally before opening this PR.
- [ ] I ran any other directly relevant local tests.

Command and result:
```bash
cd /root/GPT-QModel-Ultra-3/repos/GPTQModel
CUDA_DEVICE_ORDER=PCI_BUS_ID CUDA_VISIBLE_DEVICES=0 \
PYTHONPATH=/root/GPT-QModel-Ultra-3/repos/GPTQModel \
python -m pytest tests/models/test_llama3_2.py::TestLlama3_2::test_llama3_2 -s -v --timeout=0
```
Result: `1 passed, 16 warnings in 557.04s`.

Measured metrics:
- `gsm8k_platinum_cot :: acc,num`: `0.4690`
- `arc_challenge :: acc`: `0.3140`
- `arc_challenge :: acc_norm`: `0.3507`

## Notes

Only fast-mode (`EVAL_TASKS_FAST`) baselines are updated; slow-mode values are intentionally unchanged.
