### PR TITLE
fix(qlinear): size GPTQ buffers by bits/pack_dtype_bits

### DIFF
--- a/gptqmodel/nn_modules/qlinear/__init__.py
+++ b/gptqmodel/nn_modules/qlinear/__init__.py
@@ -750,14 +750,14 @@ class GPTQQuantLinear(PackedGroupedQuantLinear):
 
         self.register_buffer(
             "qweight",
-            t.zeros((math.ceil(in_features / self.pack_factor), out_features), dtype=self.pack_dtype),
+            t.zeros((math.ceil(in_features * self.bits / self.pack_dtype_bits), out_features), dtype=self.pack_dtype),
         )
         self.register_buffer(
             "qzeros",
             t.zeros(
                 (
                     math.ceil(in_features / self.group_size),
-                    math.ceil(out_features / self.pack_factor),
+                    math.ceil(out_features * self.bits / self.pack_dtype_bits),
                 ),
                 dtype=self.pack_dtype,
             ),
@@ -1395,7 +1395,7 @@ class PackableQuantLinear(GPTQQuantLinear):
             int_weight = int_weight.to(t.int32).T.contiguous()
             int_weight = int_weight.numpy().astype(self.pack_np_math_dtype)
 
-            qweight = np.zeros((math.ceil(int_weight.shape[0] * self.bits / 32), int_weight.shape[1]),
+            qweight = np.zeros((math.ceil(int_weight.shape[0] * self.bits / self.pack_dtype_bits), int_weight.shape[1]),
                                dtype=self.pack_np_math_dtype)
             if self.bits in [2, 4, 8]:
                 for row in range(qweight.shape[0]):
@@ -1428,7 +1428,7 @@ class PackableQuantLinear(GPTQQuantLinear):
             self.register_buffer("qweight", t.from_numpy(qweight.astype(self.pack_np_dtype)))
 
             zeros = zeros.numpy().astype(self.pack_np_math_dtype)
-            qzeros = np.zeros((zeros.shape[0], math.ceil(zeros.shape[1] * self.bits / 32)), dtype=self.pack_np_math_dtype)
+            qzeros = np.zeros((zeros.shape[0], math.ceil(zeros.shape[1] * self.bits / self.pack_dtype_bits)), dtype=self.pack_np_math_dtype)
             if self.bits in [2, 4, 8]:
                 for col in range(qzeros.shape[1]):
                     for j in range(self.pack_factor):


### PR DESCRIPTION
## Summary
`_register_gptq_buffers` and `PackableQuantLinear.pack_original` sized packed `qweight`/`qzeros` with `ceil(dim / pack_factor)` (where `pack_factor = pack_dtype_bits // bits`) or, after the previous 3-bit fix, a hardcoded `32`. Both are wrong when `pack_dtype_bits` does not equal `32` or when `pack_dtype_bits / bits` is not an integer (3-bit).

The correct number of packed words is `ceil(dim * bits / pack_dtype_bits)`.

## Changes
- `GPTQQuantLinear._register_gptq_buffers`: `qweight` rows and `qzeros` columns now use `math.ceil(dim * self.bits / self.pack_dtype_bits)`.
- `PackableQuantLinear.pack_original`: `qweight` and `qzeros` allocation now uses `math.ceil(dim * self.bits / self.pack_dtype_bits)` instead of `32`.

For 2/4/8-bit these formulas are equivalent to the old `ceil(dim / pack_factor)`. For 3-bit (`pack_dtype_bits == 32`) this gives `ceil(dim * 3 / 32)`, matching the 32-value packing loop and the `pack_block`/`pack_gpu` paths. For `int8`/`int16` pack dtypes this no longer under-allocates the buffer.

## Verification
- `ruff check gptqmodel/nn_modules/qlinear/__init__.py`: passed
- `git diff --check`: passed
- `pytest tests/test_pack.py tests/kernels/test_qlinear_hierarchy.py -q`: 27 passed

