### PR TITLE
Restore torch.nn.init functions after from_pretrained weight-init suspension

### DIFF
--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -824,19 +824,7 @@ def ModelLoader(cls):
 
         check_versions(cls, cls.require_pkgs)
 
-        def skip(*args, **kwargs):
-            pass
-
-        original_inits = (
-            torch.nn.init.kaiming_uniform_,
-            torch.nn.init.uniform_,
-            torch.nn.init.normal_,
-        )
-        torch.nn.init.kaiming_uniform_ = skip
-        torch.nn.init.uniform_ = skip
-        torch.nn.init.normal_ = skip
-
-        try:
+        with suspend_hf_weight_init():
             # normalize and auto select quantization device is not passed
             if quantize_config.device is None:
                 quantize_config.device = auto_select_device(None, None)
@@ -941,12 +929,6 @@ def ModelLoader(cls):
                 _maybe_print_module_tree(model=model)
 
                 turtle_model = None
-        finally:
-            (
-                torch.nn.init.kaiming_uniform_,
-                torch.nn.init.uniform_,
-                torch.nn.init.normal_,
-            ) = original_inits
 
         model_config = model.config.to_dict()
         seq_len_keys = ["max_position_embeddings", "seq_length", "n_positions", "multimodal_max_length"]

--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -827,114 +827,126 @@ def ModelLoader(cls):
         def skip(*args, **kwargs):
             pass
 
+        original_inits = (
+            torch.nn.init.kaiming_uniform_,
+            torch.nn.init.uniform_,
+            torch.nn.init.normal_,
+        )
         torch.nn.init.kaiming_uniform_ = skip
         torch.nn.init.uniform_ = skip
         torch.nn.init.normal_ = skip
 
-        # normalize and auto select quantization device is not passed
-        if quantize_config.device is None:
-            quantize_config.device = auto_select_device(None, None)
-        else:
-            quantize_config.device = normalize_device(quantize_config.device)
+        try:
+            # normalize and auto select quantization device is not passed
+            if quantize_config.device is None:
+                quantize_config.device = auto_select_device(None, None)
+            else:
+                quantize_config.device = normalize_device(quantize_config.device)
 
-        if dtype is None or dtype == "auto" or not isinstance(dtype, torch.dtype):
-            # TODO FIX ME for `dynamic`, non-quantized modules should be in native type
-            dtype = auto_dtype(config=config, device=quantize_config.device, quant_inference=False)
+            if dtype is None or dtype == "auto" or not isinstance(dtype, torch.dtype):
+                # TODO FIX ME for `dynamic`, non-quantized modules should be in native type
+                dtype = auto_dtype(config=config, device=quantize_config.device, quant_inference=False)
 
-        # enforce some values despite user specified
-        # non-quantized models are always loaded into cpu
-        model_init_kwargs_without_internal["device_map"] = cpu_device_map
-        set_dtype_compat(model_init_kwargs_without_internal, dtype)
-        model_init_kwargs_without_internal["_fast_init"] = cls.require_fast_init
-        #model_init_kwargs["low_cpu_mem_usage"] = True
+            # enforce some values despite user specified
+            # non-quantized models are always loaded into cpu
+            model_init_kwargs_without_internal["device_map"] = cpu_device_map
+            set_dtype_compat(model_init_kwargs_without_internal, dtype)
+            model_init_kwargs_without_internal["_fast_init"] = cls.require_fast_init
+            #model_init_kwargs["low_cpu_mem_usage"] = True
 
-        cls.before_model_load(cls, model_local_path=model_local_path, load_quantized_model=False)
-        from ..utils.hf import build_shell_model
+            cls.before_model_load(cls, model_local_path=model_local_path, load_quantized_model=False)
+            from ..utils.hf import build_shell_model
 
-        # XIELUActivation will use some weights when activation init, so can't use init_empty_weights
-        if hasattr(config, "hidden_act") and config.hidden_act == "xielu":
-            quantize_config.offload_to_disk = False
+            # XIELUActivation will use some weights when activation init, so can't use init_empty_weights
+            if hasattr(config, "hidden_act") and config.hidden_act == "xielu":
+                quantize_config.offload_to_disk = False
 
-        # some models need convert moe-experts after model loaded, like GPTOSS and Llama4
-        # so offload_to_disk is not supported for them.
-        if not cls.support_offload_to_disk:
-            quantize_config.offload_to_disk = False
-            log.warn(f"{cls} doesn't support offload_to_disk, set quantize_config.offload_to_disk to False.")
+            # some models need convert moe-experts after model loaded, like GPTOSS and Llama4
+            # so offload_to_disk is not supported for them.
+            if not cls.support_offload_to_disk:
+                quantize_config.offload_to_disk = False
+                log.warn(f"{cls} doesn't support offload_to_disk, set quantize_config.offload_to_disk to False.")
 
-        if quantize_config.offload_to_disk:
-            shell_config = copy.deepcopy(config)
-            try:
-                model = build_shell_model(cls.loader, config=shell_config, **model_init_kwargs_without_internal)
-            except RuntimeError as exc:
-                if not _is_meta_shell_build_error(exc):
-                    raise
+            if quantize_config.offload_to_disk:
+                shell_config = copy.deepcopy(config)
+                try:
+                    model = build_shell_model(cls.loader, config=shell_config, **model_init_kwargs_without_internal)
+                except RuntimeError as exc:
+                    if not _is_meta_shell_build_error(exc):
+                        raise
 
-                log.warn(
-                    "Loader: meta-device shell build failed for `%s`; falling back to direct CPU load without turtle_model: %s",
-                    model_local_path,
-                    exc,
-                )
-                log.info("Loader: loading model directly to CPU (meta shell unsupported; turtle_model disabled)")
-                fallback_init_kwargs = model_init_kwargs_without_internal.copy()
-                fallback_init_kwargs.pop("device_map", None)
-                fallback_init_kwargs["low_cpu_mem_usage"] = False
+                    log.warn(
+                        "Loader: meta-device shell build failed for `%s`; falling back to direct CPU load without turtle_model: %s",
+                        model_local_path,
+                        exc,
+                    )
+                    log.info("Loader: loading model directly to CPU (meta shell unsupported; turtle_model disabled)")
+                    fallback_init_kwargs = model_init_kwargs_without_internal.copy()
+                    fallback_init_kwargs.pop("device_map", None)
+                    fallback_init_kwargs["low_cpu_mem_usage"] = False
+                    model = _hf_loader_from_pretrained_with_dynamic_module_retry(
+                        cls.loader,
+                        model_local_path,
+                        config=config,
+                        **fallback_init_kwargs,
+                        **hf_gguf_load_kwargs,
+                    )
+                    if getattr(model, "config", None) is config:
+                        model.config = copy.deepcopy(config)
+                    _convert_model_with_defuser(cls, model, cleanup_original=False)
+                    model._model_init_kwargs = fallback_init_kwargs
+                    _maybe_print_module_tree(model=model)
+                    turtle_model = None
+                else:
+                    _convert_model_with_defuser(cls, model, cleanup_original=False)
+                    shell_model_init_kwargs = dict(model_init_kwargs_without_internal)
+                    shell_model_init_kwargs.update(hf_gguf_load_kwargs)
+                    model._model_init_kwargs = shell_model_init_kwargs
+                    _maybe_print_module_tree(model=model)
+                    turtle_model = LazyTurtle.maybe_create(
+                        model_local_path=model_local_path,
+                        config=model.config,
+                        model_init_kwargs=shell_model_init_kwargs,
+                        module_tree=copy.deepcopy(getattr(cls, "module_tree", None)),
+                        hf_conversion_map_reversed=copy.deepcopy(
+                            cls.resolve_hf_conversion_map_reversed(target_model=model)
+                        ),
+                        target_model=model,
+                    )
+
+                    if turtle_model is None:
+                        raise RuntimeError(
+                            f"Loader: can't open model path `{model_local_path}` for offload_to_disk."
+                        )
+
+                    log.info(
+                        "Loader: using checkpoint-backed lazy turtle source for `%s`",
+                        model_local_path,
+                    )
+            else:
+                log.info("Loader: loading model directly to CPU (not using meta device or turtle_model)")
                 model = _hf_loader_from_pretrained_with_dynamic_module_retry(
                     cls.loader,
                     model_local_path,
                     config=config,
-                    **fallback_init_kwargs,
+                    **model_init_kwargs_without_internal,
                     **hf_gguf_load_kwargs,
                 )
                 if getattr(model, "config", None) is config:
                     model.config = copy.deepcopy(config)
                 _convert_model_with_defuser(cls, model, cleanup_original=False)
-                model._model_init_kwargs = fallback_init_kwargs
+                direct_model_init_kwargs = dict(model_init_kwargs_without_internal)
+                direct_model_init_kwargs.update(hf_gguf_load_kwargs)
+                model._model_init_kwargs = direct_model_init_kwargs
                 _maybe_print_module_tree(model=model)
+
                 turtle_model = None
-            else:
-                _convert_model_with_defuser(cls, model, cleanup_original=False)
-                shell_model_init_kwargs = dict(model_init_kwargs_without_internal)
-                shell_model_init_kwargs.update(hf_gguf_load_kwargs)
-                model._model_init_kwargs = shell_model_init_kwargs
-                _maybe_print_module_tree(model=model)
-                turtle_model = LazyTurtle.maybe_create(
-                    model_local_path=model_local_path,
-                    config=model.config,
-                    model_init_kwargs=shell_model_init_kwargs,
-                    module_tree=copy.deepcopy(getattr(cls, "module_tree", None)),
-                    hf_conversion_map_reversed=copy.deepcopy(
-                        cls.resolve_hf_conversion_map_reversed(target_model=model)
-                    ),
-                    target_model=model,
-                )
-
-                if turtle_model is None:
-                    raise RuntimeError(
-                        f"Loader: can't open model path `{model_local_path}` for offload_to_disk."
-                    )
-
-                log.info(
-                    "Loader: using checkpoint-backed lazy turtle source for `%s`",
-                    model_local_path,
-                )
-        else:
-            log.info("Loader: loading model directly to CPU (not using meta device or turtle_model)")
-            model = _hf_loader_from_pretrained_with_dynamic_module_retry(
-                cls.loader,
-                model_local_path,
-                config=config,
-                **model_init_kwargs_without_internal,
-                **hf_gguf_load_kwargs,
-            )
-            if getattr(model, "config", None) is config:
-                model.config = copy.deepcopy(config)
-            _convert_model_with_defuser(cls, model, cleanup_original=False)
-            direct_model_init_kwargs = dict(model_init_kwargs_without_internal)
-            direct_model_init_kwargs.update(hf_gguf_load_kwargs)
-            model._model_init_kwargs = direct_model_init_kwargs
-            _maybe_print_module_tree(model=model)
-
-            turtle_model = None
+        finally:
+            (
+                torch.nn.init.kaiming_uniform_,
+                torch.nn.init.uniform_,
+                torch.nn.init.normal_,
+            ) = original_inits
 
         model_config = model.config.to_dict()
         seq_len_keys = ["max_position_embeddings", "seq_length", "n_positions", "multimodal_max_length"]

--- a/tests/test_nn_init_restore.py
+++ b/tests/test_nn_init_restore.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 
+import json
+
 import pytest
 import torch
 
@@ -46,7 +48,7 @@ def test_nn_init_restored_after_from_pretrained(original_inits):
     assert tensor.abs().sum().item() > 0
 
 
-def test_nn_init_restored_after_from_pretrained_error(original_inits, tmp_path):
+def test_nn_init_restored_after_from_pretrained_error(original_inits, tmp_path, monkeypatch):
     # config-only dir: load enters the monkeypatched region then fails on missing weights
     config = {
         "architectures": ["GPT2LMHeadModel"],
@@ -57,9 +59,19 @@ def test_nn_init_restored_after_from_pretrained_error(original_inits, tmp_path):
         "n_positions": 32,
         "vocab_size": 64,
     }
-    import json
-
     (tmp_path / "config.json").write_text(json.dumps(config))
+
+    from gptqmodel.models.base import BaseQModel
+
+    patched_state = {}
+    original_before_model_load = BaseQModel.before_model_load
+
+    def spy_before_model_load(cls, **kwargs):
+        # runs inside the monkeypatched region; record that the no-op patch is active
+        patched_state["active"] = torch.nn.init.kaiming_uniform_ is not original_inits[0]
+        return original_before_model_load(cls, **kwargs)
+
+    monkeypatch.setattr(BaseQModel, "before_model_load", spy_before_model_load)
 
     with pytest.raises(Exception):
         GPTQModel.load(
@@ -67,5 +79,9 @@ def test_nn_init_restored_after_from_pretrained_error(original_inits, tmp_path):
             quantize_config=QuantizeConfig(bits=4, group_size=128),
             device="cpu",
         )
+
+    # the failure must have occurred after the init functions were patched,
+    # otherwise the restore assertion below would hold vacuously
+    assert patched_state.get("active") is True
 
     assert_inits_restored(original_inits)

--- a/tests/test_nn_init_restore.py
+++ b/tests/test_nn_init_restore.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+import pytest
+import torch
+
+from gptqmodel import GPTQModel, QuantizeConfig
+
+
+MODEL_ID = "sshleifer/tiny-gpt2"
+
+
+@pytest.fixture
+def original_inits():
+    return (
+        torch.nn.init.kaiming_uniform_,
+        torch.nn.init.uniform_,
+        torch.nn.init.normal_,
+    )
+
+
+def assert_inits_restored(original_inits):
+    assert torch.nn.init.kaiming_uniform_ is original_inits[0]
+    assert torch.nn.init.uniform_ is original_inits[1]
+    assert torch.nn.init.normal_ is original_inits[2]
+
+
+def test_nn_init_restored_after_from_pretrained(original_inits):
+    model = GPTQModel.load(
+        MODEL_ID,
+        quantize_config=QuantizeConfig(bits=4, group_size=128),
+        device="cpu",
+    )
+    assert model is not None
+
+    assert_inits_restored(original_inits)
+
+    linear = torch.nn.Linear(256, 256)
+    assert torch.isfinite(linear.weight).all()
+    assert linear.weight.std().item() > 0.001
+
+    tensor = torch.zeros(64, 64)
+    torch.nn.init.kaiming_uniform_(tensor, a=5**0.5)
+    assert tensor.abs().sum().item() > 0
+
+
+def test_nn_init_restored_after_from_pretrained_error(original_inits, tmp_path):
+    # config-only dir: load enters the monkeypatched region then fails on missing weights
+    config = {
+        "architectures": ["GPT2LMHeadModel"],
+        "model_type": "gpt2",
+        "n_embd": 8,
+        "n_head": 2,
+        "n_layer": 1,
+        "n_positions": 32,
+        "vocab_size": 64,
+    }
+    import json
+
+    (tmp_path / "config.json").write_text(json.dumps(config))
+
+    with pytest.raises(Exception):
+        GPTQModel.load(
+            str(tmp_path),
+            quantize_config=QuantizeConfig(bits=4, group_size=128),
+            device="cpu",
+        )
+
+    assert_inits_restored(original_inits)


### PR DESCRIPTION
## Summary

Supersedes #2994 (auto-closed by a branch rename; identical content plus the review follow-ups).

`ModelLoader.from_pretrained` replaced `torch.nn.init.kaiming_uniform_`, `torch.nn.init.uniform_`, and `torch.nn.init.normal_` with a no-op to avoid wasted dense weight init during model construction, but never restored the originals. Any `nn` module created in the same process afterward silently skipped randomized initialization (e.g. a fresh `nn.Linear` kept uninitialized garbage weights), causing order-dependent flakiness when model loading is mixed with new module construction.

## What Changed

- `gptqmodel/models/loader.py`: replace the hand-rolled init monkeypatch with the existing `suspend_hf_weight_init()` context manager (from `gptqmodel/utils/hf.py`), which patches the same three functions, additionally disables HF's `_init_weights` path, and always restores globals in a `finally`.
- `tests/test_nn_init_restore.py`: new unit test asserting the init functions are restored (by identity) after both a successful `from_pretrained` load and an exception during load; a spy on `BaseQModel.before_model_load` verifies the patch was active when the error occurred (so the exception-path test cannot pass vacuously), and a fresh `nn.Linear` created after load is properly randomized.
- No API changes. The `from_quantized` path is untouched and verified unregressed (see #2994 comments).

## Tests

- [x] I added a new simple/fast unit test for this change, or documented why that is not applicable.
- [x] I ran the new targeted test locally before opening this PR.
- [x] I ran any other directly relevant local tests.

```bash
cd tests && python -m pytest test_nn_init_restore.py -x -q
# 2 passed in 3.73s
```

End-to-end runtime verification (success path, exception path, negative control on pre-fix code, from_quantized regression check) is documented in the comments on #2994.

## Review Requirements

- [x] I personally reviewed every file in this diff.
- [x] I checked that the code matches existing project structure, APIs, and conventions.
- [x] I avoided unnecessary monkeypatching and used the project's normal extension points where possible.

## Notes

The loader diff looks large due to re-indentation under the `with suspend_hf_weight_init():` block; the load body itself is unchanged.

Link to Devin session: https://app.devin.ai/sessions/1ad2ab904b1e48e39df7e7060b7c1e04
Requested by: @Qubitium