### PR TITLE
perf(quant): bypass pcre.match for exact dynamic config patterns

### DIFF
--- a/gptqmodel/quantization/config.py
+++ b/gptqmodel/quantization/config.py
@@ -1519,6 +1519,131 @@ QUANT_CONFIG_ARG_SYNONYMS_NEGATED = {
 }
 DYNAMIC_FIELD_SYNONYMS = {}
 
+# Sentinel used by the dynamic override cache to indicate no pattern matched.
+_DYNAMIC_NO_MATCH = object()
+
+# Global caches for dynamic override resolution.  The `dynamic` dict is treated
+# as immutable after config construction, so caching by `id(dynamic)` is safe
+# and lets cloned configs share compiled patterns and override lookups.
+_DYNAMIC_PATTERN_CACHE: Dict[int, List[Tuple[bool, Any, Dict[str, Any], Optional[str], int]]] = {}
+_DYNAMIC_OVERRIDE_CACHE: Dict[int, Dict[str, Any]] = {}
+# Exact-literal fast-path caches: a per-dynamic dict mapping literal module names
+# to their resolved override, and whether every pattern is an exact literal.
+_DYNAMIC_EXACT_LOOKUP_CACHE: Dict[int, Dict[str, Tuple[int, Union[Dict[str, Any], bool]]]] = {}
+_DYNAMIC_ALL_EXACT_CACHE: Dict[int, bool] = {}
+# Pre-separated regex patterns for mixed dynamic configs.
+_DYNAMIC_REGEX_PATTERN_CACHE: Dict[int, List[Tuple[int, bool, Any, Dict[str, Any]]]] = {}
+
+def _extract_literal_regex_pattern(raw: str) -> Optional[str]:
+    """If `raw` is a regex that matches a single literal string, return that string."""
+    # PCRE `.match()` is start-anchored only, so a trailing `$` is required for a
+    # true exact full-string match.  A leading `^` is also required to avoid
+    # matching arbitrary prefixes.
+    if not raw.startswith("^") or not raw.endswith("$"):
+        return None
+    raw = raw[1:-1]
+    out = []
+    i = 0
+    n = len(raw)
+    while i < n:
+        ch = raw[i]
+        if ch == "\\":
+            if i + 1 >= n:
+                return None
+            nxt = raw[i + 1]
+            if nxt == "\\":
+                out.append("\\")
+                i += 2
+                continue
+            if nxt.isalnum():
+                # Regex escape such as \d, \w, \1, \x, etc.
+                return None
+            # Escaped special character -> literal.
+            out.append(nxt)
+            i += 2
+            continue
+        if ch in ".^$*+?{}[]()|":
+            return None
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _get_dynamic_patterns(dynamic: Dict[str, Dict[str, Any]]) -> List[Tuple[bool, Any, Dict[str, Any], Optional[str], int]]:
+    """Return compiled PCRE patterns (plus optional exact literal) for a dynamic dict, caching by object id."""
+
+    cache_key = id(dynamic)
+    patterns = _DYNAMIC_PATTERN_CACHE.get(cache_key)
+    if patterns is not None:
+        return patterns
+
+    patterns = []
+    exact_lookup: Dict[str, Tuple[int, Union[Dict[str, Any], bool]]] = {}
+    regex_patterns: List[Tuple[int, bool, Any, Dict[str, Any]]] = []
+    all_exact = True
+    if dynamic is not None:
+        for index, (pattern, overrides) in enumerate(dynamic.items()):
+            is_negative = pattern.startswith("-:")
+            raw = pattern[2:] if pattern.startswith(("-:", "+:")) else pattern
+            exact_literal = _extract_literal_regex_pattern(raw)
+            if exact_literal is None:
+                all_exact = False
+                try:
+                    compiled = pcre.compile(raw)
+                except Exception as exc:
+                    raise ValueError(f"QuantizeConfig: invalid dynamic pattern `{pattern}`") from exc
+                regex_patterns.append((index, is_negative, compiled, overrides))
+            else:
+                compiled = None
+                if exact_literal not in exact_lookup:
+                    exact_lookup[exact_literal] = (index, False if is_negative else dict(overrides))
+            patterns.append((is_negative, compiled, overrides, exact_literal, index))
+    _DYNAMIC_PATTERN_CACHE[cache_key] = patterns
+    _DYNAMIC_EXACT_LOOKUP_CACHE[cache_key] = exact_lookup
+    _DYNAMIC_ALL_EXACT_CACHE[cache_key] = all_exact
+    _DYNAMIC_REGEX_PATTERN_CACHE[cache_key] = regex_patterns
+    return patterns
+
+def _resolve_dynamic_override(
+    dynamic: Dict[str, Dict[str, Any]],
+    module_name: str,
+) -> Union[Dict[str, Any], bool, None]:
+    """Return the first matching dynamic override dict, False for negative, or None."""
+
+    if dynamic is None:
+        return None
+
+    cache_key = id(dynamic)
+    override_cache = _DYNAMIC_OVERRIDE_CACHE.setdefault(cache_key, {})
+    cached = override_cache.get(module_name, _DYNAMIC_NO_MATCH)
+    if cached is not _DYNAMIC_NO_MATCH:
+        return cached
+
+    _get_dynamic_patterns(dynamic)
+
+    # Fast path: every pattern is an exact literal module name.
+    if _DYNAMIC_ALL_EXACT_CACHE.get(cache_key, False):
+        exact_entry = _DYNAMIC_EXACT_LOOKUP_CACHE[cache_key].get(module_name)
+        matched = exact_entry[1] if exact_entry is not None else None
+        override_cache[module_name] = matched
+        return matched
+
+    # Mixed fallback: find the earliest matching pattern among exact literals
+    # (O(1) lookup) and ordered regex patterns.
+    exact_entry = _DYNAMIC_EXACT_LOOKUP_CACHE[cache_key].get(module_name)
+    best_index = exact_entry[0] if exact_entry is not None else None
+    matched = exact_entry[1] if exact_entry is not None else None
+
+    for index, is_negative, compiled, overrides in _DYNAMIC_REGEX_PATTERN_CACHE[cache_key]:
+        if best_index is not None and index > best_index:
+            break
+        if compiled.match(module_name):
+            matched = False if is_negative else dict(overrides)
+            break
+
+    override_cache[module_name] = matched
+    return matched
+
 def dict_scale_dtype_to_str(d: Dict[str, Any]) -> None:
     """
     Checks whether the passed dictionary and its nested dicts have a *scale_dtype* key and if it's not None,
@@ -1693,35 +1818,33 @@ def dynamic_get(dynamic: Dict[str, Dict[str, Union[int, bool]]], module_name: st
     if dynamic is None:
         return default
 
-    for pattern, overrides in dynamic.items():
-        if pattern.startswith("-:"):
-            if pcre.compile(pattern.removeprefix("-:")).match(module_name):
-                return False
-        elif pcre.compile(pattern.removeprefix("+:")).match(module_name):
-            if key is None:
-                return overrides
-            else:
-                # subkey example: Lora override format: `{ "adapter": { "rank": 512 } }`
-                if sub_key:
-                    sub_value = overrides.get(key, None)
-                    if sub_value is None and key in DYNAMIC_FIELD_SYNONYMS:
-                        for legacy_key in DYNAMIC_FIELD_SYNONYMS[key]:
-                            if legacy_key in overrides:
-                                sub_value = overrides[legacy_key]
-                                break
-                    if isinstance(sub_value, Dict):
-                        return sub_value.get(sub_key, default)
-                    else:
-                        log.info(f"QuantConfig: Dynamic `sub_key`: `{sub_key}` failed extraction from  `sub_value`: `{sub_value}`")
-                else:
-                    if key in overrides:
-                        return overrides[key]
-                    if key in DYNAMIC_FIELD_SYNONYMS:
-                        for legacy_key in DYNAMIC_FIELD_SYNONYMS[key]:
-                            if legacy_key in overrides:
-                                return overrides[legacy_key]
-                    return default
-    return default
+    overrides = _resolve_dynamic_override(dynamic, module_name)
+    if overrides is False:
+        return False
+    if overrides is None:
+        return default
+
+    if key is None:
+        return overrides
+
+    if key in overrides:
+        sub_value = overrides[key]
+    elif key in DYNAMIC_FIELD_SYNONYMS:
+        sub_value = None
+        for legacy_key in DYNAMIC_FIELD_SYNONYMS[key]:
+            if legacy_key in overrides:
+                sub_value = overrides[legacy_key]
+                break
+    else:
+        return default
+
+    if sub_key:
+        if isinstance(sub_value, Dict):
+            return sub_value.get(sub_key, default)
+        log.info(f"QuantConfig: Dynamic `sub_key`: `{sub_key}` failed extraction from  `sub_value`: `{sub_value}`")
+        return default
+
+    return sub_value
 
 def _normalize_quant_method(value: Union[str, METHOD]) -> METHOD:
     if isinstance(value, str):

--- a/tests/qcfg/test_dynamic_config.py
+++ b/tests/qcfg/test_dynamic_config.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import patch
+
+import pcre
+import pytest
+
+from gptqmodel.quantization.config import (
+    QuantizeConfig,
+    _DYNAMIC_ALL_EXACT_CACHE,
+    _DYNAMIC_EXACT_LOOKUP_CACHE,
+    _DYNAMIC_OVERRIDE_CACHE,
+    _DYNAMIC_PATTERN_CACHE,
+    _DYNAMIC_REGEX_PATTERN_CACHE,
+)
+
+
+def _clear_dynamic_caches():
+    """Drop the global dynamic pattern/override caches so tests are independent."""
+    _DYNAMIC_PATTERN_CACHE.clear()
+    _DYNAMIC_EXACT_LOOKUP_CACHE.clear()
+    _DYNAMIC_REGEX_PATTERN_CACHE.clear()
+    _DYNAMIC_OVERRIDE_CACHE.clear()
+    _DYNAMIC_ALL_EXACT_CACHE.clear()
+
+
+@pytest.fixture(autouse=True)
+def clear_caches():
+    _clear_dynamic_caches()
+    yield
+    _clear_dynamic_caches()
+
+
+def _exact_pattern(module_name: str) -> str:
+    """Build an anchored regex that matches only `module_name` using escaped dots."""
+    escaped = module_name.replace(".", "\\.")
+    return f"+:^{escaped}$"
+
+
+def test_dynamic_exact_patterns_bypass_pcre_match():
+    """Fully-exact dynamic configs must not call pcre.Pattern.match per module."""
+    modules = [f"model.layers.{i}.mlp.down_proj" for i in range(100)]
+    dynamic = {_exact_pattern(name): {"bits": 2} for name in modules}
+    cfg = QuantizeConfig(dynamic=dynamic, bits=4, group_size=128, sym=False)
+
+    with patch.object(pcre.Pattern, "match") as mock_match:
+        for name in modules:
+            assert cfg.dynamic_get(name, "bits", cfg.bits) == 2
+        assert cfg.dynamic_get("model.layers.unknown.mlp.down_proj", "bits", cfg.bits) == cfg.bits
+        mock_match.assert_not_called()
+
+
+def test_dynamic_negative_exact_pattern_bypasses_pcre_match():
+    """A negative exact pattern should short-circuit without regex matching."""
+    dynamic = {
+        "-:^model\\.layers\\.0\\.mlp\\.down_proj$": {},
+        "+:^model\\.layers\\.1\\.mlp\\.down_proj$": {"bits": 2},
+    }
+    cfg = QuantizeConfig(dynamic=dynamic, bits=4, group_size=128, sym=False)
+
+    with patch.object(pcre.Pattern, "match") as mock_match:
+        assert cfg.dynamic_get("model.layers.0.mlp.down_proj", "bits", cfg.bits) is False
+        assert cfg.dynamic_get("model.layers.1.mlp.down_proj", "bits", cfg.bits) == 2
+        assert cfg.dynamic_get("model.layers.2.mlp.down_proj", "bits", cfg.bits) == cfg.bits
+        mock_match.assert_not_called()
+
+
+def test_dynamic_mixed_uses_pcre_only_for_regex_patterns():
+    """Mixed exact + regex configs should only call match for regex patterns."""
+    dynamic = {
+        "+:^model\\.layers\\.0\\.mlp\\.down_proj$": {"bits": 2},
+        "+:^model\\.layers\\.\\d+\\.mlp\\.gate_proj$": {"bits": 8},
+    }
+    cfg = QuantizeConfig(dynamic=dynamic, bits=4, group_size=128, sym=False)
+
+    original_match = pcre.Pattern.match
+    match_calls = []
+
+    def _counted_match(self, string):
+        match_calls.append(string)
+        return original_match(self, string)
+
+    with patch.object(pcre.Pattern, "match", _counted_match):
+        # Exact match should resolve without ever calling pcre.match.
+        assert cfg.dynamic_get("model.layers.0.mlp.down_proj", "bits", cfg.bits) == 2
+        assert not match_calls
+
+        # This matches the regex pattern; one pcre.match call is expected.
+        assert cfg.dynamic_get("model.layers.5.mlp.gate_proj", "bits", cfg.bits) == 8
+        assert len(match_calls) == 1
+
+
+def test_dynamic_prefix_pattern_is_not_exact():
+    """A pattern without a trailing `$` is a prefix regex and must be compiled/used as one."""
+    dynamic = {"+:^model\\.layers\\.1": {"bits": 2}}
+    cfg = QuantizeConfig(dynamic=dynamic, bits=4, group_size=128, sym=False)
+
+    # Should match the prefix (model.layers.1) but not a different layer.
+    assert cfg.dynamic_get("model.layers.1.mlp.down_proj", "bits", cfg.bits) == 2
+    assert cfg.dynamic_get("model.layers.10.mlp.down_proj", "bits", cfg.bits) == 2
+    assert cfg.dynamic_get("model.layers.2.mlp.down_proj", "bits", cfg.bits) == cfg.bits
+
+
+def test_dynamic_mixed_ordering_respected():
+    """When both a regex and an exact pattern match, the earlier one in the dict wins."""
+    # Regex first, then exact override for layer 5.
+    dynamic = {
+        "+:^model\\.layers\\.\\d+\\.mlp\\.gate_proj$": {"bits": 8},
+        "+:^model\\.layers\\.5\\.mlp\\.gate_proj$": {"bits": 2},
+    }
+    cfg = QuantizeConfig(dynamic=dynamic, bits=4, group_size=128, sym=False)
+
+    # Regex appears first, so it wins for layer 5.
+    assert cfg.dynamic_get("model.layers.5.mlp.gate_proj", "bits", cfg.bits) == 8
+
+    # Exact appears second, so it wins when the regex does not match.
+    dynamic_reordered = {
+        "+:^model\\.layers\\.5\\.mlp\\.gate_proj$": {"bits": 2},
+        "+:^model\\.layers\\.\\d+\\.mlp\\.gate_proj$": {"bits": 8},
+    }
+    cfg2 = QuantizeConfig(dynamic=dynamic_reordered, bits=4, group_size=128, sym=False)
+    assert cfg2.dynamic_get("model.layers.5.mlp.gate_proj", "bits", cfg2.bits) == 2
+
+
+def test_dynamic_large_exact_config_no_pcre_regression():
+    """Reproduce a large exact-only dynamic config and verify zero pcre.match calls."""
+    pattern_count = 2270
+    module_count = 36432
+
+    # Build a set of exact patterns and a larger set of module names to resolve.
+    patterns = {
+        _exact_pattern(f"model.layers.{i}.mlp.down_proj"): {"bits": 2}
+        for i in range(pattern_count)
+    }
+    cfg = QuantizeConfig(dynamic=patterns, bits=4, group_size=128, sym=False)
+
+    modules = []
+    for i in range(module_count):
+        layer = i % 1000
+        proj = i % 3
+        modules.append(f"model.layers.{layer}.mlp.proj.{proj}")
+    # Make sure a subset actually matches so the test is realistic.
+    for i in range(min(pattern_count, module_count)):
+        modules[i] = f"model.layers.{i}.mlp.down_proj"
+
+    with patch.object(pcre.Pattern, "match") as mock_match:
+        for name in modules:
+            cfg.dynamic_get(name, "bits", cfg.bits)
+        assert mock_match.call_count == 0, (
+            f"pcre.Pattern.match called {mock_match.call_count} times for a "
+            f"fully exact dynamic config; expected zero calls."
+        )


### PR DESCRIPTION
## Summary

`dynamic_get` compiled and matched every PCRE pattern for every quantized module during model loading. When a `quantize_config.json` contains many anchored literal patterns (e.g. `+:^model\.layers\.0\.mlp\.down_proj$`), this results in millions of unnecessary `pcre.Pattern.match` calls and dominated `GPTQModel.load` time.

## What Changed

- `gptqmodel/quantization/config.py`
  - Added `_extract_literal_regex_pattern()` to detect regexes that are actually anchored literal strings.
  - Added `_get_dynamic_patterns()` to compile patterns once and separate exact literals from true regexes.
  - Added `_resolve_dynamic_override()` that resolves exact literals in O(1) via a dict lookup, falling back to ordered regex matching only for genuine regex patterns.
  - Updated `dynamic_get()` to use `_resolve_dynamic_override()` while preserving existing key/sub-key/synonym handling.

- `tests/qcfg/test_dynamic_config.py`
  - Tests fully-exact, negative-exact, mixed exact+regex, prefix, and ordering semantics.
  - Adds a large-scale regression test with 2,270 exact patterns and 36,432 module-name lookups, asserting zero `pcre.match` calls.

## Tests

- [x] I added a new simple/fast unit test for this change.
- [x] I ran the new targeted test locally before opening this PR.
- [x] I ran any other directly relevant local tests.

```bash
cd /root/repos/GPTQModel
/root/vm314t/bin/python -m pytest tests/qcfg/test_dynamic_config.py -q
```

Result: `6 passed, 16 warnings in 7.57s`

## Notes

The fix preserves first-match precedence for mixed configs and only treats patterns as exact literals when they have both leading `^` and trailing `$` anchors and no unescaped regex metacharacters.
