### PR TITLE
perf(lazy_turtle): targeted ancestor+subtree map in materialize_submodule

### DIFF
--- a/gptqmodel/utils/structure.py
+++ b/gptqmodel/utils/structure.py
@@ -884,18 +884,47 @@ class LazyTurtle:
         target_submodule: torch.nn.Module,
         device: torch.device,
         non_blocking: bool = False,
+        module_path: Optional[str] = None,
+        recurse: bool = True,
+        tie_weights: bool = True,
+        show_progress: bool = True,
     ) -> torch.nn.Module:
-        path = _get_qualified_name(target_model, target_submodule)
+        if module_path is None:
+            module_path = _get_qualified_name(target_model, target_submodule)
+
+        # Build only the ancestor chain plus the descendant subtree for the target
+        # module. _resolve_prefer_transposed_hint only needs these entries, so a full
+        # target_model.named_modules() scan is avoided on every materialize call.
+        modules_by_name: Optional[Dict[str, torch.nn.Module]] = None
+        if module_path is not None:
+            modules_by_name = {"": target_model}
+            parts = module_path.split(".")
+            for i in range(len(parts)):
+                prefix = ".".join(parts[: i + 1])
+                try:
+                    modules_by_name[prefix] = target_model.get_submodule(prefix)
+                except (AttributeError, IndexError, KeyError):
+                    break
+            modules_by_name[module_path] = target_submodule
+            if recurse:
+                for subname, submod in target_submodule.named_modules():
+                    full_name = f"{module_path}.{subname}" if subname else module_path
+                    modules_by_name[full_name] = submod
+        elif recurse:
+            modules_by_name = dict(target_model.named_modules())
+
         with self._lock:
-            self._copy_checkpoint_tensors_into_submodule(
+            loaded_entries = self._copy_checkpoint_tensors_into_submodule(
                 target_model=target_model,
                 target_submodule=target_submodule,
-                module_path=path,
+                module_path=module_path,
                 device=device,
-                recurse=True,
+                recurse=recurse,
                 non_blocking=non_blocking,
+                modules_by_name=modules_by_name,
+                show_progress=show_progress,
             )
-        if hasattr(target_model, "tie_weights"):
+        if tie_weights and loaded_entries > 0 and hasattr(target_model, "tie_weights"):
             target_model.tie_weights()
         return target_submodule
 
@@ -2274,12 +2303,17 @@ class LazyTurtle:
         device: torch.device,
         recurse: bool,
         non_blocking: bool,
-    ) -> None:
+        modules_by_name: Optional[Dict[str, nn.Module]] = None,
+        show_progress: bool = True,
+    ) -> int:
         """Materialize checkpoint tensors into a shell submodule and rebuild missing init-only buffers."""
 
         t_params = dict(target_submodule.named_parameters(recurse=recurse))
         t_bufs = dict(target_submodule.named_buffers(recurse=recurse))
-        modules_by_name = dict(target_model.named_modules())
+        if modules_by_name is None:
+            # Fall back to a full model scan when the caller has not supplied a
+            # targeted ancestor+descendant map.
+            modules_by_name = dict(target_model.named_modules())
         missing_nonpersistent_buffers: list[tuple[str, str]] = []
 
         grouped_names: Dict[str, list[tuple[str, str, str, Optional[int], Optional[int], Optional[int]]]] = {}
@@ -2346,7 +2380,7 @@ class LazyTurtle:
         total_entries = sum(len(entries) for entries in grouped_names.values()) + len(concat_entries)
         progress = None
         loaded_entries = 0
-        if total_entries:
+        if total_entries and show_progress:
             progress = log.pb(range(total_entries)).manual().set(show_left_steps=False)
             module_label = module_path or "<root>"
             progress.title(f"Loading checkpoint tensors ({total_entries})")
@@ -2600,6 +2634,7 @@ class LazyTurtle:
             missing_nonpersistent_buffers=missing_nonpersistent_buffers,
             device=device,
         )
+        return loaded_entries
 
     def _build_nonpersistent_buffer_template(
         self,

--- a/scripts/benchmark_lazy_turtle_materialize_map.py
+++ b/scripts/benchmark_lazy_turtle_materialize_map.py
@@ -1,0 +1,120 @@
+"""Micro-benchmark of the module-map construction in LazyTurtle.materialize_submodule.
+
+Reports the cost of the old `dict(target_model.named_modules())` scan versus the
+targeted ancestor+descendant map used after the PR #134 optimization.
+"""
+
+from __future__ import annotations
+
+import statistics
+import time
+from typing import List, Tuple
+
+import torch
+import torch.nn as nn
+
+
+def _build_shell(num_leaves: int, depth: int = 4) -> nn.Module:
+    """Build a shell with `num_leaves` meta Linear modules under a nested tree."""
+    torch.set_default_dtype(torch.float16)
+    root = nn.Module()
+    root.layers = nn.ModuleList()
+    leaves_per_layer = max(1, num_leaves // max(1, depth))
+    for i in range(depth):
+        layer = nn.Module()
+        layer.blocks = nn.ModuleList()
+        for j in range(leaves_per_layer):
+            block = nn.Module()
+            block.proj = nn.Linear(64, 64, bias=False, device="meta")
+            layer.blocks.append(block)
+        root.layers.append(layer)
+    return root
+
+
+def _old_map_build(target_model: nn.Module) -> dict[str, nn.Module]:
+    return dict(target_model.named_modules())
+
+
+def _new_map_build(target_model: nn.Module, target_submodule: nn.Module, module_path: str) -> dict[str, nn.Module]:
+    modules_by_name: dict[str, nn.Module] = {"": target_model}
+    parts = module_path.split(".")
+    for i in range(len(parts)):
+        prefix = ".".join(parts[: i + 1])
+        try:
+            modules_by_name[prefix] = target_model.get_submodule(prefix)
+        except (AttributeError, IndexError, KeyError):
+            break
+    modules_by_name[module_path] = target_submodule
+    for subname, submod in target_submodule.named_modules():
+        full_name = f"{module_path}.{subname}" if subname else module_path
+        modules_by_name[full_name] = submod
+    return modules_by_name
+
+
+def _timeit(fn, repeat: int = 5) -> Tuple[float, float]:
+    times: List[float] = []
+    for _ in range(repeat):
+        torch.cuda.synchronize() if torch.cuda.is_available() else None
+        t0 = time.perf_counter()
+        fn()
+        torch.cuda.synchronize() if torch.cuda.is_available() else None
+        t1 = time.perf_counter()
+        times.append(t1 - t0)
+    return statistics.mean(times), statistics.stdev(times)
+
+
+def main() -> None:
+    scales = [1_000, 5_000, 10_000, 27_000, 50_000]
+    repeats = max(3, 30_000 // max(scales))  # fewer reps for larger models
+
+    print("LazyTurtle module-map construction: old full-model scan vs. targeted map\n")
+    header = f"{'total_modules':>13} {'old_mean_ms':>12} {'new_mean_ms':>12} {'speedup':>9} {'saved_ms':>10}"
+    print(header)
+    print("-" * len(header))
+
+    for num_leaves in scales:
+        shell = _build_shell(num_leaves)
+        total_modules = len(list(shell.named_modules()))
+        target_submodule = shell.layers[0].blocks[0]
+        module_path = "layers.0.blocks.0"
+
+        def old():
+            _old_map_build(shell)
+
+        def new():
+            _new_map_build(shell, target_submodule, module_path)
+
+        old_mean, _ = _timeit(old, repeats)
+        new_mean, _ = _timeit(new, repeats)
+
+        old_ms = old_mean * 1000
+        new_ms = new_mean * 1000
+        speedup = old_ms / new_ms if new_ms else 0.0
+        saved_ms = old_ms - new_ms
+
+        print(f"{total_modules:13d} {old_ms:12.3f} {new_ms:12.3f} {speedup:9.1f} {saved_ms:10.3f}")
+
+    print("\nLarge MoE model extrapolation (total_modules ≈ 27,000, ~775 materialize_submodule calls/layer):")
+    shell = _build_shell(27_000)
+    target_submodule = shell.layers[0].blocks[0]
+    module_path = "layers.0.blocks.0"
+    old_mean, _ = _timeit(lambda: _old_map_build(shell), 5)
+    new_mean, _ = _timeit(lambda: _new_map_build(shell, target_submodule, module_path), 5)
+    old_per_call = old_mean
+    new_per_call = new_mean
+    calls_per_layer = 775
+    layers = 33
+    total_old = old_per_call * calls_per_layer * layers
+    total_new = new_per_call * calls_per_layer * layers
+    print(f"  old map time per call: {old_per_call * 1000:.3f} ms")
+    print(f"  new map time per call: {new_per_call * 1000:.3f} ms")
+    print(f"  calls per layer:        {calls_per_layer}")
+    print(f"  layers:                 {layers}")
+    print(f"  old total map time:     {total_old:.3f} s")
+    print(f"  new total map time:     {total_new:.3f} s")
+    print(f"  map time saved:         {total_old - total_new:.3f} s")
+    print(f"  full-model named_modules() scans eliminated: {calls_per_layer * layers:,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_lazy_turtle_lifecycle.py
+++ b/scripts/profile_lazy_turtle_lifecycle.py
@@ -1,0 +1,293 @@
+"""Lifecycle telemetry profiler for LazyTurtle turtle -> shell -> disk offload.
+
+Emulates a 1/10-scale synthetic MoE model (33 layers, 25 experts per layer,
+hidden 3072 -> 307, MoE intermediate 1024 -> 102). For each layer it materializes
+all leaf modules from a synthetic safetensors checkpoint into a meta shell, then
+offloads each leaf to disk, recording entry/exit timers for the materialize and
+offload calls. No quantization math is run.
+"""
+
+from __future__ import annotations
+
+import os
+import statistics
+import tempfile
+import time
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any, Dict, List, Tuple
+
+import torch
+import torch.nn as nn
+
+from gptqmodel.utils.model import move_to
+from gptqmodel.utils.offload import offload_to_disk
+from gptqmodel.utils.structure import LazyTurtle
+
+
+try:
+    from safetensors.torch import save_file
+except ImportError as exc:  # pragma: no cover - script diagnostic
+    raise SystemExit("`safetensors` is required for this profiler") from exc
+
+
+NUM_LAYERS = int(os.environ.get("LAZY_LIFECYCLE_LAYERS", 33))
+NUM_EXPERTS = int(os.environ.get("LAZY_LIFECYCLE_EXPERTS", 25))
+HIDDEN_SIZE = int(os.environ.get("LAZY_LIFECYCLE_HIDDEN", 307))
+MOE_INTERMEDIATE = int(os.environ.get("LAZY_LIFECYCLE_MOE_HIDDEN", 102))
+DTYPE = torch.float16
+
+
+@dataclass
+class Telemetry:
+    events: List[Dict[str, Any]] = field(default_factory=list)
+
+    def record(
+        self,
+        phase: str,
+        name: str,
+        start: float,
+        end: float,
+        layer: int | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.events.append(
+            {
+                "phase": phase,
+                "name": name,
+                "start": start,
+                "end": end,
+                "duration": end - start,
+                "layer": layer,
+                **kwargs,
+            }
+        )
+
+    def durations_for_layer(self, phase: str, layer: int) -> List[float]:
+        return [e["duration"] for e in self.events if e["phase"] == phase and e.get("layer") == layer]
+
+
+class ShellModel(nn.Module):
+    """Meta-device shell that mirrors the synthetic MoE structure."""
+
+    def __init__(
+        self,
+        num_layers: int,
+        num_experts: int,
+        hidden: int,
+        moe_hidden: int,
+    ) -> None:
+        super().__init__()
+        torch.set_default_dtype(DTYPE)
+        self.model = nn.Module()
+        self.model.layers = nn.ModuleDict()
+        for i in range(num_layers):
+            layer = nn.Module()
+            layer.self_attn = nn.Module()
+            layer.self_attn.q_proj = nn.Linear(hidden, hidden, bias=False, device="meta")
+            layer.self_attn.k_proj = nn.Linear(hidden, hidden, bias=False, device="meta")
+            layer.self_attn.v_proj = nn.Linear(hidden, hidden, bias=False, device="meta")
+            layer.self_attn.o_proj = nn.Linear(hidden, hidden, bias=False, device="meta")
+            layer.mlp = nn.Module()
+            layer.mlp.gate = nn.Linear(hidden, num_experts, bias=False, device="meta")
+            layer.mlp.experts = nn.ModuleList()
+            for _ in range(num_experts):
+                expert = nn.Module()
+                expert.gate_proj = nn.Linear(hidden, moe_hidden, bias=False, device="meta")
+                expert.up_proj = nn.Linear(hidden, moe_hidden, bias=False, device="meta")
+                expert.down_proj = nn.Linear(moe_hidden, hidden, bias=False, device="meta")
+                layer.mlp.experts.append(expert)
+            self.model.layers[str(i)] = layer
+
+        for p in self.parameters():
+            p.requires_grad = False
+
+
+def make_checkpoint(
+    checkpoint_dir: str,
+    num_layers: int,
+    num_experts: int,
+    hidden: int,
+    moe_hidden: int,
+) -> None:
+    torch.set_default_dtype(DTYPE)
+    tensors: Dict[str, torch.Tensor] = {}
+    for i in range(num_layers):
+        tensors[f"model.layers.{i}.self_attn.q_proj.weight"] = torch.randn(hidden, hidden)
+        tensors[f"model.layers.{i}.self_attn.k_proj.weight"] = torch.randn(hidden, hidden)
+        tensors[f"model.layers.{i}.self_attn.v_proj.weight"] = torch.randn(hidden, hidden)
+        tensors[f"model.layers.{i}.self_attn.o_proj.weight"] = torch.randn(hidden, hidden)
+        tensors[f"model.layers.{i}.mlp.gate.weight"] = torch.randn(num_experts, hidden)
+        for j in range(num_experts):
+            tensors[f"model.layers.{i}.mlp.experts.{j}.gate_proj.weight"] = torch.randn(moe_hidden, hidden)
+            tensors[f"model.layers.{i}.mlp.experts.{j}.up_proj.weight"] = torch.randn(moe_hidden, hidden)
+            tensors[f"model.layers.{i}.mlp.experts.{j}.down_proj.weight"] = torch.randn(hidden, moe_hidden)
+    save_file(tensors, os.path.join(checkpoint_dir, "model.safetensors"))
+
+
+def iter_leaf_paths(layer_idx: int, num_experts: int) -> List[str]:
+    paths: List[str] = []
+    for proj in ("q_proj", "k_proj", "v_proj", "o_proj"):
+        paths.append(f"model.layers.{layer_idx}.self_attn.{proj}")
+    paths.append(f"model.layers.{layer_idx}.mlp.gate")
+    for j in range(num_experts):
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            paths.append(f"model.layers.{layer_idx}.mlp.experts.{j}.{proj}")
+    return paths
+
+
+def linear_fit(xs: List[float], ys: List[float]) -> Tuple[float, float, float]:
+    """Return (slope, intercept, r_squared) for a simple OLS fit."""
+    n = len(xs)
+    if n < 2:
+        return 0.0, 0.0, 0.0
+    mean_x = statistics.mean(xs)
+    mean_y = statistics.mean(ys)
+    ss_xx = sum((x - mean_x) ** 2 for x in xs)
+    ss_xy = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    slope = ss_xy / ss_xx if ss_xx else 0.0
+    intercept = mean_y - slope * mean_x
+    ss_res = sum((y - (slope * x + intercept)) ** 2 for x, y in zip(xs, ys))
+    ss_tot = sum((y - mean_y) ** 2 for y in ys)
+    r2 = 1.0 - (ss_res / ss_tot) if ss_tot else 0.0
+    return slope, intercept, r2
+
+
+def run_lazy_turtle_lifecycle(
+    num_layers: int = NUM_LAYERS,
+    num_experts: int = NUM_EXPERTS,
+    hidden: int = HIDDEN_SIZE,
+    moe_hidden: int = MOE_INTERMEDIATE,
+) -> Dict[str, Any]:
+    os.environ.setdefault("GPTQMODEL_LAZY_TURTLE_PARALLEL_LOAD_WORKERS", "1")
+    torch.set_default_dtype(DTYPE)
+
+    telemetry = Telemetry()
+    with tempfile.TemporaryDirectory() as checkpoint_dir, tempfile.TemporaryDirectory() as offload_dir:
+        make_checkpoint(checkpoint_dir, num_layers, num_experts, hidden, moe_hidden)
+        shell = ShellModel(num_layers, num_experts, hidden, moe_hidden)
+        device = torch.device("cpu")
+
+        turtle = LazyTurtle(
+            model_local_path=checkpoint_dir,
+            config=SimpleNamespace(),
+            target_model=shell,
+            hf_conversion_map_reversed=None,
+        )
+
+        per_layer: List[Dict[str, Any]] = []
+        for layer_idx in range(num_layers):
+            layer_start = time.perf_counter()
+            layer = shell.get_submodule(f"model.layers.{layer_idx}")
+            paths = iter_leaf_paths(layer_idx, num_experts)
+
+            materialize_total = 0.0
+            for path in paths:
+                sub = shell.get_submodule(path)
+                t0 = time.perf_counter()
+                turtle.materialize_submodule(
+                    target_model=shell,
+                    target_submodule=sub,
+                    device=device,
+                    module_path=path,
+                    recurse=True,
+                    tie_weights=False,
+                    show_progress=False,
+                )
+                t1 = time.perf_counter()
+                telemetry.record("materialize", path, t0, t1, layer=layer_idx)
+                materialize_total += t1 - t0
+
+            move_start = time.perf_counter()
+            move_to(layer, device)
+            move_end = time.perf_counter()
+            telemetry.record("move_to", f"model.layers.{layer_idx}", move_start, move_end, layer=layer_idx)
+
+            offload_total = 0.0
+            for path in paths:
+                sub = shell.get_submodule(path)
+                t0 = time.perf_counter()
+                offload_to_disk(
+                    module=sub,
+                    model=shell,
+                    disk_path=offload_dir,
+                )
+                t1 = time.perf_counter()
+                telemetry.record("offload", path, t0, t1, layer=layer_idx)
+                offload_total += t1 - t0
+
+            layer_end = time.perf_counter()
+            per_layer.append(
+                {
+                    "layer": layer_idx,
+                    "modules": len(paths),
+                    "materialize_total": materialize_total,
+                    "offload_total": offload_total,
+                    "move_total": move_end - move_start,
+                    "layer_total": layer_end - layer_start,
+                }
+            )
+
+    return {
+        "num_layers": num_layers,
+        "num_experts": num_experts,
+        "hidden": hidden,
+        "moe_hidden": moe_hidden,
+        "per_layer": per_layer,
+        "telemetry": telemetry,
+    }
+
+
+def print_report(result: Dict[str, Any]) -> None:
+    per_layer = result["per_layer"]
+    print("\nLazyTurtle lifecycle telemetry (turtle -> shell -> disk)\n")
+    header = f"{'layer':>5} {'modules':>7} {'mat_total':>10} {'off_total':>10} {'move_total':>10} {'layer_total':>11}"
+    print(header)
+    print("-" * len(header))
+    for row in per_layer:
+        print(
+            f"{row['layer']:5d} {row['modules']:7d} "
+            f"{row['materialize_total']:10.3f} {row['offload_total']:10.3f} "
+            f"{row['move_total']:10.3f} {row['layer_total']:11.3f}"
+        )
+
+    xs = [r["layer"] for r in per_layer]
+    layer_totals = [r["layer_total"] for r in per_layer]
+    mat_totals = [r["materialize_total"] for r in per_layer]
+    off_totals = [r["offload_total"] for r in per_layer]
+
+    def summarize(name: str, ys: List[float]) -> None:
+        slope, intercept, r2 = linear_fit(xs, ys)
+        q = max(1, len(ys) // 4)
+        first_avg = statistics.mean(ys[:q])
+        last_avg = statistics.mean(ys[-q:])
+        print(f"\n{name}:")
+        print(f"  first_quarter_avg = {first_avg:.3f}s")
+        print(f"  last_quarter_avg  = {last_avg:.3f}s")
+        if first_avg:
+            print(f"  last/first ratio  = {last_avg / first_avg:.2f}")
+        else:
+            print("  last/first ratio  = N/A")
+        print(f"  linear slope      = {slope:.6f}s/layer")
+        print(f"  R^2               = {r2:.4f}")
+
+    summarize("layer_total", layer_totals)
+    summarize("materialize_total", mat_totals)
+    summarize("offload_total", off_totals)
+
+    telemetry: Telemetry = result["telemetry"]
+    early_layer_off = telemetry.durations_for_layer("offload", 0) + telemetry.durations_for_layer("offload", 1)
+    late_layer_off = telemetry.durations_for_layer("offload", max(0, len(per_layer) - 2))
+    if early_layer_off:
+        print(f"\nper-module median offload early = {statistics.median(early_layer_off):.4f}s")
+    if late_layer_off:
+        print(f"per-module median offload late  = {statistics.median(late_layer_off):.4f}s")
+
+
+def main() -> None:
+    result = run_lazy_turtle_lifecycle()
+    print_report(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_lazy_turtle_materialize_map.py
+++ b/tests/test_lazy_turtle_materialize_map.py
@@ -1,0 +1,184 @@
+"""Regression tests for the targeted module-map optimization in LazyTurtle.materialize_submodule."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+from safetensors.torch import save_file
+
+from gptqmodel.utils.structure import LazyTurtle
+
+
+class _TransposedCheckpointInner(nn.Module):
+    """Nested module whose checkpoint weight is stored in (in, out) layout."""
+
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        # Runtime Linear expects (out, in). Checkpoint stores (in, out) and is
+        # marked transposed on the parent container.
+        self.layer = nn.Linear(in_features, out_features, bias=False)
+
+
+class _TransposedCheckpointShell(nn.Module):
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        self.inner = _TransposedCheckpointInner(in_features, out_features)
+
+
+def _write_index(model_dir: Path, shard_name: str, tensors: dict[str, torch.Tensor]) -> None:
+    (model_dir / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": dict.fromkeys(tensors, shard_name)}), encoding="utf-8"
+    )
+
+
+def test_materialize_submodule_recurse_true_uses_descendant_and_ancestor_map(tmp_path, monkeypatch):
+    """With recurse=True, module_path uses ancestor+descendant map instead of target_model.named_modules()."""
+
+    in_features, out_features = 16, 32
+    model_dir = tmp_path / "source"
+    model_dir.mkdir()
+
+    # Checkpoint stores (in, out); the shell Linear expects (out, in).
+    source = {"inner.layer.weight": torch.randn(in_features, out_features, dtype=torch.float32)}
+    save_file(source, str(model_dir / "model.safetensors"))
+    _write_index(model_dir, "model.safetensors", source)
+
+    shell = _TransposedCheckpointShell(in_features, out_features)
+    for p in shell.parameters():
+        p.requires_grad = False
+
+    # Mark the parent container as transposed so _resolve_prefer_transposed_hint
+    # must be able to walk from the descendant up to this ancestor.
+    shell.inner.is_transposed = True
+
+    turtle = LazyTurtle.maybe_create(
+        model_local_path=str(model_dir),
+        config=SimpleNamespace(_experts_implementation=None),
+        model_init_kwargs={"device_map": {"": "cpu"}},
+    )
+    assert turtle is not None
+
+    original_named_modules = nn.Module.named_modules
+
+    def _raising_named_modules(self, *args, **kwargs):
+        # Scanning the root model would be the old full-model-map behavior.
+        if self is shell:
+            raise AssertionError("target_model.named_modules() should not be called")
+        return original_named_modules(self, *args, **kwargs)
+
+    monkeypatch.setattr(nn.Module, "named_modules", _raising_named_modules)
+
+    turtle.materialize_submodule(
+        target_model=shell,
+        target_submodule=shell.inner,
+        device=torch.device("cpu"),
+        module_path="inner",
+        recurse=True,
+    )
+
+    expected = source["inner.layer.weight"].transpose(0, 1).contiguous()
+    loaded = shell.inner.layer.weight
+    assert loaded.shape == expected.shape
+    assert loaded.dtype == expected.dtype
+    assert torch.equal(loaded, expected)
+
+
+def test_materialize_submodule_recurse_false_uses_ancestor_map_for_leaf(tmp_path, monkeypatch):
+    """With recurse=False, module_path uses the ancestor chain to resolve transpose hints on a leaf."""
+
+    in_features, out_features = 16, 32
+    model_dir = tmp_path / "source"
+    model_dir.mkdir()
+
+    source = {"inner.layer.weight": torch.randn(in_features, out_features, dtype=torch.float32)}
+    save_file(source, str(model_dir / "model.safetensors"))
+    _write_index(model_dir, "model.safetensors", source)
+
+    shell = _TransposedCheckpointShell(in_features, out_features)
+    for p in shell.parameters():
+        p.requires_grad = False
+
+    shell.inner.is_transposed = True
+
+    turtle = LazyTurtle.maybe_create(
+        model_local_path=str(model_dir),
+        config=SimpleNamespace(_experts_implementation=None),
+        model_init_kwargs={"device_map": {"": "cpu"}},
+    )
+    assert turtle is not None
+
+    original_named_modules = nn.Module.named_modules
+
+    def _raising_named_modules(self, *args, **kwargs):
+        if self is shell:
+            raise AssertionError("target_model.named_modules() should not be called")
+        return original_named_modules(self, *args, **kwargs)
+
+    monkeypatch.setattr(nn.Module, "named_modules", _raising_named_modules)
+
+    turtle.materialize_submodule(
+        target_model=shell,
+        target_submodule=shell.inner.layer,
+        device=torch.device("cpu"),
+        module_path="inner.layer",
+        recurse=False,
+    )
+
+    expected = source["inner.layer.weight"].transpose(0, 1).contiguous()
+    loaded = shell.inner.layer.weight
+    assert loaded.shape == expected.shape
+    assert loaded.dtype == expected.dtype
+    assert torch.equal(loaded, expected)
+
+
+def test_materialize_submodule_descendant_map_respects_local_is_transposed(tmp_path, monkeypatch):
+    """A descendant's own is_transposed hint must be found via the subtree map."""
+
+    in_features, out_features = 16, 32
+    model_dir = tmp_path / "source"
+    model_dir.mkdir()
+
+    source = {"inner.layer.weight": torch.randn(in_features, out_features, dtype=torch.float32)}
+    save_file(source, str(model_dir / "model.safetensors"))
+    _write_index(model_dir, "model.safetensors", source)
+
+    shell = _TransposedCheckpointShell(in_features, out_features)
+    for p in shell.parameters():
+        p.requires_grad = False
+
+    # Set the hint on the leaf module itself, not on the parent.
+    shell.inner.layer.is_transposed = True
+
+    turtle = LazyTurtle.maybe_create(
+        model_local_path=str(model_dir),
+        config=SimpleNamespace(_experts_implementation=None),
+        model_init_kwargs={"device_map": {"": "cpu"}},
+    )
+    assert turtle is not None
+
+    original_named_modules = nn.Module.named_modules
+
+    def _raising_named_modules(self, *args, **kwargs):
+        if self is shell:
+            raise AssertionError("target_model.named_modules() should not be called")
+        return original_named_modules(self, *args, **kwargs)
+
+    monkeypatch.setattr(nn.Module, "named_modules", _raising_named_modules)
+
+    turtle.materialize_submodule(
+        target_model=shell,
+        target_submodule=shell.inner,
+        device=torch.device("cpu"),
+        module_path="inner",
+        recurse=True,
+    )
+
+    expected = source["inner.layer.weight"].transpose(0, 1).contiguous()
+    loaded = shell.inner.layer.weight
+    assert loaded.shape == expected.shape
+    assert loaded.dtype == expected.dtype
+    assert torch.equal(loaded, expected)


### PR DESCRIPTION
## Summary

`LazyTurtle.materialize_submodule` was building `dict(target_model.named_modules())` on every call, which is `O(total_modules × modules_per_layer)` and dominated per-module load time for large MoE models. This change replaces that full-model scan with a targeted map that contains only the target submodule, its ancestors, and (when `recurse=True`) its descendants, which is exactly what `_resolve_prefer_transposed_hint` needs.

```python
# before
modules_by_name = dict(target_model.named_modules())

# after
modules_by_name = {"": target_model}
for i in range(len(parts)):
    modules_by_name[prefix] = target_model.get_submodule(prefix)
modules_by_name[module_path] = target_submodule
if recurse:
    for subname, submod in target_submodule.named_modules():
        modules_by_name[...] = submod
```

- `materialize_submodule` now accepts optional `module_path`, `recurse`, `tie_weights`, and `show_progress` kwargs, builds the targeted map, and passes it to `_copy_checkpoint_tensors_into_submodule`.
- `_copy_checkpoint_tensors_into_submodule` now accepts an optional `modules_by_name` map and falls back to a full `named_modules()` scan only when none is provided.
- Added `tests/test_lazy_turtle_materialize_map.py` with regression tests that monkeypatch `nn.Module.named_modules` to raise if a full model scan is used, while still verifying `is_transposed` hints on ancestors and descendants and numerical parity of the loaded weights.
- Added `scripts/benchmark_lazy_turtle_materialize_map.py` and `scripts/profile_lazy_turtle_lifecycle.py` for micro-benchmarking map construction and measuring the full turtle -> shell -> disk lifecycle on a synthetic MoE model.

Validation:
- `ruff check ...` clean
- `pytest -q tests/test_structure.py tests/test_lazy_turtle_materialize_map.py` — 5 passed
- `python scripts/benchmark_lazy_turtle_materialize_map.py` and `LAZY_LIFECYCLE_LAYERS=2 python scripts/profile_lazy_turtle_lifecycle.py` run successfully on CPU
