### PR TITLE
fix(qlinear): size GPTQ buffers by pack_factor and skip Laguna g_proj quantization

### DIFF
--- a/gptqmodel/models/definitions/laguna.py
+++ b/gptqmodel/models/definitions/laguna.py
@@ -29,7 +29,7 @@ class LagunaQModel(BaseQModel):
                 "q_proj:0",
                 "k_proj:0",
                 "v_proj:0",
-                "g_proj:0",
+                "g_proj:!",
                 "o_proj:1",
             ),
             "post_attention_layernorm": ("post_attention_layernorm:!",),

--- a/gptqmodel/nn_modules/qlinear/__init__.py
+++ b/gptqmodel/nn_modules/qlinear/__init__.py
@@ -750,14 +750,14 @@ class GPTQQuantLinear(PackedGroupedQuantLinear):
 
         self.register_buffer(
             "qweight",
-            t.zeros((in_features // self.pack_dtype_bits * self.bits, out_features), dtype=self.pack_dtype),
+            t.zeros((math.ceil(in_features / self.pack_factor), out_features), dtype=self.pack_dtype),
         )
         self.register_buffer(
             "qzeros",
             t.zeros(
                 (
                     math.ceil(in_features / self.group_size),
-                    out_features // self.pack_dtype_bits * self.bits,
+                    math.ceil(out_features / self.pack_factor),
                 ),
                 dtype=self.pack_dtype,
             ),
@@ -1395,7 +1395,7 @@ class PackableQuantLinear(GPTQQuantLinear):
             int_weight = int_weight.to(t.int32).T.contiguous()
             int_weight = int_weight.numpy().astype(self.pack_np_math_dtype)
 
-            qweight = np.zeros((int_weight.shape[0] // self.pack_dtype_bits * self.bits, int_weight.shape[1]),
+            qweight = np.zeros((math.ceil(int_weight.shape[0] / self.pack_factor), int_weight.shape[1]),
                                dtype=self.pack_np_math_dtype)
             if self.bits in [2, 4, 8]:
                 for row in range(qweight.shape[0]):
@@ -1428,7 +1428,7 @@ class PackableQuantLinear(GPTQQuantLinear):
             self.register_buffer("qweight", t.from_numpy(qweight.astype(self.pack_np_dtype)))
 
             zeros = zeros.numpy().astype(self.pack_np_math_dtype)
-            qzeros = np.zeros((zeros.shape[0], zeros.shape[1] // self.pack_dtype_bits * self.bits), dtype=self.pack_np_math_dtype)
+            qzeros = np.zeros((zeros.shape[0], math.ceil(zeros.shape[1] / self.pack_factor)), dtype=self.pack_np_math_dtype)
             if self.bits in [2, 4, 8]:
                 for col in range(qzeros.shape[1]):
                     for j in range(self.pack_factor):

--- a/tests/kernels/test_qlinear_hierarchy.py
+++ b/tests/kernels/test_qlinear_hierarchy.py
@@ -234,3 +234,34 @@ def test_weight_only_kernels_do_not_declare_grouped_support_metadata():
         assert not hasattr(cls, "SUPPORTS_GROUP_SIZE")
         assert not hasattr(cls, "SUPPORTS_DESC_ACT")
         assert not hasattr(cls, "SUPPORTS_SYM")
+
+
+def test_gptq_quant_linear_buffer_shapes_for_non_word_aligned_out_features():
+    """Laguna's g_proj has out_features=48/72, which is a multiple of pack_factor (8) but not pack_dtype_bits (32)."""
+    import math
+
+    for out_features in (48, 72):
+        layer = TorchLinear(
+            bits=4,
+            group_size=32,
+            sym=True,
+            desc_act=False,
+            in_features=3072,
+            out_features=out_features,
+            bias=False,
+        )
+        expected_qweight_rows = math.ceil(3072 / layer.pack_factor)
+        expected_qzeros_cols = math.ceil(out_features / layer.pack_factor)
+        assert layer.qweight.shape == (expected_qweight_rows, out_features)
+        assert layer.qzeros.shape == (math.ceil(3072 / 32), expected_qzeros_cols)
+
+        # Ensure a checkpoint with the natural packed shapes loads cleanly.
+        state = {
+            "qweight": torch.zeros((expected_qweight_rows, out_features), dtype=torch.int32),
+            "qzeros": torch.zeros((math.ceil(3072 / 32), expected_qzeros_cols), dtype=torch.int32),
+            "scales": torch.zeros((math.ceil(3072 / 32), out_features), dtype=torch.float16),
+            "g_idx": torch.tensor([i // 32 for i in range(3072)], dtype=torch.int32),
+        }
+        missing, unexpected = layer.load_state_dict(state, strict=False)
+        assert not missing
+        assert not unexpected


### PR DESCRIPTION
## Summary

Fixes two related issues for Laguna S-2.1:

1. `GPTQQuantLinear._register_gptq_buffers` (and the fallback `PackableQuantLinear.pack`) sized packed buffers with `// pack_dtype_bits * bits`. This only equals `// pack_factor` when the dimension is a multiple of `pack_dtype_bits` (32), so layers like `self_attn.g_proj` with `out_features=48` or `72` got a `qzeros` buffer with too few columns and `load_checkpoint` failed with a shape mismatch.
2. Laguna's per-head `g_proj` is tiny (0.28–0.42 MB dense) and not worth quantizing. Mark it as `:!` in `LagunaQModel.module_tree` so it is bypassed during dense → quantization.

## What Changed

- `gptqmodel/nn_modules/qlinear/__init__.py`:
  - `_register_gptq_buffers` now allocates `qweight` rows and `qzeros` columns with `math.ceil(features / self.pack_factor)`.
  - `PackableQuantLinear.pack` uses the same `pack_factor`-based sizing for `qweight`/`qzeros`.
- `gptqmodel/models/definitions/laguna.py`:
  - `self_attn.g_proj` changed from `:0` to `:!` so `simple_layer_modules` excludes it from quantization.
- `tests/kernels/test_qlinear_hierarchy.py`:
  - Added `test_gptq_quant_linear_buffer_shapes_for_non_word_aligned_out_features` covering `out_features=48` and `72`.

## Tests

- [x] Added targeted unit test for the buffer-sizing regression.
- [x] Ran the test locally:

```bash
python -m pytest tests/kernels/test_qlinear_hierarchy.py::test_gptq_quant_linear_buffer_shapes_for_non_word_aligned_out_features -q
# 1 passed
```

- [x] `ruff check gptqmodel/nn_modules/qlinear/__init__.py gptqmodel/models/definitions/laguna.py tests/kernels/test_qlinear_hierarchy.py --config format/ruff.toml` passes.
- [x] `git diff --check` passes.

## Notes

- The `g_proj:!` change applies to the dense → quantization path. Existing checkpoints quantized with `g_proj.qweight` will treat it as unexpected unless the loader is taught to dequantize them, but the primary goal is to avoid quantizing these tiny layers going forward.