### PR TITLE
docs: fix FP8Config/EXL3Config imports in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,8 @@ model.save(quant_path)
 ##### FP8 Example: Llama 3.2 1B Instruct
 
 ```py
-from gptqmodel import BACKEND, FP8Config, GPTQModel
+from gptqmodel import BACKEND, GPTQModel
+from gptqmodel.quantization import FP8Config
 
 model_id = "meta-llama/Llama-3.2-1B-Instruct"
 quant_path = "Llama-3.2-1B-Instruct-FP8-E4M3"
@@ -478,7 +479,8 @@ model.save(quant_path)
 
 ```py
 from datasets import load_dataset
-from gptqmodel import BACKEND, EXL3Config, GPTQModel
+from gptqmodel import BACKEND, GPTQModel
+from gptqmodel.quantization import EXL3Config
 
 model_id = "meta-llama/Llama-3.2-1B-Instruct"
 quant_path = "Llama-3.2-1B-Instruct-EXL3"


### PR DESCRIPTION
The **FP8** and **EXL3** quantization examples in the README import their config class from the top-level `gptqmodel` package:

```python
from gptqmodel import BACKEND, FP8Config, GPTQModel   # line 461
from gptqmodel import BACKEND, EXL3Config, GPTQModel  # line 481
```

But `FP8Config` and `EXL3Config` are **not** re-exported at the top level — `gptqmodel/__init__.py` re-exports only a fixed set from `.quantization` (`AWQConfig`, `BaseQuantizeConfig`, `GPTQConfig`, `QuantizeConfig`, `RTNConfig`, `GGUFConfig`, …) and has no `__getattr__`. Both classes are defined in and exported from `gptqmodel.quantization` (`gptqmodel/quantization/config.py`, re-exported by `gptqmodel/quantization/__init__.py`).

So running either example fails on the first line:

```
ImportError: cannot import name 'FP8Config' from 'gptqmodel'
```

This imports the two configs from `gptqmodel.quantization`, matching the existing pattern already used earlier in the README (the `from gptqmodel.quantization import (...)` block). `GGUFConfig` (which *is* top-level exported) is left unchanged.

Docs-only, makes the examples runnable.
