### PR TITLE
fix(qlinear,tests): avoid None non-persistent had_K buffer and tune test allocator

### DIFF
--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -245,8 +245,7 @@ def _setup_rotation_online_had(model, rotation: Optional[str]) -> None:
             had_K, K = get_hadK(intermediate_size)
             module.online_full_had = True
             module.K = K
-            if had_K is not None:
-                module.register_buffer("had_K", had_K, persistent=False)
+            module.set_had_K(had_K)
             online_count += 1
 
     if online_count == 0:

--- a/gptqmodel/nn_modules/qlinear/__init__.py
+++ b/gptqmodel/nn_modules/qlinear/__init__.py
@@ -122,11 +122,16 @@ class BaseQuantLinear(nn.Module):
         self._autotune_result: Any = None
 
         # Rotation/online-Hadamard state for SpinQuant/QuaRot inference.
+        # Do NOT register `had_K` as a buffer unless a real tensor is supplied:
+        # `accelerate` iterates non-persistent buffers during disk offloading and
+        # `set_module_tensor_to_device` fails on `None` buffer values. The
+        # rotation/loader paths explicitly call `register_buffer("had_K", ...,
+        # persistent=False)` when the Hadamard matrix is actually computed.
         self.online_full_had = False
         self.online_partial_had = False
         self.had_dim = -1
         self.K = 1
-        self.register_buffer("had_K", None, persistent=False)
+        self.had_K = None
 
         validate_args = {
             "bits": bits,
@@ -469,6 +474,25 @@ class BaseQuantLinear(nn.Module):
 
         self.clear_autotune()
         return super().train(mode)
+
+    def set_had_K(self, had_K: Optional[t.Tensor]):
+        """Set or clear the rotation Hadamard matrix, keeping it as a non-persistent buffer only when a real tensor is supplied.
+
+        Avoids registering `had_K` as a `None` non-persistent buffer, because
+        `accelerate` iterates such buffers during disk offloading and
+        `set_module_tensor_to_device` raises on `None` values.
+        """
+        # Remove any existing plain attribute or buffer slot so that
+        # `register_buffer` can (re-)install the non-persistent buffer cleanly.
+        if "had_K" in self.__dict__:
+            del self.__dict__["had_K"]
+        if "had_K" in self._buffers:
+            del self._buffers["had_K"]
+
+        if had_K is not None:
+            self.register_buffer("had_K", had_K, persistent=False)
+        else:
+            self.had_K = None
 
     def _apply_rotation_to_input(self, x: t.Tensor) -> t.Tensor:
         """Apply online Hadamard transform to the input for SpinQuant/QuaRot inference."""

--- a/gptqmodel/quantization/rotation/rotation.py
+++ b/gptqmodel/quantization/rotation/rotation.py
@@ -159,7 +159,7 @@ def rotate_mlp_output(layer, Q, device):
     W.online_partial_had = False
     W.had_dim = -1
     had_K, K = get_hadK(W.in_features)
-    W.had_K = had_K
+    W.set_had_K(had_K)
     W.K = K
 
     if W.bias is not None:

--- a/tests/kernels/test_qlinear_hierarchy.py
+++ b/tests/kernels/test_qlinear_hierarchy.py
@@ -265,3 +265,22 @@ def test_gptq_quant_linear_buffer_shapes_for_non_word_aligned_out_features():
         missing, unexpected = layer.load_state_dict(state, strict=False)
         assert not missing
         assert not unexpected
+
+
+def test_had_k_placeholder_is_not_a_none_buffer():
+    """Non-persistent None buffers break accelerate's disk offloader; keep had_K as a plain attribute until rotation/loader materializes a real tensor."""
+    layer = TorchLinear(
+        bits=4,
+        group_size=128,
+        sym=True,
+        desc_act=False,
+        in_features=64,
+        out_features=64,
+        bias=False,
+        register_buffers=False,
+    )
+    assert layer.had_K is None
+    assert "had_K" not in layer._buffers
+    assert "had_K" not in layer.state_dict()
+    # Accelerate should not see a None tensor during offloading.
+    assert "had_K" not in {name for name, _ in layer.named_buffers()}

--- a/tests/models/model_test.py
+++ b/tests/models/model_test.py
@@ -12,7 +12,7 @@ if sys.platform == "darwin":
     os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
 
 os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
-os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True,max_split_size_mb:256,garbage_collection_threshold:0.7" #"expandable_segments:True"
+os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True,max_split_size_mb:1024,garbage_collection_threshold:0.5" #"expandable_segments:True"
 
 # Following makes test results more deterministic but much slower
 # # the CUBLAS env is required for use_deterministic_algorithms

--- a/tests/test_rotation_persistence.py
+++ b/tests/test_rotation_persistence.py
@@ -33,7 +33,7 @@ class _DummyQuantLinear(BaseQuantLinear):
         self.online_partial_had = False
         self.had_dim = -1
         self.K = 1
-        self.register_buffer("had_K", None, persistent=False)
+        self.had_K = None
 
 
 class _DummyMlp(torch.nn.Module):


### PR DESCRIPTION
## Summary

`BaseQuantLinear` was registering `had_K` as a non-persistent buffer with a `None` value. When `offload_to_disk=True` is enabled during quantization, `accelerate` iterates non-persistent buffers and calls `set_module_tensor_to_device`, which crashes with `AttributeError: 'NoneType' object has no attribute 'device'`.

This change keeps `had_K` as a plain `None` attribute by default and only materializes it as a non-persistent buffer when rotation/loader code actually computes a real Hadamard tensor.

## What Changed

- `gptqmodel/nn_modules/qlinear/__init__.py`:
  - `self.had_K = None` instead of `self.register_buffer("had_K", None, persistent=False)`.
  - New `set_had_K(had_K)` helper removes any existing attribute/buffer slot, then registers a real tensor as a non-persistent buffer or resets a plain `None` placeholder.
- `gptqmodel/models/loader.py`: `_setup_rotation_online_had` now calls `module.set_had_K(had_K)`.
- `gptqmodel/quantization/rotation/rotation.py`: `fusing/fuse_layer_norms` rotation path now calls `W.set_had_K(had_K)`.
- `tests/test_rotation_persistence.py`: `_DummyQuantLinear` now mirrors the real `BaseQuantLinear` init (plain `None` `had_K`).
- `tests/models/model_test.py`: `PYTORCH_ALLOC_CONF` set to `expandable_segments:True,max_split_size_mb:1024,garbage_collection_threshold:0.5`.
- `tests/kernels/test_qlinear_hierarchy.py`: added `test_had_k_placeholder_is_not_a_none_buffer` to prevent regression.

## Tests

- [x] Added `test_had_k_placeholder_is_not_a_none_buffer`.
- [x] Ran the new targeted test locally:

```bash
cd /root/GPT-QModel-Clean
python -m pytest tests/kernels/test_qlinear_hierarchy.py::test_had_k_placeholder_is_not_a_none_buffer -q
# 1 passed, 16 warnings
```

- [x] Ran rotation persistence tests:

```bash
python -m pytest tests/test_rotation_persistence.py -q
# 9 passed, 1 skipped, 16 warnings
```

- [x] Ran `tests/models/test_llama3_2.py` on single GPU (CUDA 6) with `offload_to_disk=True`:

```bash
export CUDA_VISIBLE_DEVICES=6
python -m pytest tests/models/test_llama3_2.py -q -s
# 1 passed in 169.08s
```

Scores (MARLIN fast mode):
- `gsm8k_platinum_cot:acc,num` = 0.4599 (expected 0.469, within tolerance)
- `arc_challenge:acc` = 0.3157 (expected 0.314)
- `arc_challenge:acc_norm` = 0.3532 (expected 0.3507)

No temp CUDA segment-allocation errors or OOM appeared in the log.

```bash
ruff check gptqmodel/nn_modules/qlinear/__init__.py gptqmodel/models/loader.py gptqmodel/quantization/rotation/rotation.py tests/test_rotation_persistence.py tests/kernels/test_qlinear_hierarchy.py tests/models/model_test.py
git diff --check
# All checks passed
```

## Review Requirements

- [x] I personally reviewed every file in this diff.
- [x] The changes match existing project structure and conventions.
- [x] The fix uses a normal `BaseQuantLinear` method rather than monkeypatching `accelerate`.

## Notes

- The `PYTORCH_ALLOC_CONF` change in `model_test.py` is the user-requested global test allocator tuning.
- `set_had_K` ensures `had_K` is always either a plain `None` attribute or a real non-persistent buffer tensor, so `disk_offload` never encounters a `None` buffer value and rotated models still move `had_K` to the execution device correctly.

Link to Devin session: https://app.devin.ai/sessions/05e28239d26145d8bb0a26ac17be0539
Requested by: @Qubitium