### PR TITLE
fix(qlinear): size pack_original qweight/qzeros by bits/32 for 3-bit GPTQ

### DIFF
--- a/gptqmodel/nn_modules/qlinear/__init__.py
+++ b/gptqmodel/nn_modules/qlinear/__init__.py
@@ -1395,7 +1395,7 @@ class PackableQuantLinear(GPTQQuantLinear):
             int_weight = int_weight.to(t.int32).T.contiguous()
             int_weight = int_weight.numpy().astype(self.pack_np_math_dtype)
 
-            qweight = np.zeros((math.ceil(int_weight.shape[0] / self.pack_factor), int_weight.shape[1]),
+            qweight = np.zeros((math.ceil(int_weight.shape[0] * self.bits / 32), int_weight.shape[1]),
                                dtype=self.pack_np_math_dtype)
             if self.bits in [2, 4, 8]:
                 for row in range(qweight.shape[0]):
@@ -1428,7 +1428,7 @@ class PackableQuantLinear(GPTQQuantLinear):
             self.register_buffer("qweight", t.from_numpy(qweight.astype(self.pack_np_dtype)))
 
             zeros = zeros.numpy().astype(self.pack_np_math_dtype)
-            qzeros = np.zeros((zeros.shape[0], math.ceil(zeros.shape[1] / self.pack_factor)), dtype=self.pack_np_math_dtype)
+            qzeros = np.zeros((zeros.shape[0], math.ceil(zeros.shape[1] * self.bits / 32)), dtype=self.pack_np_math_dtype)
             if self.bits in [2, 4, 8]:
                 for col in range(qzeros.shape[1]):
                     for j in range(self.pack_factor):


### PR DESCRIPTION
## Summary
`PackableQuantLinear.pack_original` sizes its packed `qweight` and `qzeros` buffers with `math.ceil(dim / self.pack_factor)`. For 3-bit weights, `pack_factor = 32 // 3 = 10`, but the 3-bit custom packing loop consumes 32 integer values to produce 3 packed rows (32 × 3 bits = 96 bits). The `ceil(dim / 10)` allocation therefore over-allocates and the loop overruns the input array.

## Changes
- Size `pack_original` `qweight` and `qzeros` with `math.ceil(dim * self.bits / 32)` instead of `math.ceil(dim / self.pack_factor)`.
- This is equivalent for 2/4/8-bit (`32 / bits` is an integer) and exact for the 3-bit custom layout.

## Verification
- `ruff check gptqmodel/nn_modules/qlinear/__init__.py`: passed
- `git diff --check`: passed
- `pytest tests/test_pack.py -q`: 18 passed (covers 3-bit `pack_original`)
