### PR TITLE
perf(marlin): cache scale permutation tensors and use index_select

### DIFF
--- a/gptqmodel/utils/marlin.py
+++ b/gptqmodel/utils/marlin.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import threading
 from pathlib import Path
 from shutil import which
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import numpy
 import torch
@@ -388,11 +389,11 @@ def replace_tensor(layer: torch.nn.Module, name: str,
 
 def marlin_permute_scales(s: torch.Tensor, size_k: int, size_n: int,
                           group_size: int) -> torch.Tensor:
-    scale_perm, scale_perm_single = get_scale_perms()
+    scale_perm, scale_perm_single = _get_scale_perm_tensors(s.device)
     if group_size < size_k and group_size != -1:
-        s = s.reshape((-1, len(scale_perm)))[:, scale_perm]
+        s = s.reshape((-1, len(scale_perm))).index_select(1, scale_perm)
     else:
-        s = s.reshape((-1, len(scale_perm_single)))[:, scale_perm_single]
+        s = s.reshape((-1, len(scale_perm_single))).index_select(1, scale_perm_single)
     s = s.reshape((-1, size_n)).contiguous()
 
     return s
@@ -407,6 +408,29 @@ def get_scale_perms():
         scale_perm_single.extend(
             [2 * i + j for j in [0, 1, 8, 9, 16, 17, 24, 25]])
     return scale_perm, scale_perm_single
+
+
+# Cache pre-materialized permutation index tensors per device to avoid
+# converting the constant Python lists on every Marlin scales/bias call.
+_SCALE_PERM_TENSOR_CACHE: Dict[torch.device, Tuple[torch.Tensor, torch.Tensor]] = {}
+_SCALE_PERM_TENSOR_LOCK = threading.Lock()
+
+
+def _get_scale_perm_tensors(device: torch.device) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Return (scale_perm, scale_perm_single) index tensors on `device`."""
+    cache = _SCALE_PERM_TENSOR_CACHE.get(device)
+    if cache is not None:
+        return cache
+
+    with _SCALE_PERM_TENSOR_LOCK:
+        cache = _SCALE_PERM_TENSOR_CACHE.get(device)
+        if cache is None:
+            scale_perm, scale_perm_single = get_scale_perms()
+            perm_t = torch.tensor(scale_perm, device=device, dtype=torch.long)
+            perm_single_t = torch.tensor(scale_perm_single, device=device, dtype=torch.long)
+            cache = (perm_t, perm_single_t)
+            _SCALE_PERM_TENSOR_CACHE[device] = cache
+    return cache
 
 def maybe_warn_marlin_atomic_add_env():
     if torch.compiler.is_dynamo_compiling():
@@ -716,6 +740,6 @@ def awq_to_marlin_zero_points(q_zp_packed: torch.Tensor, size_k: int,
 
 def marlin_permute_bias(s: torch.Tensor) -> torch.Tensor:
     origin_shape = s.shape
-    _, scale_perm_single = get_scale_perms()
-    s = s.reshape((-1, len(scale_perm_single)))[:, scale_perm_single]
+    _, scale_perm_single = _get_scale_perm_tensors(s.device)
+    s = s.reshape((-1, len(scale_perm_single))).index_select(1, scale_perm_single)
     return s.reshape(*origin_shape).contiguous()

--- a/tests/test_marlin_permute.py
+++ b/tests/test_marlin_permute.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2024-2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from gptqmodel.utils.marlin import (
+    get_scale_perms,
+    marlin_permute_bias,
+    marlin_permute_scales,
+)
+
+
+@pytest.mark.parametrize("size_k,size_n,group_size", [
+    (3072, 3072, 128),
+    (3072, 12288, 128),
+    (12288, 3072, 128),
+    (3072, 1024, 128),
+    (1024, 3072, 128),
+])
+def test_marlin_permute_scales_matches_reference(size_k, size_n, group_size):
+    """marlin_permute_scales output must match a simple Python-list reference."""
+    scale_perm, scale_perm_single = get_scale_perms()
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    scales = torch.randn(size_k // group_size, size_n, dtype=torch.float32, device=device)
+
+    out = marlin_permute_scales(scales, size_k, size_n, group_size)
+
+    if group_size < size_k and group_size != -1:
+        expected = scales.reshape((-1, len(scale_perm)))[:, scale_perm]
+    else:
+        expected = scales.reshape((-1, len(scale_perm_single)))[:, scale_perm_single]
+    expected = expected.reshape((-1, size_n)).contiguous()
+
+    assert out.shape == expected.shape
+    torch.testing.assert_close(out, expected)
+
+
+def test_marlin_permute_bias_matches_reference():
+    """marlin_permute_bias output must match a simple Python-list reference."""
+    _, scale_perm_single = get_scale_perms()
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    bias = torch.randn(3072, dtype=torch.float32, device=device)
+
+    out = marlin_permute_bias(bias)
+    expected = bias.reshape((-1, len(scale_perm_single)))[:, scale_perm_single]
+    expected = expected.reshape(bias.shape).contiguous()
+
+    assert out.shape == expected.shape
+    torch.testing.assert_close(out, expected)


### PR DESCRIPTION
## Summary

`marlin_permute_scales` and `marlin_permute_bias` re-created the Marlin scale/bias permutation index tensors from Python lists on every call. For MoE models with tens of thousands of experts (e.g. Laguna-S-2.1-GPTQ-FIXED, 36,432 quant modules) this added ~4.4s during `GPTQModel.load`.

## What Changed

- `gptqmodel/utils/marlin.py`
  - Added a per-device cache `_SCALE_PERM_TENSOR_CACHE` protected by a `threading.Lock` and helper `_get_scale_perm_tensors()`.
  - `marlin_permute_scales` and `marlin_permute_bias` now use pre-materialized `torch.long` index tensors and `torch.index_select` instead of Python-list advanced indexing.

- `tests/test_marlin_permute.py`
  - Added correctness tests for `marlin_permute_scales` and `marlin_permute_bias` covering Laguna attention/MLP/MoE shapes.
  - Tests dynamically select `cuda:0` when available and fall back to `cpu`, and use `float32` to avoid crashing on CPU-only hosts.

## Tests

- [x] I added a new simple/fast unit test for this change.
- [x] I ran the new targeted test locally before opening this PR.
- [x] I ran any other directly relevant local tests.

```bash
cd /root/repos/GPTQModel
/root/vm314t/bin/python -m ruff check gptqmodel/utils/marlin.py tests/test_marlin_permute.py
/root/vm314t/bin/python -m pytest tests/test_marlin_permute.py -q
```

Result: `6 passed, 16 warnings in 6.73s` and `ruff` clean.

## Notes

Benchmarked on Laguna-S-2.1-GPTQ-FIXED with `BACKEND.GPTQ_MARLIN` on GPU 7:

- `gptq_marlin_repack` remained ~1.9s (already fast CUDA kernel).
- `marlin_permute_scales` dropped from ~4.4s to ~2.4s for all 36,432 modules.
- Total packing/repacking overhead is ~6.3s out of a ~96-140s load, so the remaining load-time bottleneck is elsewhere (safetensors weight I/O and per-module Python/validation overhead).

