### PR TITLE
gptq: add planar (gptq_p) checkpoint format with 3/5/6/7-bit support

### DIFF
--- a/docs/gptq_planar.md
+++ b/docs/gptq_planar.md
@@ -1,0 +1,73 @@
+# GPTQ planar checkpoint format (`gptq_p`)
+
+`gptq_p` is a distinct GPTQ checkpoint format that stores quantized codes as
+word-aligned **bit planes** ("split-plane" packing) instead of a continuous
+bit stream. It is the native format for 5/6/7-bit GPTQ and an optional layout
+for 2/3/4/8-bit. It is not interchangeable with the legacy continuous `gptq`
+(v1) / `gptq_v2` formats.
+
+## Why planar
+
+The continuous layout packs codes back-to-back, so any width that does not
+divide 32 produces codes straddling `int32` word boundaries, forcing
+per-position carry/stitch logic in every pack, unpack, convert, and kernel
+path. Planar packing splits each code into planes whose widths divide 32, so
+every packed word contains whole fields and decode is branch-free shifts and
+masks per plane plus an OR — the same approach GGUF uses for `q5_k`/`q6_k`.
+
+Storage cost is identical to continuous packing — exactly
+`ceil(n * bits / 32)` words — so `qweight`/`qzeros` keep their standard GPTQ
+tensor names and shapes. Only the config metadata
+(`checkpoint_format="gptq_p"`) distinguishes a planar checkpoint.
+
+## Plane layouts
+
+| bits | planes            | reconstruction                  |
+|------|-------------------|---------------------------------|
+| 2    | (2)               | single plane                    |
+| 3    | (2) + (1)         | `q = lo \| hi << 2`             |
+| 4    | (4)               | single plane                    |
+| 5    | (4) + (1)         | `q = lo \| hi << 4`             |
+| 6    | (4) + (2)         | `q = lo \| hi << 4`             |
+| 7    | (4) + (2) + (1)   | `q = lo \| mid << 4 \| hi << 6` |
+| 8    | (8)               | single plane                    |
+
+Single-plane widths (2/4/8) produce words bit-identical to the continuous
+2/4/8-bit layout, so `gptq_p` at those widths differs from `gptq_v2` only in
+metadata.
+
+## Storage contract
+
+- Packed words are `int32`.
+- Every 32 consecutive logical codes form a block stored as `bits` adjacent
+  words: low-plane words first, then the higher planes.
+- Within a plane of width `w`, word `i` holds codes
+  `[i*(32//w), (i+1)*(32//w))` at shifts `w*j`, matching the standard
+  2/4/8-bit packing convention.
+- No code ever crosses a word boundary; any group of 32 codes decodes
+  independently from `bits` words at a fixed offset (desc_act friendly).
+- The packed dimension must be divisible by 32; misaligned shapes are
+  rejected at module construction.
+- `qweight` packs along rows, `qzeros` along columns.
+
+## Format semantics
+
+- Serialized as `checkpoint_format="gptq_p"`.
+- Zero points use **v2 semantics** (true zero, no `-1` bias); planar
+  checkpoints never pass through the legacy GPTQ v1 `+1` qzeros correction.
+- 5/6/7-bit configurations auto-route to `gptq_p` (those widths have no
+  continuous layout). Explicit `format="gptq_p"` is accepted for bits 2-8.
+- Legacy `gptq`/`gptq_v2` at 2/3/4/8-bit keep their continuous layouts and
+  conversion behavior unchanged; 3-bit is planar only under `gptq_p`.
+
+## Validation summary
+
+CPU validation covers planar pack/unpack round-trips for all widths
+(including endpoint codes and misaligned-shape rejection), packer parity,
+dequantization against logical-code references, planar-vs-continuous parity
+(bit-identical dequant for 3-bit, bit-identical words for 2/4/8), v1/v2
+zeros conversion round-trips, config routing/serialization, and whole-model
+quantize -> save -> reload -> inference lifecycles for every bit width.
+Measured dequantization error matches the theoretical quantization half-step
+plus fp16 scale precision, with no systematic zero-point bias. GPU-native
+planar kernels are a separate, later phase.

--- a/docs/gptq_planar.md
+++ b/docs/gptq_planar.md
@@ -47,7 +47,9 @@ metadata.
 - No code ever crosses a word boundary; any group of 32 codes decodes
   independently from `bits` words at a fixed offset (desc_act friendly).
 - The packed dimension must be divisible by 32; misaligned shapes are
-  rejected at module construction.
+  rejected at module construction. This includes quantized embeddings and
+  lm_head at planar widths: vocabularies not divisible by 32 are a known
+  limitation (padding support is deferred).
 - `qweight` packs along rows, `qzeros` along columns.
 
 ## Format semantics

--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -299,7 +299,7 @@ def _setup_rotation_online_had(model, rotation: Optional[str]) -> None:
             module.online_full_had = True
             module.K = K
             if had_K is not None:
-                module.register_buffer("had_K", had_K, persistent=False)
+                module.set_had_K(had_K)
             online_count += 1
 
     if online_count == 0:

--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -824,117 +824,111 @@ def ModelLoader(cls):
 
         check_versions(cls, cls.require_pkgs)
 
-        def skip(*args, **kwargs):
-            pass
+        with suspend_hf_weight_init():
+            # normalize and auto select quantization device is not passed
+            if quantize_config.device is None:
+                quantize_config.device = auto_select_device(None, None)
+            else:
+                quantize_config.device = normalize_device(quantize_config.device)
 
-        torch.nn.init.kaiming_uniform_ = skip
-        torch.nn.init.uniform_ = skip
-        torch.nn.init.normal_ = skip
+            if dtype is None or dtype == "auto" or not isinstance(dtype, torch.dtype):
+                # TODO FIX ME for `dynamic`, non-quantized modules should be in native type
+                dtype = auto_dtype(config=config, device=quantize_config.device, quant_inference=False)
 
-        # normalize and auto select quantization device is not passed
-        if quantize_config.device is None:
-            quantize_config.device = auto_select_device(None, None)
-        else:
-            quantize_config.device = normalize_device(quantize_config.device)
+            # enforce some values despite user specified
+            # non-quantized models are always loaded into cpu
+            model_init_kwargs_without_internal["device_map"] = cpu_device_map
+            set_dtype_compat(model_init_kwargs_without_internal, dtype)
+            model_init_kwargs_without_internal["_fast_init"] = cls.require_fast_init
+            #model_init_kwargs["low_cpu_mem_usage"] = True
 
-        if dtype is None or dtype == "auto" or not isinstance(dtype, torch.dtype):
-            # TODO FIX ME for `dynamic`, non-quantized modules should be in native type
-            dtype = auto_dtype(config=config, device=quantize_config.device, quant_inference=False)
+            cls.before_model_load(cls, model_local_path=model_local_path, load_quantized_model=False)
+            from ..utils.hf import build_shell_model
 
-        # enforce some values despite user specified
-        # non-quantized models are always loaded into cpu
-        model_init_kwargs_without_internal["device_map"] = cpu_device_map
-        set_dtype_compat(model_init_kwargs_without_internal, dtype)
-        model_init_kwargs_without_internal["_fast_init"] = cls.require_fast_init
-        #model_init_kwargs["low_cpu_mem_usage"] = True
+            # XIELUActivation will use some weights when activation init, so can't use init_empty_weights
+            if hasattr(config, "hidden_act") and config.hidden_act == "xielu":
+                quantize_config.offload_to_disk = False
 
-        cls.before_model_load(cls, model_local_path=model_local_path, load_quantized_model=False)
-        from ..utils.hf import build_shell_model
+            # some models need convert moe-experts after model loaded, like GPTOSS and Llama4
+            # so offload_to_disk is not supported for them.
+            if not cls.support_offload_to_disk:
+                quantize_config.offload_to_disk = False
+                log.warn(f"{cls} doesn't support offload_to_disk, set quantize_config.offload_to_disk to False.")
 
-        # XIELUActivation will use some weights when activation init, so can't use init_empty_weights
-        if hasattr(config, "hidden_act") and config.hidden_act == "xielu":
-            quantize_config.offload_to_disk = False
+            if quantize_config.offload_to_disk:
+                shell_config = copy.deepcopy(config)
+                try:
+                    model = build_shell_model(cls.loader, config=shell_config, **model_init_kwargs_without_internal)
+                except RuntimeError as exc:
+                    if not _is_meta_shell_build_error(exc):
+                        raise
 
-        # some models need convert moe-experts after model loaded, like GPTOSS and Llama4
-        # so offload_to_disk is not supported for them.
-        if not cls.support_offload_to_disk:
-            quantize_config.offload_to_disk = False
-            log.warn(f"{cls} doesn't support offload_to_disk, set quantize_config.offload_to_disk to False.")
+                    log.warn(
+                        "Loader: meta-device shell build failed for `%s`; falling back to direct CPU load without turtle_model: %s",
+                        model_local_path,
+                        exc,
+                    )
+                    log.info("Loader: loading model directly to CPU (meta shell unsupported; turtle_model disabled)")
+                    fallback_init_kwargs = model_init_kwargs_without_internal.copy()
+                    fallback_init_kwargs.pop("device_map", None)
+                    fallback_init_kwargs["low_cpu_mem_usage"] = False
+                    model = _hf_loader_from_pretrained_with_dynamic_module_retry(
+                        cls.loader,
+                        model_local_path,
+                        config=config,
+                        **fallback_init_kwargs,
+                        **hf_gguf_load_kwargs,
+                    )
+                    if getattr(model, "config", None) is config:
+                        model.config = copy.deepcopy(config)
+                    _convert_model_with_defuser(cls, model, cleanup_original=False)
+                    model._model_init_kwargs = fallback_init_kwargs
+                    _maybe_print_module_tree(model=model)
+                    turtle_model = None
+                else:
+                    _convert_model_with_defuser(cls, model, cleanup_original=False)
+                    shell_model_init_kwargs = dict(model_init_kwargs_without_internal)
+                    shell_model_init_kwargs.update(hf_gguf_load_kwargs)
+                    model._model_init_kwargs = shell_model_init_kwargs
+                    _maybe_print_module_tree(model=model)
+                    turtle_model = LazyTurtle.maybe_create(
+                        model_local_path=model_local_path,
+                        config=model.config,
+                        model_init_kwargs=shell_model_init_kwargs,
+                        module_tree=copy.deepcopy(getattr(cls, "module_tree", None)),
+                        hf_conversion_map_reversed=copy.deepcopy(
+                            cls.resolve_hf_conversion_map_reversed(target_model=model)
+                        ),
+                        target_model=model,
+                    )
 
-        if quantize_config.offload_to_disk:
-            shell_config = copy.deepcopy(config)
-            try:
-                model = build_shell_model(cls.loader, config=shell_config, **model_init_kwargs_without_internal)
-            except RuntimeError as exc:
-                if not _is_meta_shell_build_error(exc):
-                    raise
+                    if turtle_model is None:
+                        raise RuntimeError(
+                            f"Loader: can't open model path `{model_local_path}` for offload_to_disk."
+                        )
 
-                log.warn(
-                    "Loader: meta-device shell build failed for `%s`; falling back to direct CPU load without turtle_model: %s",
-                    model_local_path,
-                    exc,
-                )
-                log.info("Loader: loading model directly to CPU (meta shell unsupported; turtle_model disabled)")
-                fallback_init_kwargs = model_init_kwargs_without_internal.copy()
-                fallback_init_kwargs.pop("device_map", None)
-                fallback_init_kwargs["low_cpu_mem_usage"] = False
+                    log.info(
+                        "Loader: using checkpoint-backed lazy turtle source for `%s`",
+                        model_local_path,
+                    )
+            else:
+                log.info("Loader: loading model directly to CPU (not using meta device or turtle_model)")
                 model = _hf_loader_from_pretrained_with_dynamic_module_retry(
                     cls.loader,
                     model_local_path,
                     config=config,
-                    **fallback_init_kwargs,
+                    **model_init_kwargs_without_internal,
                     **hf_gguf_load_kwargs,
                 )
                 if getattr(model, "config", None) is config:
                     model.config = copy.deepcopy(config)
                 _convert_model_with_defuser(cls, model, cleanup_original=False)
-                model._model_init_kwargs = fallback_init_kwargs
+                direct_model_init_kwargs = dict(model_init_kwargs_without_internal)
+                direct_model_init_kwargs.update(hf_gguf_load_kwargs)
+                model._model_init_kwargs = direct_model_init_kwargs
                 _maybe_print_module_tree(model=model)
+
                 turtle_model = None
-            else:
-                _convert_model_with_defuser(cls, model, cleanup_original=False)
-                shell_model_init_kwargs = dict(model_init_kwargs_without_internal)
-                shell_model_init_kwargs.update(hf_gguf_load_kwargs)
-                model._model_init_kwargs = shell_model_init_kwargs
-                _maybe_print_module_tree(model=model)
-                turtle_model = LazyTurtle.maybe_create(
-                    model_local_path=model_local_path,
-                    config=model.config,
-                    model_init_kwargs=shell_model_init_kwargs,
-                    module_tree=copy.deepcopy(getattr(cls, "module_tree", None)),
-                    hf_conversion_map_reversed=copy.deepcopy(
-                        cls.resolve_hf_conversion_map_reversed(target_model=model)
-                    ),
-                    target_model=model,
-                )
-
-                if turtle_model is None:
-                    raise RuntimeError(
-                        f"Loader: can't open model path `{model_local_path}` for offload_to_disk."
-                    )
-
-                log.info(
-                    "Loader: using checkpoint-backed lazy turtle source for `%s`",
-                    model_local_path,
-                )
-        else:
-            log.info("Loader: loading model directly to CPU (not using meta device or turtle_model)")
-            model = _hf_loader_from_pretrained_with_dynamic_module_retry(
-                cls.loader,
-                model_local_path,
-                config=config,
-                **model_init_kwargs_without_internal,
-                **hf_gguf_load_kwargs,
-            )
-            if getattr(model, "config", None) is config:
-                model.config = copy.deepcopy(config)
-            _convert_model_with_defuser(cls, model, cleanup_original=False)
-            direct_model_init_kwargs = dict(model_init_kwargs_without_internal)
-            direct_model_init_kwargs.update(hf_gguf_load_kwargs)
-            model._model_init_kwargs = direct_model_init_kwargs
-            _maybe_print_module_tree(model=model)
-
-            turtle_model = None
 
         model_config = model.config.to_dict()
         seq_len_keys = ["max_position_embeddings", "seq_length", "n_positions", "multimodal_max_length"]

--- a/gptqmodel/nn_modules/qlinear/__init__.py
+++ b/gptqmodel/nn_modules/qlinear/__init__.py
@@ -134,8 +134,9 @@ class BaseQuantLinear(nn.Module):
         self.online_partial_had = False
         self.had_dim = -1
         self.K = 1
-        # Not a registered buffer: accelerate's offload hooks cannot handle
-        # None-valued buffers, and `had_K` stays None unless rotation is used.
+        # Not a registered buffer while None: accelerate's offload hooks cannot
+        # handle None-valued buffers. `set_had_K` promotes it to a real buffer
+        # when rotation assigns a tensor.
         self.had_K = None
 
         validate_args = {
@@ -479,6 +480,27 @@ class BaseQuantLinear(nn.Module):
 
         self.clear_autotune()
         return super().train(mode)
+
+    def set_had_K(self, had_K: Optional[t.Tensor]) -> None:
+        """Assign the rotation Hadamard tensor, registering it as a buffer.
+
+        `had_K` starts life as a plain None attribute (None-valued buffers break
+        accelerate's offload hooks), so a real tensor must be promoted to a
+        registered buffer to follow module device/dtype moves.
+        """
+        if "had_K" in self._buffers:
+            if had_K is None:
+                del self._buffers["had_K"]
+                self.had_K = None
+            else:
+                self._buffers["had_K"] = had_K
+            return
+        if had_K is None:
+            self.had_K = None
+            return
+        if hasattr(self, "had_K"):
+            del self.had_K
+        self.register_buffer("had_K", had_K, persistent=False)
 
     def _apply_rotation_to_input(self, x: t.Tensor) -> t.Tensor:
         """Apply online Hadamard transform to the input for SpinQuant/QuaRot inference."""
@@ -1229,9 +1251,10 @@ class PackableQuantLinear(GPTQQuantLinear):
         # Each block writes a disjoint row range of the preallocated qweight and
         # only reads the shared W/scales/zeros tensors, so blocks can run on a
         # thread pool. Threads only help on free-threaded (GIL=0) Python builds;
-        # default to sequential unless an explicit worker count is requested.
-        if workers is not None and workers > 0:
-            workers_eff = max(1, min(workers, total_blocks))
+        # keep the sequential default and enable the pool only through an
+        # explicit GPTQMODEL_PACK_THREADS opt-in.
+        if env_threads:
+            workers_eff = max(1, min(pack_block_threads, total_blocks))
         else:
             workers_eff = 1
         if workers_eff == 1:

--- a/gptqmodel/nn_modules/qlinear/__init__.py
+++ b/gptqmodel/nn_modules/qlinear/__init__.py
@@ -22,6 +22,14 @@ from ...quantization import FORMAT, METHOD
 from ...utils.backend import BACKEND
 from ...utils.env import env_flag
 from ...utils.logger import setup_logger
+from ...utils.planar_packing import (
+    PLANAR_BITS,
+    PLANAR_FORMAT_BITS,
+    planar_pack_cols,
+    planar_pack_rows,
+    planar_unpack_cols,
+    planar_unpack_rows,
+)
 from ...utils.safe import THREADPOOLCTL
 
 
@@ -126,7 +134,9 @@ class BaseQuantLinear(nn.Module):
         self.online_partial_had = False
         self.had_dim = -1
         self.K = 1
-        self.register_buffer("had_K", None, persistent=False)
+        # Not a registered buffer: accelerate's offload hooks cannot handle
+        # None-valued buffers, and `had_K` stays None unless rotation is used.
+        self.had_K = None
 
         validate_args = {
             "bits": bits,
@@ -709,6 +719,7 @@ class GPTQQuantLinear(PackedGroupedQuantLinear):
                  register_buffers_out_features: int = None,
                  dtype: Optional[t.dtype] = None,
                  **kwargs):
+        format = kwargs.pop("format", None)
         super().__init__(
             bits=bits,
             group_size=group_size,
@@ -728,6 +739,28 @@ class GPTQQuantLinear(PackedGroupedQuantLinear):
             **kwargs,
         )
 
+        self.format = format
+        # Planar (split-plane, gptq_p) routing: 5/6/7-bit only exists planar;
+        # 3-bit is planar only under gptq_p. 2/4/8-bit planar words are
+        # bit-identical to the continuous layout, so they keep the fast paths.
+        if format == FORMAT.GPTQ_P and self.bits not in PLANAR_FORMAT_BITS:
+            raise ValueError(
+                f"format={FORMAT.GPTQ_P} supports bits {PLANAR_FORMAT_BITS}, got bits={self.bits}"
+            )
+        self.planar = self.bits in PLANAR_BITS or (format == FORMAT.GPTQ_P and self.bits == 3)
+
+        # Planar packing stores whole 32-code blocks; `_validate` covers the
+        # planar-only widths (5/6/7) but is format-blind, so format-dependent
+        # planar 3-bit must be checked here where the format is known.
+        # NotImplementedError keeps this recoverable for the kernel-selection
+        # loop, which treats it as "unsupported by this kernel".
+        if self.planar:
+            for dim_name, dim in (("in_features", self.in_features), ("out_features", self.out_features)):
+                if dim % 32 != 0:
+                    raise NotImplementedError(
+                        f"planar {self.bits}-bit requires `{dim_name}` divisible by 32, got {dim_name}={dim}."
+                    )
+
         # GPTQ v1/v2 conversions only apply to GPTQ-style qzero storage.
         self._qzeros_format = 1
 
@@ -737,6 +770,36 @@ class GPTQQuantLinear(PackedGroupedQuantLinear):
                 register_buffers_in_features=register_buffers_in_features,
                 register_buffers_out_features=register_buffers_out_features,
             )
+
+    @classmethod
+    def _validate(cls, bits: int=4, group_size: int=128, desc_act: bool=False, sym: bool=False, pack_dtype:t.dtype=None, dtype: Optional[t.dtype]=None, dynamic:Optional[dict]=None, in_features:int=None,
+                  out_features:int=None, device:Optional[DEVICE]=None, trainable:Optional[bool]=None, adapter:Optional[Adapter]=None) -> Tuple[bool, Optional[Exception]]:
+        ok, err = super()._validate(
+            bits=bits,
+            group_size=group_size,
+            desc_act=desc_act,
+            sym=sym,
+            pack_dtype=pack_dtype,
+            dtype=dtype,
+            dynamic=dynamic,
+            in_features=in_features,
+            out_features=out_features,
+            device=device,
+            trainable=trainable,
+            adapter=adapter,
+        )
+        if not ok:
+            return ok, err
+
+        # Planar-only widths pack whole 32-code blocks, so the packed
+        # dimensions must be 32-aligned regardless of the class-level
+        # SUPPORTS_*_FEATURES_DIVISIBLE_BY declarations.
+        if bits in PLANAR_BITS:
+            for dim_name, dim in (("in_features", in_features), ("out_features", out_features)):
+                if dim is not None and dim % 32 != 0:
+                    err = f"{cls}: planar {bits}-bit requires `{dim_name}` divisible by 32: actual {dim_name} = `{dim}`."
+                    return False, NotImplementedError(err)
+        return True, None
 
     def _register_gptq_buffers(
         self,
@@ -813,6 +876,11 @@ class PackableQuantLinear(GPTQQuantLinear):
 
         device = self._wf_device()
 
+        if self.planar:
+            # Planar dequantization unpacks bit planes directly and does not
+            # use wf shift buffers.
+            return
+
         if self.bits in [2, 4, 8]:
             wf = t.tensor(list(range(0, self.pack_dtype_bits, self.bits)), dtype=t.int32).unsqueeze(0).to(
                 device=device)
@@ -854,6 +922,11 @@ class PackableQuantLinear(GPTQQuantLinear):
         return buf
 
     def dequantize_weight(self, num_itr: int = 1):
+        if self.planar:
+            zeros = planar_unpack_cols(self.qzeros, self.bits).reshape(self.scales.shape)
+            weight = planar_unpack_rows(self.qweight, self.bits)
+            return self._dequantize_from_codes(weight, zeros, num_itr=num_itr)
+
         self._init_wf_unsqueeze_buffers()
         wf_zero = getattr(self, "wf_unsqueeze_zero", None)
         wf_neg_one = getattr(self, "wf_unsqueeze_neg_one", None)
@@ -900,6 +973,9 @@ class PackableQuantLinear(GPTQQuantLinear):
             weight = t.cat([weight[:, 0, :11], weight[:, 1, 1:12], weight[:, 2, 1:11]], dim=1)
         weight = weight.reshape(weight.shape[0] * weight.shape[1], weight.shape[2])
 
+        return self._dequantize_from_codes(weight, zeros, num_itr=num_itr)
+
+    def _dequantize_from_codes(self, weight: t.Tensor, zeros: t.Tensor, num_itr: int = 1):
         if num_itr == 1:
             weights = self.scales[self.g_idx.long()] * (weight - zeros[self.g_idx.long()])
         else:
@@ -983,6 +1059,8 @@ class PackableQuantLinear(GPTQQuantLinear):
         self.register_buffer("scales", scales.to(dtype=t.float16))
         if linear.bias is not None:
             self.register_buffer("bias", linear.bias.detach().to("cpu", dtype=t.float16))
+        elif not hasattr(self, "bias"):
+            self.bias = None
 
         # ---------- constants ----------
         bits = int(self.bits)  # 2,3,4,8
@@ -1008,6 +1086,8 @@ class PackableQuantLinear(GPTQQuantLinear):
                     env_threads,
                     pack_block_threads,
                 )
+
+        planar = self.planar
 
         if not disable_ext and bits in (2, 4, 8):
             try:
@@ -1036,8 +1116,10 @@ class PackableQuantLinear(GPTQQuantLinear):
         if bits in (2, 4, 8):
             pack_factor = word_bits // bits  # 16, 8, 4 respectively
             # If the instance carries a different pack_factor, ignore it for safety.
-        elif bits == 3:
+        elif bits == 3 and not planar:
             pack_factor = None  # sentinel: use the 10-1-10-1-10 scheme
+        elif planar:
+            pack_factor = None  # sentinel: use split-plane packing
         else:
             raise NotImplementedError(f"Unsupported bits={bits}")
 
@@ -1046,8 +1128,8 @@ class PackableQuantLinear(GPTQQuantLinear):
         if OUT_DTYPE != t.int32:
             raise ValueError("pack_block() expects self.pack_dtype == torch.int32 for 32-bit words.")
 
-        # rows = (in // 32) * ({2,4,8} -> bits rows ; 3 -> 3 rows)
-        rows_per_group = (bits if bits != 3 else 3)
+        # rows = (in // 32) * bits for every supported layout
+        rows_per_group = bits
         qweight_rows = (in_features // word_bits) * rows_per_group
         qweight = t.empty((qweight_rows, out_features), dtype=OUT_DTYPE, device="cpu")
 
@@ -1125,11 +1207,13 @@ class PackableQuantLinear(GPTQQuantLinear):
             base_group = (i0 // word_bits)
             for g in range(groups32):
                 sub = int_block[g * word_bits:(g + 1) * word_bits]  # [32, out] int32
-                dst_rows = (base_group + g) * (bits if bits != 3 else 3)
+                dst_rows = (base_group + g) * rows_per_group
                 if bits in (2, 4, 8):
                     _pack_rows_2_4_8(sub, qweight, dst_rows)
-                elif bits == 3:
+                elif bits == 3 and not planar:
                     _pack_rows_3(sub, qweight, dst_rows)
+                elif planar:
+                    qweight[dst_rows:dst_rows + bits] = planar_pack_rows(sub, bits)
                 else:
                     raise NotImplementedError(f"Unsupported bits={bits}")
 
@@ -1141,8 +1225,15 @@ class PackableQuantLinear(GPTQQuantLinear):
         ranges = [(i0, min(i0 + block_in, in_features)) for i0 in starts]
         len(ranges)
 
-        # TODO FIX ME...threads safety issue with threaded block work
-        workers_eff = 1 # max(1, min(workers, total_blocks))
+        total_blocks = len(ranges)
+        # Each block writes a disjoint row range of the preallocated qweight and
+        # only reads the shared W/scales/zeros tensors, so blocks can run on a
+        # thread pool. Threads only help on free-threaded (GIL=0) Python builds;
+        # default to sequential unless an explicit worker count is requested.
+        if workers is not None and workers > 0:
+            workers_eff = max(1, min(workers, total_blocks))
+        else:
+            workers_eff = 1
         if workers_eff == 1:
             for i0, i1 in ranges:
                 _process_block(i0, i1)
@@ -1165,7 +1256,7 @@ class PackableQuantLinear(GPTQQuantLinear):
                 base = col * pf
                 for j in range(pf):
                     qzeros_np[:, col] |= zeros_np[:, base + j] << (bits * j)
-        elif bits == 3:
+        elif bits == 3 and not planar:
             i = 0
             col = 0
             while col < qzeros_np.shape[1]:
@@ -1187,6 +1278,12 @@ class PackableQuantLinear(GPTQQuantLinear):
                     qzeros_np[:, col] |= zeros_np[:, j] << (3 * (j - i) + 2)
                 i += 10
                 col += 1
+        elif planar:
+            qzeros_np = (
+                planar_pack_cols(zeros.to(t.int64), bits)
+                .numpy()
+                .astype(self.pack_np_math_dtype, copy=False)
+            )
         else:
             raise NotImplementedError(f"Unsupported bits={bits}")
 
@@ -1264,12 +1361,12 @@ class PackableQuantLinear(GPTQQuantLinear):
                 .view(1, pack_factor, 1)
                 * bits
             )
-        elif bits == 3:
+        elif bits == 3 or self.planar:
             shifts_pf64 = None
         else:
             raise NotImplementedError(f"Unsupported bits={bits}")
 
-        rows_per_group = (bits if bits != 3 else 3)
+        rows_per_group = bits
         qweight_dev = t.empty(
             (in_features // word_bits * rows_per_group, out_features),
             dtype=self.pack_dtype,
@@ -1326,8 +1423,12 @@ class PackableQuantLinear(GPTQQuantLinear):
                 dst_rows = (base_group + g) * rows_per_group
                 if bits in (2, 4, 8):
                     _pack_rows_2_4_8(sub, qweight_dev, dst_rows)
-                else:
+                elif bits == 3 and not self.planar:
                     _pack_rows_3(sub, qweight_dev, dst_rows)
+                elif self.planar:
+                    qweight_dev[dst_rows:dst_rows + bits] = planar_pack_rows(sub, bits).to(self.pack_dtype)
+                else:
+                    raise NotImplementedError(f"Unsupported bits={bits}")
 
         zeros_int = zeros_dev.to(dtype=t.int64)
         if bits in (2, 4, 8):
@@ -1345,7 +1446,7 @@ class PackableQuantLinear(GPTQQuantLinear):
             )
             packed = (zeros_view << shifts).sum(dim=-1, dtype=t.int64) & mask_tensor
             qzeros_dev = packed.to(dtype=self.pack_dtype)
-        elif bits == 3:
+        elif bits == 3 and not self.planar:
             groups = zeros_int.shape[1] // word_bits
             qzeros_chunks: List[t.Tensor] = []
             for g in range(groups):
@@ -1353,6 +1454,8 @@ class PackableQuantLinear(GPTQQuantLinear):
                 packed = _pack_rows_3_values(block.T).transpose(0, 1)
                 qzeros_chunks.append(packed.to(dtype=self.pack_dtype))
             qzeros_dev = t.cat(qzeros_chunks, dim=1)
+        elif self.planar:
+            qzeros_dev = planar_pack_cols(zeros_int, bits).to(dtype=self.pack_dtype)
         else:
             raise NotImplementedError(f"Unsupported bits={bits}")
 
@@ -1389,6 +1492,8 @@ class PackableQuantLinear(GPTQQuantLinear):
                 # TODO why clone?
                 # self.bias = linear.bias.clone().to(dtype=t.float16)
                 self.register_buffer("bias", linear.bias.to(dtype=t.float16))
+            elif not hasattr(self, "bias"):
+                self.bias = None
 
             int_weight = t.round((W + scale_zeros[self.g_idx].T) / scales[self.g_idx].T)
             int_weight.clamp_(0, self.maxq)
@@ -1401,7 +1506,7 @@ class PackableQuantLinear(GPTQQuantLinear):
                 for row in range(qweight.shape[0]):
                     for j in range(self.pack_factor):
                         qweight[row] |= int_weight[row * self.pack_factor + j] << (self.bits * j)
-            elif self.bits == 3:
+            elif self.bits == 3 and not self.planar:
                 i = 0
                 row = 0
                 while row < qweight.shape[0]:
@@ -1423,6 +1528,18 @@ class PackableQuantLinear(GPTQQuantLinear):
                         qweight[row] |= int_weight[j] << (3 * (j - i) + 2)
                     i += 10
                     row += 1
+            elif self.planar:
+                qweight = (
+                    planar_pack_rows(
+                        t.from_numpy(int_weight.astype(np.int64)),
+                        self.bits,
+                        pack_dtype=self.pack_dtype,
+                    )
+                    .numpy()
+                    .astype(self.pack_np_math_dtype, copy=False)
+                )
+            else:
+                raise NotImplementedError(f"Unsupported bits={self.bits}")
 
             # self.qweight = t.from_numpy(qweight.astype(self.pack_np_dtype))
             self.register_buffer("qweight", t.from_numpy(qweight.astype(self.pack_np_dtype)))
@@ -1433,7 +1550,7 @@ class PackableQuantLinear(GPTQQuantLinear):
                 for col in range(qzeros.shape[1]):
                     for j in range(self.pack_factor):
                         qzeros[:, col] |= zeros[:, col * self.pack_factor + j] << (self.bits * j)
-            elif self.bits == 3:
+            elif self.bits == 3 and not self.planar:
                 i = 0
                 col = 0
                 while col < qzeros.shape[1]:
@@ -1455,6 +1572,18 @@ class PackableQuantLinear(GPTQQuantLinear):
                         qzeros[:, col] |= zeros[:, j] << (3 * (j - i) + 2)
                     i += 10
                     col += 1
+            elif self.planar:
+                qzeros = (
+                    planar_pack_cols(
+                        t.from_numpy(zeros.astype(np.int64)),
+                        self.bits,
+                        pack_dtype=self.pack_dtype,
+                    )
+                    .numpy()
+                    .astype(self.pack_np_math_dtype, copy=False)
+                )
+            else:
+                raise NotImplementedError(f"Unsupported bits={self.bits}")
 
             # self.qzeros = t.from_numpy(qzeros.astype(self.pack_np_dtype))
             self.register_buffer("qzeros", t.from_numpy(qzeros.astype(self.pack_np_dtype)))

--- a/gptqmodel/nn_modules/qlinear/__init__.py
+++ b/gptqmodel/nn_modules/qlinear/__init__.py
@@ -896,12 +896,12 @@ class PackableQuantLinear(GPTQQuantLinear):
         ):
             return
 
-        device = self._wf_device()
-
         if self.planar:
             # Planar dequantization unpacks bit planes directly and does not
             # use wf shift buffers.
             return
+
+        device = self._wf_device()
 
         if self.bits in [2, 4, 8]:
             wf = t.tensor(list(range(0, self.pack_dtype_bits, self.bits)), dtype=t.int32).unsqueeze(0).to(
@@ -1251,12 +1251,19 @@ class PackableQuantLinear(GPTQQuantLinear):
         # Each block writes a disjoint row range of the preallocated qweight and
         # only reads the shared W/scales/zeros tensors, so blocks can run on a
         # thread pool. Threads only help on free-threaded (GIL=0) Python builds;
-        # keep the sequential default and enable the pool only through an
-        # explicit GPTQMODEL_PACK_THREADS opt-in.
-        if env_threads:
-            workers_eff = max(1, min(pack_block_threads, total_blocks))
-        else:
-            workers_eff = 1
+        # keep the sequential default and enable the pool only through the
+        # dedicated GPTQMODEL_PACK_PY_THREADS opt-in (GPTQMODEL_PACK_THREADS
+        # keeps its existing meaning of sizing the native extension only).
+        py_threads_env = os.getenv("GPTQMODEL_PACK_PY_THREADS")
+        workers_eff = 1
+        if py_threads_env:
+            try:
+                workers_eff = max(1, min(int(py_threads_env), total_blocks))
+            except ValueError:
+                log.warning(
+                    "pack_block: invalid GPTQMODEL_PACK_PY_THREADS `%s`; using sequential packing.",
+                    py_threads_env,
+                )
         if workers_eff == 1:
             for i0, i1 in ranges:
                 _process_block(i0, i1)

--- a/gptqmodel/nn_modules/qlinear/__init__.py
+++ b/gptqmodel/nn_modules/qlinear/__init__.py
@@ -740,8 +740,8 @@ class GPTQQuantLinear(PackedGroupedQuantLinear):
                  register_buffers_in_features: int = None,
                  register_buffers_out_features: int = None,
                  dtype: Optional[t.dtype] = None,
+                 format: Optional[FORMAT] = None,
                  **kwargs):
-        format = kwargs.pop("format", None)
         super().__init__(
             bits=bits,
             group_size=group_size,

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -7,6 +7,7 @@
 import math
 import os
 from collections.abc import Iterable
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -148,6 +149,7 @@ class TorchLinear(PackableQuantLinear):
         pack_dtype: torch.dtype = torch.int32,
         adapter: Adapter = None,
         register_buffers: bool = True,
+        format: Optional[FORMAT] = None,
         **kwargs,
     ):
         super().__init__(
@@ -163,6 +165,7 @@ class TorchLinear(PackableQuantLinear):
             adapter=adapter,
             register_buffers=register_buffers,
             enable_wf_unsqueeze=kwargs.pop("enable_wf_unsqueeze", True),
+            format=format,
             **kwargs)
 
         self.dequant_dtype = torch.int16 if self.bits == 8 else torch.int8

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -113,8 +113,8 @@ class _LinearWeightMetadata:
 class TorchLinear(PackableQuantLinear):
     SUPPORTS_BACKENDS = [BACKEND.GPTQ_TORCH]
     SUPPORTS_METHODS = [METHOD.GPTQ]
-    SUPPORTS_FORMATS = {FORMAT.GPTQ: 20, FORMAT.GPTQ_V2: 20}
-    SUPPORTS_BITS = [2, 3, 4, 8]
+    SUPPORTS_FORMATS = {FORMAT.GPTQ: 20, FORMAT.GPTQ_V2: 20, FORMAT.GPTQ_P: 20}
+    SUPPORTS_BITS = [2, 3, 4, 5, 6, 7, 8]
     SUPPORTS_GROUP_SIZE = [-1, 16, 32, 64, 128, 256, 512, 1024]
     SUPPORTS_DESC_ACT = [True, False]
     SUPPORTS_SYM = [True, False]
@@ -546,6 +546,10 @@ class TorchLinear(PackableQuantLinear):
     def _should_use_streaming(self, x: torch.Tensor) -> bool:
         if not self._streaming_enabled:
             return False
+        # Streaming decode assumes the 2/4/8-bit wf shift-buffer layout; 3-bit
+        # and planar 5/6/7-bit widths use the eager dequant path instead.
+        if self.bits not in (2, 4, 8):
+            return False
         if x.device.type != "cuda":
             return False
         if not HAS_CUDA:
@@ -665,6 +669,9 @@ class TorchLinear(PackableQuantLinear):
             return False
         if self.bits not in (2, 3, 4, 8):
             return False
+        # Planar 3-bit words do not match the continuous Triton decode layout.
+        if self.planar:
+            return False
         if not (self.qweight.is_contiguous() and self.qzeros.is_contiguous() and self.scales.is_contiguous()):
             return False
         # g_idx is stored as int32 tensor; ensure it resides on the same device.
@@ -688,6 +695,7 @@ class TorchLinear(PackableQuantLinear):
         return weights
 
     def _dequantize_weight_cached_248(self, num_itr: int = 1) -> torch.Tensor:
+        self._init_wf_unsqueeze_buffers()
         zeros = self._stream_decode_qzeros()
         g_idx_long = self._stream_g_idx_long(target_device=self.qweight.device)
         self._maybe_offload_g_idx_to_cpu()
@@ -755,12 +763,12 @@ class TorchQuantEmbeddings(TorchLinear):
 
     SUPPORTS_BACKENDS = [BACKEND.GPTQ_TORCH]
     SUPPORTS_METHODS = [METHOD.GPTQ]
-    SUPPORTS_FORMATS = {FORMAT.GPTQ: 20, FORMAT.GPTQ_V2: 20}
+    SUPPORTS_FORMATS = {FORMAT.GPTQ: 20, FORMAT.GPTQ_V2: 20, FORMAT.GPTQ_P: 20}
     # Embeddings are selected by module role in create_quant_module(), and must
     # not be discovered as a general backend: their forward contract accepts
     # integer token IDs, not hidden states.
     SUPPORTS_BACKEND_SELECTION = False
-    SUPPORTS_BITS = [2, 3, 4, 8]
+    SUPPORTS_BITS = [2, 3, 4, 5, 6, 7, 8]
     SUPPORTS_GROUP_SIZE = [-1, 16, 32, 64, 128, 256, 512, 1024]
     SUPPORTS_DESC_ACT = [True, False]
     SUPPORTS_SYM = [True, False]

--- a/gptqmodel/quantization/config.py
+++ b/gptqmodel/quantization/config.py
@@ -109,6 +109,9 @@ class FORMAT(str, Enum):
     GPTQ = "gptq"
     # v2 format fixed sym = False quantization
     GPTQ_V2 = "gptq_v2"
+    # planar (split-plane, word-aligned high-plane) layout; distinct from the
+    # continuous gptq/gptq_v2 layouts. Zeros use v2 semantics on disk.
+    GPTQ_P = "gptq_p"
     GGUF = "gguf"
     FP8 = "fp8"
     BITSANDBYTES = "bitsandbytes"
@@ -614,7 +617,7 @@ def _normalize_quant_bits(bits: Union[int, float, str, GGUFBits], format_value: 
         raise ValueError(f"QuantizeConfig: unsupported bits specification `{bits}`.")
 
     normalized_width = normalized.bits if isinstance(normalized, GGUFBits) else normalized
-    valid_bit_widths = [1, 2, 3, 4, 5, 6, 8]
+    valid_bit_widths = [1, 2, 3, 4, 5, 6, 7, 8]
     if normalized_width not in valid_bit_widths:
         raise ValueError(f"QuantizeConfig: `bits` must resolve to one of `{valid_bit_widths}`.")
 
@@ -1398,6 +1401,7 @@ QUANT_METHOD_FORMAT_MAPPING = {
     METHOD.GPTQ: {
         FORMAT.GPTQ,
         FORMAT.GPTQ_V2,
+        FORMAT.GPTQ_P,
         FORMAT.MARLIN,
         FORMAT.BITBLAS,
     },
@@ -1432,6 +1436,7 @@ QUANT_METHOD_FORMAT_MAPPING = {
 GPTQ_EXPORT_FORMATS: Tuple[FORMAT, ...] = (
     FORMAT.GPTQ,
     FORMAT.GPTQ_V2,
+    FORMAT.GPTQ_P,
     FORMAT.MARLIN,
     FORMAT.BITBLAS,
 )
@@ -1465,6 +1470,7 @@ EXL3_EXPORT_FORMATS: Tuple[FORMAT, ...] = (
 RTN_EXPORT_FORMATS: Tuple[FORMAT, ...] = (
     FORMAT.GPTQ,
     FORMAT.GPTQ_V2,
+    FORMAT.GPTQ_P,
     FORMAT.GEMM,
     FORMAT.GEMV,
     FORMAT.GEMV_FAST,
@@ -1477,6 +1483,7 @@ GGUF_EXPORT_FORMATS: Tuple[FORMAT, ...] = (
 _UNAMBIGUOUS_EXPORT_METHOD_BY_FORMAT = {
     FORMAT.GPTQ: METHOD.GPTQ,
     FORMAT.GPTQ_V2: METHOD.GPTQ,
+    FORMAT.GPTQ_P: METHOD.GPTQ,
     FORMAT.FP8: METHOD.FP8,
     FORMAT.BITSANDBYTES: METHOD.BITSANDBYTES,
     FORMAT.EXL3: METHOD.EXL3,
@@ -2427,7 +2434,7 @@ def _normalize_quantize_config_constructor_kwargs(kwargs: Dict[str, Any]) -> Dic
 
 @dataclass
 class BaseQuantizeConfig(metaclass=QuantizeConfigMeta):
-    bits: Union[int, str, GGUFBits] = field(default=4, metadata={"choices": [2, 3, 4, 5, 6, 8]})
+    bits: Union[int, str, GGUFBits] = field(default=4, metadata={"choices": [2, 3, 4, 5, 6, 7, 8]})
 
     # allow dynamic bitsize per layer, if None or some layer not set, use bits
     dynamic: Optional[Dict[str, Dict[str, Union[int, str, bool, GGUFBits]]]] = field(default=None)
@@ -2646,6 +2653,28 @@ class BaseQuantizeConfig(metaclass=QuantizeConfigMeta):
         valid_bit_widths = fields_info[0].metadata["choices"]
         if quant_bits_width(self.bits) not in valid_bit_widths:
             raise ValueError(f"QuantizeConfig: `bits` must be in the set of `{fields_info[0].metadata['choices']}`.")
+
+        # 5/6/7-bit GPTQ only exists in the planar (split-plane) layout, which is
+        # a distinct checkpoint format from the continuous gptq/gptq_v2 layouts.
+        # Per-layer dynamic bit overrides count too: one 5/6/7-bit layer makes
+        # the checkpoint planar.
+        planar_only_bits = quant_bits_width(self.bits) in (5, 6, 7)
+        if not planar_only_bits and self.dynamic is not None:
+            planar_only_bits = any(
+                isinstance(layer_dict, dict) and quant_bits_width(layer_dict.get("bits", self.bits)) in (5, 6, 7)
+                for layer, layer_dict in self.dynamic.items()
+                if not layer.startswith('-')
+            )
+        if (
+            self.method == METHOD.GPTQ
+            and format_family in (FORMAT.GPTQ, FORMAT.GPTQ_V2)
+            and planar_only_bits
+        ):
+            log.info(
+                f"QuantizeConfig: 5/6/7-bit layers use the planar layout; auto fix `format` to `{FORMAT.GPTQ_P}`."
+            )
+            self.format = FORMAT.GPTQ_P
+            format_family = self._resolve_checkpoint_format()
 
         if self.dynamic is not None:
             self.dynamic = {

--- a/gptqmodel/quantization/protocol.py
+++ b/gptqmodel/quantization/protocol.py
@@ -492,6 +492,7 @@ def _resolve_export_format(method: METHOD, export: Optional[ExportSpec]) -> FORM
         mapping = {
             FORMAT.GPTQ.value: FORMAT.GPTQ,
             FORMAT.GPTQ_V2.value: FORMAT.GPTQ_V2,
+            FORMAT.GPTQ_P.value: FORMAT.GPTQ_P,
             FORMAT.MARLIN.value: FORMAT.MARLIN,
             FORMAT.BITBLAS.value: FORMAT.BITBLAS,
         }

--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -41,7 +41,7 @@ from ..models._const import (
     EXPERT_INDEX_PLACEHOLDER,
     SUPPORTS_MODULE_TYPES,
 )
-from ..nn_modules.qlinear import BaseQuantLinear
+from ..nn_modules.qlinear import BaseQuantLinear, GPTQQuantLinear
 from ..nn_modules.qlinear.exllamav2 import ExllamaV2Linear
 from ..nn_modules.qlinear.exllamav2_awq import AwqExllamaV2Linear
 from ..nn_modules.qlinear.torch import TorchQuantEmbeddings
@@ -604,6 +604,11 @@ def create_quant_module(
     validate_bits = quant_bits_width(tmp_bits)
     constructor_bits = tmp_bits if getattr(linear_cls, "QUANT_TYPE", None) == "gguf" else validate_bits
 
+    # GPTQ modules need the checkpoint format to select between the continuous
+    # (gptq/gptq_v2) and planar (gptq_p) packed layouts.
+    if issubclass(linear_cls, GPTQQuantLinear) and format in (FORMAT.GPTQ, FORMAT.GPTQ_V2, FORMAT.GPTQ_P):
+        tmp_init_kwargs.setdefault("format", format)
+
     # when loading a quantized model, device is the target passed through the GPT-QModel load path
     # check in_features and out_features validate
     _, err = linear_cls.validate(
@@ -764,7 +769,9 @@ def convert_gptq_v1_to_v2_format_module(module: BaseQuantLinear, bits: int, pack
             # GPTQ INT3 spills some zero-point bits across adjacent packed words.
             # Reuse the logical field shift so module conversion matches the
             # safetensor dequant path and the canonical INT3 pack layout.
-            module.qzeros.data.copy_(_correct_gptq_v1_qzeros(module.qzeros.data, bits))
+            module.qzeros.data.copy_(
+                _correct_gptq_v1_qzeros(module.qzeros.data, bits, planar=getattr(module, "planar", False))
+            )
         else:
             # Only int32 packing words are used for GPTQ INT3 in actual checkpoints.
             # Keep the legacy constant-offset path for synthetic smaller word sizes.
@@ -821,8 +828,16 @@ def convert_gptq_v1_to_v2_format_module(module: BaseQuantLinear, bits: int, pack
             module.qzeros.data += 0b0000000100000001
         elif pack_dtype == torch.int8:
             module.qzeros.data += 0b00000001
+    elif bits in (5, 6, 7):
+        if pack_dtype != torch.int32:
+            raise NotImplementedError(
+                f"Planar {bits}-bit GPTQ only supports 32-bit packing words, got pack_dtype={pack_dtype}."
+            )
+        # Planar layouts spread each zero-point across bit planes, so shift the
+        # decoded logical values instead of adding a packed-word constant.
+        module.qzeros.data.copy_(_correct_gptq_v1_qzeros(module.qzeros.data, bits, planar=True))
     else:
-        raise NotImplementedError("Only 2,3,4,8 bits are supported.")
+        raise NotImplementedError("Only 2,3,4,5,6,7,8 bits are supported.")
 
     # change format id
     module.qzero_format(format=2)
@@ -897,7 +912,7 @@ def convert_gptq_v2_to_v1_format_module(
         if pack_dtype == torch.int32:
             # Keep INT3 export symmetric with the load-side logical correction.
             module.qzeros.data.copy_(
-                _revert_gptq_v1_qzeros_correction(module.qzeros.data, bits)
+                _revert_gptq_v1_qzeros_correction(module.qzeros.data, bits, planar=getattr(module, "planar", False))
             )
         else:
             module.qzeros.data[:, range(0, module.qzeros.data.shape[1], 3)] -= (
@@ -913,8 +928,16 @@ def convert_gptq_v2_to_v1_format_module(
         module.qzeros.data -= 0b00010001000100010001000100010001
     elif bits == 8:
         module.qzeros.data -= 0b00000001000000010000000100000001
+    elif bits in (5, 6, 7):
+        if pack_dtype != torch.int32:
+            raise NotImplementedError(
+                f"Planar {bits}-bit GPTQ only supports 32-bit packing words, got pack_dtype={pack_dtype}."
+            )
+        module.qzeros.data.copy_(
+            _revert_gptq_v1_qzeros_correction(module.qzeros.data, bits, planar=True)
+        )
     else:
-        raise NotImplementedError("Only 2,3,4,8 bits are supported.")
+        raise NotImplementedError("Only 2,3,4,5,6,7,8 bits are supported.")
 
     module.qzero_format(format=1)
 

--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -606,7 +606,7 @@ def create_quant_module(
 
     # GPTQ modules need the checkpoint format to select between the continuous
     # (gptq/gptq_v2) and planar (gptq_p) packed layouts.
-    if issubclass(linear_cls, GPTQQuantLinear) and format in (FORMAT.GPTQ, FORMAT.GPTQ_V2, FORMAT.GPTQ_P):
+    if issubclass(linear_cls, GPTQQuantLinear):
         tmp_init_kwargs.setdefault("format", format)
 
     # when loading a quantized model, device is the target passed through the GPT-QModel load path
@@ -1301,6 +1301,25 @@ def gptqmodel_post_init(model, use_act_order: bool, quantize_config: QuantizeCon
 
         # have persistent buffers, otherwise we will get OOM
         model.device_tensors = device_tensors
+
+    # The continuous and planar (gptq_p) 3-bit word layouts are not
+    # interchangeable, and a 3-bit module is only planar when its constructor
+    # received `format=gptq_p`. Fail loudly if any construction site dropped
+    # the format instead of silently decoding the wrong layout.
+    if quantize_config is not None:
+        expect_planar3 = resolve_quant_format(quantize_config.format, quantize_config.method) == FORMAT.GPTQ_P
+        for name, submodule in model.named_modules():
+            if (
+                isinstance(submodule, GPTQQuantLinear)
+                and submodule.bits == 3
+                and submodule.planar != expect_planar3
+            ):
+                raise ValueError(
+                    f"`{name}`: 3-bit quant module was constructed with planar={submodule.planar} "
+                    f"but the checkpoint format is `{quantize_config.format}`; the continuous and "
+                    f"planar 3-bit layouts are not interchangeable. Pass `format=` when "
+                    "constructing the module."
+                )
 
     # The buffers need to have been initialized first before calling make_q4.
     for _, submodule in model.named_modules():

--- a/gptqmodel/utils/model_dequant.py
+++ b/gptqmodel/utils/model_dequant.py
@@ -27,6 +27,12 @@ from ..quantization.dtype import (
     dequantize_fp8,
 )
 from ..utils.logger import setup_logger
+from ..utils.planar_packing import (
+    PLANAR_BITS,
+    planar_pack_cols,
+    planar_unpack_cols,
+    planar_unpack_rows,
+)
 
 
 LOG = logging.getLogger(__name__)
@@ -714,9 +720,11 @@ def detect_format(model_path: Path, config: dict) -> str:
     raise ValueError("Unable to detect quantization format for model")
 
 
-def unpack_cols(packed: torch.Tensor, bits: int) -> torch.Tensor:
-    if bits == 3:
+def unpack_cols(packed: torch.Tensor, bits: int, *, planar: bool = False) -> torch.Tensor:
+    if bits == 3 and not planar:
         return _unpack_cols_3bit(packed)
+    if bits in PLANAR_BITS or (planar and bits == 3):
+        return planar_unpack_cols(packed, bits)
 
     pack_bits = packed.element_size() * 8
     pack_factor = pack_bits // bits
@@ -729,9 +737,11 @@ def unpack_cols(packed: torch.Tensor, bits: int) -> torch.Tensor:
     return result
 
 
-def pack_cols(values: torch.Tensor, bits: int, *, pack_dtype: torch.dtype) -> torch.Tensor:
-    if bits == 3:
+def pack_cols(values: torch.Tensor, bits: int, *, pack_dtype: torch.dtype, planar: bool = False) -> torch.Tensor:
+    if bits == 3 and not planar:
         return _pack_cols_3bit(values, pack_dtype=pack_dtype)
+    if bits in PLANAR_BITS or (planar and bits == 3):
+        return planar_pack_cols(values, bits, pack_dtype=pack_dtype)
 
     pack_bits = torch.empty((), dtype=pack_dtype).element_size() * 8
     pack_factor = pack_bits // bits
@@ -752,9 +762,11 @@ def pack_cols(values: torch.Tensor, bits: int, *, pack_dtype: torch.dtype) -> to
     return packed
 
 
-def unpack_rows(packed: torch.Tensor, bits: int) -> torch.Tensor:
-    if bits == 3:
+def unpack_rows(packed: torch.Tensor, bits: int, *, planar: bool = False) -> torch.Tensor:
+    if bits == 3 and not planar:
         return _unpack_rows_3bit(packed)
+    if bits in PLANAR_BITS or (planar and bits == 3):
+        return planar_unpack_rows(packed, bits)
 
     pack_bits = packed.element_size() * 8
     pack_factor = pack_bits // bits
@@ -885,22 +897,22 @@ def _uses_gptq_v1_qzeros(config: dict) -> bool:
     return checkpoint_format in {"gptq", "gemm"}
 
 
-def _shift_gptq_qzeros(qzeros: torch.Tensor, bits: int, *, delta: int) -> torch.Tensor:
+def _shift_gptq_qzeros(qzeros: torch.Tensor, bits: int, *, delta: int, planar: bool = False) -> torch.Tensor:
     # GPTQ v1 stores qzeros with a per-field -1 offset. For 3-bit checkpoints,
     # some logical values straddle adjacent packed words, so a packed-word add/sub
     # is not equivalent to shifting each decoded zero-point. Decode the fields,
     # shift them in logical space, then repack into the original storage dtype.
-    zeros = unpack_cols(qzeros, bits)
+    zeros = unpack_cols(qzeros, bits, planar=planar)
     shifted = (zeros + delta) & ((1 << bits) - 1)
-    return pack_cols(shifted, bits, pack_dtype=qzeros.dtype)
+    return pack_cols(shifted, bits, pack_dtype=qzeros.dtype, planar=planar)
 
 
-def _correct_gptq_v1_qzeros(qzeros: torch.Tensor, bits: int) -> torch.Tensor:
-    return _shift_gptq_qzeros(qzeros, bits, delta=1)
+def _correct_gptq_v1_qzeros(qzeros: torch.Tensor, bits: int, *, planar: bool = False) -> torch.Tensor:
+    return _shift_gptq_qzeros(qzeros, bits, delta=1, planar=planar)
 
 
-def _revert_gptq_v1_qzeros_correction(qzeros: torch.Tensor, bits: int) -> torch.Tensor:
-    return _shift_gptq_qzeros(qzeros, bits, delta=-1)
+def _revert_gptq_v1_qzeros_correction(qzeros: torch.Tensor, bits: int, *, planar: bool = False) -> torch.Tensor:
+    return _shift_gptq_qzeros(qzeros, bits, delta=-1, planar=planar)
 
 
 def convert_fp8_shard(
@@ -1355,10 +1367,16 @@ def convert_gptq_file(
         g_idx = buf["g_idx"].to(torch.long)
 
         bits = config.get("bits", 4)
-        if _uses_gptq_v1_qzeros(config):
-            qzeros = _correct_gptq_v1_qzeros(qzeros, bits)
-        weight_int = unpack_rows(qweight, bits)
-        zeros = unpack_cols(qzeros, bits)
+        format_value = str(
+            config.get("checkpoint_format") or config.get("format") or ""
+        ).strip().lower()
+        # 5/6/7-bit only exists planar with v2 zero semantics, so the format
+        # label is not trusted for those widths (it may be missing entirely).
+        planar = format_value == "gptq_p" or bits in PLANAR_BITS
+        if _uses_gptq_v1_qzeros(config) and not planar:
+            qzeros = _correct_gptq_v1_qzeros(qzeros, bits, planar=planar)
+        weight_int = unpack_rows(qweight, bits, planar=planar)
+        zeros = unpack_cols(qzeros, bits, planar=planar)
 
         scales_full = scales.to(torch.float32)[g_idx]
         zeros_full = zeros.to(torch.float32)[g_idx]

--- a/gptqmodel/utils/planar_packing.py
+++ b/gptqmodel/utils/planar_packing.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+"""Split-plane (planar) bit packing for the GPTQ `gptq_p` checkpoint format.
+
+A logical `b`-bit code is stored as word-aligned bit planes whose widths each
+divide 32, so every packed word contains whole fields and no code straddles a
+word boundary (unlike the continuous 3-bit layout):
+
+- 2-bit = single 2-bit plane (bit-identical to the continuous 2-bit layout)
+- 3-bit = 2-bit low plane + 1-bit high plane
+- 4-bit = single 4-bit plane (bit-identical to the continuous 4-bit layout)
+- 5-bit = 4-bit low plane + 1-bit high plane
+- 6-bit = 4-bit low plane + 2-bit high plane
+- 7-bit = 4-bit low plane + 2-bit mid plane + 1-bit top plane
+- 8-bit = single 8-bit plane (bit-identical to the continuous 8-bit layout)
+
+For every 32 consecutive logical codes the planes are stored adjacently as
+`bits` int32 words: first the low-plane words, then the higher planes. Within a
+plane of width `w`, word `i` holds codes `[i*(32//w), (i+1)*(32//w))` at shifts
+`w*j`, matching the row-major `[bits, pack_factor]` convention of the 2/4/8-bit
+packers. The layout fills exactly `ceil(n * bits / 32)` words, so qweight and
+qzeros keep their standard GPTQ shapes.
+"""
+
+from typing import Tuple
+
+import torch
+
+
+# Bit widths that have no continuous layout and are always stored planar.
+PLANAR_BITS: Tuple[int, ...] = (5, 6, 7)
+# All bit widths the planar (gptq_p) layout supports.
+PLANAR_FORMAT_BITS: Tuple[int, ...] = (2, 3, 4, 5, 6, 7, 8)
+
+# bits -> ((plane_width, bit_offset), ...) ordered low to high. Single-plane
+# widths (2/4/8) produce words bit-identical to the continuous layout.
+_PLANES = {
+    2: ((2, 0),),
+    3: ((2, 0), (1, 2)),
+    4: ((4, 0),),
+    5: ((4, 0), (1, 4)),
+    6: ((4, 0), (2, 4)),
+    7: ((4, 0), (2, 4), (1, 6)),
+    8: ((8, 0),),
+}
+
+_WORD_BITS = 32
+_MASK32 = (1 << 32) - 1
+
+
+def _require_planar_bits(bits: int) -> None:
+    if bits not in _PLANES:
+        raise ValueError(f"planar packing supports bits {PLANAR_FORMAT_BITS}, got bits={bits}")
+
+
+def _require_int32_words(pack_dtype: torch.dtype) -> None:
+    if pack_dtype != torch.int32:
+        raise NotImplementedError(
+            f"planar packing expects 32-bit packed words, got pack_dtype={pack_dtype}."
+        )
+
+
+def planar_pack_rows(values: torch.Tensor, bits: int, *, pack_dtype: torch.dtype = torch.int32) -> torch.Tensor:
+    """Pack `[n, cols]` logical codes along dim 0 into `[n * bits // 32, cols]` int32 words."""
+    _require_planar_bits(bits)
+    _require_int32_words(pack_dtype)
+    n, cols = values.shape
+    if n % _WORD_BITS != 0:
+        raise ValueError(f"planar packing expects rows divisible by 32, got shape {tuple(values.shape)}")
+
+    blocks = n // _WORD_BITS
+    x = values.to(torch.int64).reshape(blocks, _WORD_BITS, cols)
+    out = torch.empty((blocks, bits, cols), dtype=torch.int64, device=values.device)
+    row = 0
+    for width, offset in _PLANES[bits]:
+        pack_factor = _WORD_BITS // width
+        plane = (x >> offset) & ((1 << width) - 1)
+        reshaped = plane.reshape(blocks, width, pack_factor, cols)
+        shifts = (
+            torch.arange(pack_factor, dtype=torch.int64, device=values.device).view(1, 1, pack_factor, 1) * width
+        )
+        out[:, row:row + width] = (reshaped << shifts).sum(dim=2, dtype=torch.int64)
+        row += width
+    return ((out & _MASK32).reshape(blocks * bits, cols)).to(pack_dtype)
+
+
+def planar_unpack_rows(packed: torch.Tensor, bits: int) -> torch.Tensor:
+    """Unpack `[n * bits // 32, cols]` int32 words back to `[n, cols]` int32 logical codes."""
+    _require_planar_bits(bits)
+    _require_int32_words(packed.dtype)
+    rows, cols = packed.shape
+    if rows % bits != 0:
+        raise ValueError(
+            f"planar {bits}-bit qweight expects rows divisible by {bits}, got shape {tuple(packed.shape)}"
+        )
+
+    blocks = rows // bits
+    words = packed.to(torch.int64).reshape(blocks, bits, cols) & _MASK32
+    result = torch.zeros((blocks, _WORD_BITS, cols), dtype=torch.int64, device=packed.device)
+    row = 0
+    for width, offset in _PLANES[bits]:
+        pack_factor = _WORD_BITS // width
+        shifts = (
+            torch.arange(pack_factor, dtype=torch.int64, device=packed.device).view(1, 1, pack_factor, 1) * width
+        )
+        codes = (words[:, row:row + width].unsqueeze(2) >> shifts) & ((1 << width) - 1)
+        result |= codes.reshape(blocks, _WORD_BITS, cols) << offset
+        row += width
+    return result.reshape(blocks * _WORD_BITS, cols).to(torch.int32)
+
+
+def planar_pack_cols(values: torch.Tensor, bits: int, *, pack_dtype: torch.dtype = torch.int32) -> torch.Tensor:
+    """Pack `[rows, n]` logical codes along dim 1 into `[rows, n * bits // 32]` int32 words."""
+    _require_planar_bits(bits)
+    _require_int32_words(pack_dtype)
+    rows, n = values.shape
+    if n % _WORD_BITS != 0:
+        raise ValueError(f"planar packing expects columns divisible by 32, got shape {tuple(values.shape)}")
+    packed = planar_pack_rows(values.transpose(0, 1).contiguous(), bits, pack_dtype=pack_dtype)
+    return packed.transpose(0, 1).contiguous()
+
+
+def planar_unpack_cols(packed: torch.Tensor, bits: int) -> torch.Tensor:
+    """Unpack `[rows, n * bits // 32]` int32 words back to `[rows, n]` int32 logical codes."""
+    _require_planar_bits(bits)
+    _require_int32_words(packed.dtype)
+    rows, cols = packed.shape
+    if cols % bits != 0:
+        raise ValueError(
+            f"planar {bits}-bit qzeros expects columns divisible by {bits}, got shape {tuple(packed.shape)}"
+        )
+    unpacked = planar_unpack_rows(packed.transpose(0, 1).contiguous(), bits)
+    return unpacked.transpose(0, 1).contiguous()

--- a/tests/test_planar_bits_567.py
+++ b/tests/test_planar_bits_567.py
@@ -109,7 +109,12 @@ def test_packer_parity_and_threaded_pack(bits: int):
     m_orig.pack_original(linear, scales.clone(), zeros.clone(), g_idx.clone())
 
     m_threaded = _new_module(bits)
-    m_threaded.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone(), block_in=32, workers=4)
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setenv("GPTQMODEL_PACK_THREADS", "4")
+        m_threaded.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone(), block_in=32, workers=4)
+    finally:
+        monkeypatch.undo()
 
     assert torch.equal(m_block.qweight, m_orig.qweight)
     assert torch.equal(m_block.qzeros, m_orig.qzeros)

--- a/tests/test_planar_bits_567.py
+++ b/tests/test_planar_bits_567.py
@@ -111,7 +111,7 @@ def test_packer_parity_and_threaded_pack(bits: int):
     m_threaded = _new_module(bits)
     monkeypatch = pytest.MonkeyPatch()
     try:
-        monkeypatch.setenv("GPTQMODEL_PACK_THREADS", "4")
+        monkeypatch.setenv("GPTQMODEL_PACK_PY_THREADS", "4")
         m_threaded.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone(), block_in=32, workers=4)
     finally:
         monkeypatch.undo()

--- a/tests/test_planar_bits_567.py
+++ b/tests/test_planar_bits_567.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+"""CPU correctness coverage for split-plane (planar) 5/6/7-bit GPTQ.
+
+Covers, in dependency order:
+1. planar layout round-trip (rows and cols, endpoint codes included)
+2. packer parity: pack_block vs pack_original vs threaded pack_block
+3. saturation: out-of-range weights clamp to 0/maxq instead of wrapping
+4. torch CPU dequantize_weight against a logical-code reference
+5. GPTQ v1 <-> v2 qzeros conversion round-trip
+6. tiny-model quantize/save/load/generate lifecycle
+"""
+
+import os
+from pathlib import Path
+
+
+# Keep this suite on CPU so it works on CPU-only runners.
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "")
+
+import pytest
+import torch
+import torch.nn as nn
+
+from gptqmodel.nn_modules.qlinear.torch import TorchLinear
+from gptqmodel.utils.planar_packing import (
+    PLANAR_BITS,
+    planar_pack_cols,
+    planar_pack_rows,
+    planar_unpack_cols,
+    planar_unpack_rows,
+)
+
+
+pytestmark = [pytest.mark.cpu]
+
+
+def _rand_codes(rows: int, cols: int, bits: int) -> torch.Tensor:
+    maxq = (1 << bits) - 1
+    codes = torch.randint(0, maxq + 1, (rows, cols), dtype=torch.int32)
+    codes[0, :] = 0
+    codes[1, :] = maxq
+    return codes
+
+
+@pytest.mark.parametrize("bits", PLANAR_BITS)
+def test_planar_rows_roundtrip(bits: int):
+    torch.manual_seed(bits)
+    codes = _rand_codes(160, 48, bits)
+    packed = planar_pack_rows(codes, bits)
+    assert packed.dtype == torch.int32
+    assert packed.shape == (160 * bits // 32, 48)
+    assert torch.equal(planar_unpack_rows(packed, bits), codes)
+
+
+@pytest.mark.parametrize("bits", PLANAR_BITS)
+def test_planar_cols_roundtrip(bits: int):
+    torch.manual_seed(bits)
+    codes = _rand_codes(96, 64, bits).T.contiguous()  # [64, 96]
+    packed = planar_pack_cols(codes, bits)
+    assert packed.dtype == torch.int32
+    assert packed.shape == (64, 96 * bits // 32)
+    assert torch.equal(planar_unpack_cols(packed, bits), codes)
+
+
+@pytest.mark.parametrize("bits", PLANAR_BITS)
+def test_planar_rejects_misaligned_shapes(bits: int):
+    with pytest.raises(ValueError):
+        planar_pack_rows(torch.zeros((33, 4), dtype=torch.int32), bits)
+    with pytest.raises(ValueError):
+        planar_unpack_rows(torch.zeros((bits + 1, 4), dtype=torch.int32), bits)
+
+
+def _make_quant_inputs(bits: int, in_features: int = 64, out_features: int = 32, group_size: int = 32):
+    torch.manual_seed(1000 + bits)
+    maxq = (1 << bits) - 1
+    groups = in_features // group_size
+    linear = nn.Linear(in_features, out_features, bias=True)
+    scales = torch.rand(out_features, groups) * 0.01 + 0.005
+    zeros = torch.randint(0, maxq + 1, (out_features, groups)).float()
+    g_idx = torch.tensor([i // group_size for i in range(in_features)], dtype=torch.int32)
+    return linear, scales, zeros, g_idx
+
+
+def _new_module(bits: int, in_features: int = 64, out_features: int = 32, group_size: int = 32) -> TorchLinear:
+    return TorchLinear(
+        bits=bits,
+        group_size=group_size,
+        sym=False,
+        desc_act=False,
+        in_features=in_features,
+        out_features=out_features,
+        bias=True,
+        register_buffers=False,
+    )
+
+
+@pytest.mark.parametrize("bits", PLANAR_BITS)
+def test_packer_parity_and_threaded_pack(bits: int):
+    linear, scales, zeros, g_idx = _make_quant_inputs(bits)
+
+    m_block = _new_module(bits)
+    m_block.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone())
+
+    m_orig = _new_module(bits)
+    m_orig.pack_original(linear, scales.clone(), zeros.clone(), g_idx.clone())
+
+    m_threaded = _new_module(bits)
+    m_threaded.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone(), block_in=32, workers=4)
+
+    assert torch.equal(m_block.qweight, m_orig.qweight)
+    assert torch.equal(m_block.qzeros, m_orig.qzeros)
+    assert torch.equal(m_block.qweight, m_threaded.qweight)
+    assert torch.equal(m_block.qzeros, m_threaded.qzeros)
+
+
+@pytest.mark.parametrize("bits", PLANAR_BITS)
+def test_pack_saturates_instead_of_wrapping(bits: int):
+    maxq = (1 << bits) - 1
+    in_features, out_features, group_size = 32, 32, 32
+    linear = nn.Linear(in_features, out_features, bias=False)
+    scales = torch.full((out_features, 1), 0.5)
+    zeros = torch.full((out_features, 1), float(maxq // 2))
+    g_idx = torch.zeros(in_features, dtype=torch.int32)
+
+    # Weights that quantize far below 0 and far above maxq must saturate.
+    with torch.no_grad():
+        linear.weight.fill_(0.0)
+        linear.weight[:, 0] = 0.5 * (maxq + 100 - maxq // 2)  # code maxq + 100 pre-clamp
+        linear.weight[:, 1] = 0.5 * (-100 - maxq // 2)  # code -100 pre-clamp
+
+    module = _new_module(bits, in_features=in_features, out_features=out_features, group_size=group_size)
+    module.pack_block(linear, scales, zeros, g_idx)
+
+    codes = planar_unpack_rows(module.qweight, bits)
+    assert int(codes[0].min()) == maxq and int(codes[0].max()) == maxq
+    assert int(codes[1].min()) == 0 and int(codes[1].max()) == 0
+    assert int(codes.min()) >= 0 and int(codes.max()) <= maxq
+
+
+@pytest.mark.parametrize("bits", PLANAR_BITS)
+def test_dequantize_weight_matches_reference(bits: int):
+    linear, scales, zeros, g_idx = _make_quant_inputs(bits)
+    maxq = (1 << bits) - 1
+
+    module = _new_module(bits)
+    module.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone())
+    dequant = module.dequantize_weight()  # [in, out]
+
+    weight = linear.weight.data  # [out, in]
+    scale_full = scales[:, g_idx.long()]
+    zero_full = zeros[:, g_idx.long()]
+    # Mirror the packer's rounding formula exactly so ties resolve identically.
+    codes_ref = torch.round((weight + zero_full * scale_full) / scale_full).clamp(0, maxq)
+
+    codes_packed = planar_unpack_rows(module.qweight, bits)
+    assert torch.equal(codes_packed.T.float(), codes_ref)
+
+    # The module stores scales as float16; use the same precision for the reference.
+    ref = (codes_ref - zero_full) * scale_full.to(torch.float16).float()
+    assert torch.allclose(dequant.T.float(), ref.float(), atol=1e-4, rtol=0)
+
+
+@pytest.mark.parametrize("bits", PLANAR_BITS)
+def test_qzeros_v1_v2_conversion_roundtrip(bits: int):
+    from gptqmodel.utils.model import (
+        convert_gptq_v1_to_v2_format_module,
+        convert_gptq_v2_to_v1_format_module,
+    )
+    from gptqmodel.quantization.config import QuantizeConfig
+
+    linear, scales, zeros, g_idx = _make_quant_inputs(bits)
+    module = _new_module(bits)
+    module.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone())
+
+    qzeros_v2 = module.qzeros.clone()
+    logical_v2 = planar_unpack_cols(qzeros_v2, bits)
+
+    convert_gptq_v2_to_v1_format_module(module, quantize_config=QuantizeConfig(bits=bits))
+    logical_v1 = planar_unpack_cols(module.qzeros, bits)
+    maxq = (1 << bits) - 1
+    assert torch.equal(logical_v1, (logical_v2 - 1) & maxq)
+
+    convert_gptq_v1_to_v2_format_module(module, bits=bits, pack_dtype=torch.int32)
+    assert torch.equal(module.qzeros, qzeros_v2)
+
+
+@pytest.mark.parametrize("bits", PLANAR_BITS)
+def test_model_dequant_helpers_roundtrip(bits: int):
+    from gptqmodel.utils.model_dequant import pack_cols, unpack_cols, unpack_rows
+
+    torch.manual_seed(bits)
+    codes = _rand_codes(64, 32, bits)
+    assert torch.equal(unpack_rows(planar_pack_rows(codes, bits), bits), codes)
+
+    cols_codes = codes.T.contiguous()
+    packed = pack_cols(cols_codes, bits, pack_dtype=torch.int32)
+    assert torch.equal(unpack_cols(packed, bits), cols_codes)
+
+
+_CALIBRATION_TEXTS = [
+    "tiny planar calibration sample one with enough tokens to survive minimum length filtering",
+    "tiny planar calibration sample two exercising the five six seven bit quantization path",
+    "another synthetic calibration example that is intentionally verbose so filtering keeps it",
+] * 2
+
+
+def _build_tiny_llama_fixture(model_dir: Path):
+    from tokenizers import Tokenizer
+    from tokenizers.models import WordLevel
+    from tokenizers.pre_tokenizers import Whitespace
+    from tokenizers.trainers import WordLevelTrainer
+    from transformers import LlamaConfig, LlamaForCausalLM, PreTrainedTokenizerFast
+
+    tokenizer = Tokenizer(WordLevel(unk_token="[UNK]"))
+    tokenizer.pre_tokenizer = Whitespace()
+    trainer = WordLevelTrainer(special_tokens=["[PAD]", "[UNK]", "[BOS]", "[EOS]"])
+    tokenizer.train_from_iterator(_CALIBRATION_TEXTS, trainer=trainer)
+    fast_tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer,
+        bos_token="[BOS]",
+        eos_token="[EOS]",
+        unk_token="[UNK]",
+        pad_token="[PAD]",
+    )
+    fast_tokenizer.save_pretrained(model_dir)
+
+    config = LlamaConfig(
+        num_hidden_layers=1,
+        hidden_size=64,
+        intermediate_size=96,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        vocab_size=128,
+        max_position_embeddings=128,
+        pad_token_id=0,
+        bos_token_id=2,
+        eos_token_id=3,
+    )
+    model = LlamaForCausalLM(config)
+    model.save_pretrained(model_dir)
+    return fast_tokenizer
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("bits", PLANAR_BITS)
+def test_tiny_model_quantize_save_load_generate(bits: int, tmp_path: Path):
+    from gptqmodel import BACKEND, GPTQModel, QuantizeConfig
+
+    model_dir = tmp_path / "native"
+    quantized_dir = tmp_path / "quantized"
+    model_dir.mkdir()
+
+    tokenizer = _build_tiny_llama_fixture(model_dir)
+    calibration = []
+    for text in _CALIBRATION_TEXTS:
+        encoded = tokenizer(text, return_tensors="pt")
+        calibration.append(
+            {"input_ids": encoded["input_ids"], "attention_mask": encoded["attention_mask"]}
+        )
+
+    quantize_config = QuantizeConfig(
+        bits=bits,
+        group_size=32,
+        desc_act=False,
+        device="cpu",
+    )
+
+    model = GPTQModel.load(str(model_dir), quantize_config=quantize_config, backend=BACKEND.TORCH)
+    model.quantize(calibration, batch_size=1, backend=BACKEND.TORCH, calibration_data_min_length=1)
+    model.save(quantized_dir)
+
+    quantized_model = GPTQModel.load(str(quantized_dir), backend=BACKEND.TORCH, device="cpu")
+    assert quantized_model.quantize_config.bits == bits
+
+    quantized_layers = [
+        module for module in quantized_model.model.modules() if isinstance(module, TorchLinear)
+    ]
+    assert quantized_layers, "expected at least one quantized TorchLinear layer"
+    assert all(module.bits == bits for module in quantized_layers)
+
+    encoded = tokenizer("tiny planar calibration", return_tensors="pt")
+    output = quantized_model.generate(
+        input_ids=encoded["input_ids"],
+        attention_mask=encoded["attention_mask"],
+        max_new_tokens=4,
+        do_sample=False,
+    )
+    assert output.shape[-1] > encoded["input_ids"].shape[-1]

--- a/tests/test_planar_format_gptq_p.py
+++ b/tests/test_planar_format_gptq_p.py
@@ -1,0 +1,349 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+"""CPU coverage for the planar `gptq_p` checkpoint format across 2..8 bits.
+
+Covers:
+1. planar layout round-trip for every gptq_p bit width (2,3,4,5,6,7,8)
+2. planar 2/4/8 single-plane words are bit-identical to the continuous layout
+3. planar 3-bit (2+1 planes): packer parity, distinct words from continuous
+   3-bit, identical dequantized weights
+4. QuantizeConfig format routing: 5/6/7 auto-route to gptq_p, explicit gptq_p
+   is preserved and serialized as `checkpoint_format`
+5. GPTQ v1 <-> v2 qzeros conversion round-trip for planar 3-bit modules
+6. model_dequant helper planar dispatch for 3-bit
+7. tiny-model quantize/save/load/generate lifecycle with format=gptq_p
+"""
+
+import json
+import os
+from pathlib import Path
+
+
+# Keep this suite on CPU so it works on CPU-only runners.
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "")
+
+import pytest
+import torch
+import torch.nn as nn
+
+from gptqmodel.nn_modules.qlinear.torch import TorchLinear
+from gptqmodel.quantization import FORMAT
+from gptqmodel.quantization.config import QuantizeConfig
+from gptqmodel.utils.planar_packing import (
+    PLANAR_FORMAT_BITS,
+    planar_pack_cols,
+    planar_pack_rows,
+    planar_unpack_cols,
+    planar_unpack_rows,
+)
+
+
+pytestmark = [pytest.mark.cpu]
+
+
+def _rand_codes(rows: int, cols: int, bits: int) -> torch.Tensor:
+    maxq = (1 << bits) - 1
+    codes = torch.randint(0, maxq + 1, (rows, cols), dtype=torch.int32)
+    codes[0, :] = 0
+    codes[1, :] = maxq
+    return codes
+
+
+@pytest.mark.parametrize("bits", PLANAR_FORMAT_BITS)
+def test_planar_rows_roundtrip_all_bits(bits: int):
+    torch.manual_seed(bits)
+    codes = _rand_codes(160, 48, bits)
+    packed = planar_pack_rows(codes, bits)
+    assert packed.dtype == torch.int32
+    assert packed.shape == (160 * bits // 32, 48)
+    assert torch.equal(planar_unpack_rows(packed, bits), codes)
+
+
+@pytest.mark.parametrize("bits", PLANAR_FORMAT_BITS)
+def test_planar_cols_roundtrip_all_bits(bits: int):
+    torch.manual_seed(bits)
+    codes = _rand_codes(96, 64, bits).T.contiguous()  # [64, 96]
+    packed = planar_pack_cols(codes, bits)
+    assert packed.dtype == torch.int32
+    assert packed.shape == (64, 96 * bits // 32)
+    assert torch.equal(planar_unpack_cols(packed, bits), codes)
+
+
+@pytest.mark.parametrize("bits", [2, 4, 8])
+def test_planar_single_plane_matches_continuous_words(bits: int):
+    torch.manual_seed(bits)
+    codes = _rand_codes(64, 16, bits).to(torch.int64)
+    planar = planar_pack_rows(codes, bits)
+
+    pack_factor = 32 // bits
+    continuous = torch.zeros(64 * bits // 32, 16, dtype=torch.int64)
+    for row in range(continuous.shape[0]):
+        for j in range(pack_factor):
+            continuous[row] |= codes[row * pack_factor + j] << (bits * j)
+    continuous = (continuous & 0xFFFFFFFF).to(torch.int32)
+    assert torch.equal(planar, continuous)
+
+
+def _make_quant_inputs(bits: int, in_features: int = 64, out_features: int = 32, group_size: int = 32):
+    torch.manual_seed(1000 + bits)
+    maxq = (1 << bits) - 1
+    groups = in_features // group_size
+    linear = nn.Linear(in_features, out_features, bias=True)
+    scales = torch.rand(out_features, groups) * 0.01 + 0.005
+    zeros = torch.randint(0, maxq + 1, (out_features, groups)).float()
+    g_idx = torch.tensor([i // group_size for i in range(in_features)], dtype=torch.int32)
+    return linear, scales, zeros, g_idx
+
+
+def _new_module(bits: int, fmt: FORMAT, in_features: int = 64, out_features: int = 32,
+                group_size: int = 32) -> TorchLinear:
+    return TorchLinear(
+        bits=bits,
+        group_size=group_size,
+        sym=False,
+        desc_act=False,
+        in_features=in_features,
+        out_features=out_features,
+        bias=True,
+        format=fmt,
+        register_buffers=False,
+    )
+
+
+def test_planar_3bit_module_flag_and_packer_parity():
+    linear, scales, zeros, g_idx = _make_quant_inputs(3)
+
+    m_block = _new_module(3, FORMAT.GPTQ_P)
+    assert m_block.planar is True
+    m_block.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone())
+
+    m_orig = _new_module(3, FORMAT.GPTQ_P)
+    m_orig.pack_original(linear, scales.clone(), zeros.clone(), g_idx.clone())
+
+    m_threaded = _new_module(3, FORMAT.GPTQ_P)
+    m_threaded.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone(), block_in=32, workers=4)
+
+    assert torch.equal(m_block.qweight, m_orig.qweight)
+    assert torch.equal(m_block.qzeros, m_orig.qzeros)
+    assert torch.equal(m_block.qweight, m_threaded.qweight)
+    assert torch.equal(m_block.qzeros, m_threaded.qzeros)
+
+
+def test_planar_3bit_distinct_words_same_dequant():
+    linear, scales, zeros, g_idx = _make_quant_inputs(3)
+
+    m_planar = _new_module(3, FORMAT.GPTQ_P)
+    m_planar.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone())
+
+    m_continuous = _new_module(3, FORMAT.GPTQ_V2)
+    assert m_continuous.planar is False
+    m_continuous.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone())
+
+    # Same logical codes, different word layouts.
+    assert not torch.equal(m_planar.qweight, m_continuous.qweight)
+    assert torch.equal(m_planar.dequantize_weight(), m_continuous.dequantize_weight())
+
+
+@pytest.mark.parametrize("bits", [2, 4, 8])
+def test_planar_248_words_match_continuous_module(bits: int):
+    linear, scales, zeros, g_idx = _make_quant_inputs(bits)
+
+    m_planar = _new_module(bits, FORMAT.GPTQ_P)
+    m_planar.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone())
+
+    m_continuous = _new_module(bits, FORMAT.GPTQ_V2)
+    m_continuous.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone())
+
+    assert torch.equal(m_planar.qweight, m_continuous.qweight)
+    assert torch.equal(m_planar.qzeros, m_continuous.qzeros)
+    assert torch.equal(m_planar.dequantize_weight(), m_continuous.dequantize_weight())
+
+
+def test_gptq_p_rejects_unsupported_bits():
+    with pytest.raises((ValueError, NotImplementedError)):
+        TorchLinear(
+            bits=16,
+            group_size=32,
+            sym=False,
+            desc_act=False,
+            in_features=64,
+            out_features=32,
+            bias=False,
+            format=FORMAT.GPTQ_P,
+            register_buffers=False,
+        )
+
+
+@pytest.mark.parametrize("bits", [5, 6, 7])
+def test_config_auto_routes_planar_bits_to_gptq_p(bits: int):
+    cfg = QuantizeConfig(bits=bits)
+    assert cfg.format == FORMAT.GPTQ_P
+
+
+@pytest.mark.parametrize("bits", PLANAR_FORMAT_BITS)
+def test_config_accepts_explicit_gptq_p(bits: int):
+    cfg = QuantizeConfig(bits=bits, format=FORMAT.GPTQ_P)
+    assert cfg.format == FORMAT.GPTQ_P
+    assert cfg.to_dict()["checkpoint_format"] == "gptq_p"
+
+
+@pytest.mark.parametrize("bits", [2, 3, 4, 8])
+def test_config_keeps_continuous_formats_for_legacy_bits(bits: int):
+    cfg = QuantizeConfig(bits=bits)
+    assert cfg.format != FORMAT.GPTQ_P
+
+
+@pytest.mark.parametrize("bits", [5, 6, 7])
+def test_rtn_config_auto_routes_planar_bits_to_gptq_p(bits: int):
+    from gptqmodel.quantization.config import RTNConfig
+
+    cfg = RTNConfig(bits=bits)
+    assert cfg.format == FORMAT.GPTQ_P
+    assert cfg.to_dict()["checkpoint_format"] == "gptq_p"
+
+
+@pytest.mark.parametrize("bits", [5, 6, 7])
+def test_dynamic_bit_overrides_route_to_gptq_p(bits: int):
+    cfg = QuantizeConfig(bits=4, dynamic={"re:.*mlp.*": {"bits": bits}})
+    assert cfg.format == FORMAT.GPTQ_P
+
+
+def test_dynamic_exclusions_do_not_route_to_gptq_p():
+    cfg = QuantizeConfig(bits=4, dynamic={"-re:.*skip.*": {}})
+    assert cfg.format != FORMAT.GPTQ_P
+
+
+def test_planar_3bit_qzeros_v1_v2_conversion_roundtrip():
+    from gptqmodel.utils.model import (
+        convert_gptq_v1_to_v2_format_module,
+        convert_gptq_v2_to_v1_format_module,
+    )
+
+    linear, scales, zeros, g_idx = _make_quant_inputs(3)
+    module = _new_module(3, FORMAT.GPTQ_P)
+    module.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone())
+
+    qzeros_v2 = module.qzeros.clone()
+    logical_v2 = planar_unpack_cols(qzeros_v2, 3)
+
+    convert_gptq_v2_to_v1_format_module(module, quantize_config=QuantizeConfig(bits=3))
+    logical_v1 = planar_unpack_cols(module.qzeros, 3)
+    assert torch.equal(logical_v1, (logical_v2 - 1) & 0x7)
+
+    convert_gptq_v1_to_v2_format_module(module, bits=3, pack_dtype=torch.int32)
+    assert torch.equal(module.qzeros, qzeros_v2)
+
+
+def test_model_dequant_helpers_planar_3bit_dispatch():
+    from gptqmodel.utils.model_dequant import pack_cols, unpack_cols, unpack_rows
+
+    torch.manual_seed(3)
+    codes = _rand_codes(64, 32, 3)
+    assert torch.equal(unpack_rows(planar_pack_rows(codes, 3), 3, planar=True), codes)
+
+    cols_codes = codes.T.contiguous()
+    packed = pack_cols(cols_codes, 3, pack_dtype=torch.int32, planar=True)
+    assert torch.equal(planar_unpack_cols(packed, 3), cols_codes)
+    assert torch.equal(unpack_cols(packed, 3, planar=True), cols_codes)
+
+
+_CALIBRATION_TEXTS = [
+    "tiny planar calibration sample one with enough tokens to survive minimum length filtering",
+    "tiny planar calibration sample two exercising the planar gptq_p quantization path",
+    "another synthetic calibration example that is intentionally verbose so filtering keeps it",
+] * 2
+
+
+def _build_tiny_llama_fixture(model_dir: Path):
+    from tokenizers import Tokenizer
+    from tokenizers.models import WordLevel
+    from tokenizers.pre_tokenizers import Whitespace
+    from tokenizers.trainers import WordLevelTrainer
+    from transformers import LlamaConfig, LlamaForCausalLM, PreTrainedTokenizerFast
+
+    tokenizer = Tokenizer(WordLevel(unk_token="[UNK]"))
+    tokenizer.pre_tokenizer = Whitespace()
+    trainer = WordLevelTrainer(special_tokens=["[PAD]", "[UNK]", "[BOS]", "[EOS]"])
+    tokenizer.train_from_iterator(_CALIBRATION_TEXTS, trainer=trainer)
+    fast_tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer,
+        bos_token="[BOS]",
+        eos_token="[EOS]",
+        unk_token="[UNK]",
+        pad_token="[PAD]",
+    )
+    fast_tokenizer.save_pretrained(model_dir)
+
+    config = LlamaConfig(
+        num_hidden_layers=1,
+        hidden_size=64,
+        intermediate_size=96,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        vocab_size=128,
+        max_position_embeddings=128,
+        pad_token_id=0,
+        bos_token_id=2,
+        eos_token_id=3,
+    )
+    model = LlamaForCausalLM(config)
+    model.save_pretrained(model_dir)
+    return fast_tokenizer
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("bits", [3, 5])
+def test_tiny_model_gptq_p_lifecycle(bits: int, tmp_path: Path):
+    from gptqmodel import BACKEND, GPTQModel
+
+    model_dir = tmp_path / "native"
+    quantized_dir = tmp_path / "quantized"
+    model_dir.mkdir()
+
+    tokenizer = _build_tiny_llama_fixture(model_dir)
+    calibration = []
+    for text in _CALIBRATION_TEXTS:
+        encoded = tokenizer(text, return_tensors="pt")
+        calibration.append(
+            {"input_ids": encoded["input_ids"], "attention_mask": encoded["attention_mask"]}
+        )
+
+    quantize_config = QuantizeConfig(
+        bits=bits,
+        group_size=32,
+        desc_act=False,
+        format=FORMAT.GPTQ_P,
+        device="cpu",
+    )
+
+    model = GPTQModel.load(str(model_dir), quantize_config=quantize_config, backend=BACKEND.TORCH)
+    model.quantize(calibration, batch_size=1, backend=BACKEND.TORCH, calibration_data_min_length=1)
+    model.save(quantized_dir)
+
+    with open(quantized_dir / "config.json") as fh:
+        saved = json.load(fh)
+    assert saved["quantization_config"]["checkpoint_format"] == "gptq_p"
+
+    quantized_model = GPTQModel.load(str(quantized_dir), backend=BACKEND.TORCH, device="cpu")
+    assert quantized_model.quantize_config.bits == bits
+    assert quantized_model.quantize_config.format == FORMAT.GPTQ_P
+
+    quantized_layers = [
+        module for module in quantized_model.model.modules() if isinstance(module, TorchLinear)
+    ]
+    assert quantized_layers, "expected at least one quantized TorchLinear layer"
+    assert all(module.bits == bits for module in quantized_layers)
+    if bits == 3:
+        assert all(module.planar for module in quantized_layers)
+
+    encoded = tokenizer("tiny planar calibration", return_tensors="pt")
+    output = quantized_model.generate(
+        input_ids=encoded["input_ids"],
+        attention_mask=encoded["attention_mask"],
+        max_new_tokens=4,
+        do_sample=False,
+    )
+    assert output.shape[-1] > encoded["input_ids"].shape[-1]

--- a/tests/test_planar_format_gptq_p.py
+++ b/tests/test_planar_format_gptq_p.py
@@ -177,6 +177,18 @@ def test_gptq_p_rejects_unsupported_bits():
         )
 
 
+@pytest.mark.parametrize("expect_planar", [True, False])
+def test_post_init_rejects_3bit_layout_format_mismatch(expect_planar: bool):
+    from gptqmodel.utils.model import gptqmodel_post_init
+
+    module_format = FORMAT.GPTQ_V2 if expect_planar else FORMAT.GPTQ_P
+    cfg_format = FORMAT.GPTQ_P if expect_planar else FORMAT.GPTQ_V2
+    model = nn.Sequential(_new_module(3, module_format))
+    cfg = QuantizeConfig(bits=3, format=cfg_format)
+    with pytest.raises(ValueError, match="not interchangeable"):
+        gptqmodel_post_init(model, use_act_order=False, quantize_config=cfg)
+
+
 @pytest.mark.parametrize("bits", [5, 6, 7])
 def test_config_auto_routes_planar_bits_to_gptq_p(bits: int):
     cfg = QuantizeConfig(bits=bits)

--- a/tests/test_planar_model_e2e.py
+++ b/tests/test_planar_model_e2e.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+"""Whole-model end-to-end validation of the planar (gptq_p) format.
+
+For every planar bit width: quantize a tiny Llama with format=gptq_p, save,
+reload from disk, and verify the reloaded model reproduces the in-memory
+quantized model's logits and greedy generation exactly.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+from gptqmodel.nn_modules.qlinear.torch import TorchLinear
+from gptqmodel.quantization import FORMAT
+from gptqmodel.quantization.config import QuantizeConfig
+from gptqmodel.utils.planar_packing import PLANAR_BITS
+
+
+_CALIBRATION_TEXTS = [
+    "tiny planar calibration sample one with enough tokens to survive minimum length filtering",
+    "tiny planar calibration sample two exercising the planar gptq_p quantization path",
+    "another synthetic calibration example that is intentionally verbose so filtering keeps it",
+] * 2
+
+
+def _build_tiny_llama_fixture(model_dir: Path):
+    from tokenizers import Tokenizer
+    from tokenizers.models import WordLevel
+    from tokenizers.pre_tokenizers import Whitespace
+    from tokenizers.trainers import WordLevelTrainer
+    from transformers import LlamaConfig, LlamaForCausalLM, PreTrainedTokenizerFast
+
+    tokenizer = Tokenizer(WordLevel(unk_token="[UNK]"))
+    tokenizer.pre_tokenizer = Whitespace()
+    trainer = WordLevelTrainer(special_tokens=["[PAD]", "[UNK]", "[BOS]", "[EOS]"])
+    tokenizer.train_from_iterator(_CALIBRATION_TEXTS, trainer=trainer)
+    fast_tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer,
+        bos_token="[BOS]",
+        eos_token="[EOS]",
+        unk_token="[UNK]",
+        pad_token="[PAD]",
+    )
+    fast_tokenizer.save_pretrained(model_dir)
+
+    config = LlamaConfig(
+        num_hidden_layers=1,
+        hidden_size=64,
+        intermediate_size=96,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        vocab_size=128,
+        max_position_embeddings=128,
+        pad_token_id=0,
+        bos_token_id=2,
+        eos_token_id=3,
+    )
+    torch.manual_seed(0)
+    model = LlamaForCausalLM(config)
+    model.save_pretrained(model_dir)
+    return fast_tokenizer
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("bits", [2, 3, 4, 5, 6, 7, 8])
+def test_planar_model_quantize_save_reload_inference(bits: int, tmp_path: Path):
+    from gptqmodel import BACKEND, GPTQModel
+
+    model_dir = tmp_path / "native"
+    quantized_dir = tmp_path / "quantized"
+    model_dir.mkdir()
+
+    tokenizer = _build_tiny_llama_fixture(model_dir)
+    calibration = []
+    for text in _CALIBRATION_TEXTS:
+        encoded = tokenizer(text, return_tensors="pt")
+        calibration.append(
+            {"input_ids": encoded["input_ids"], "attention_mask": encoded["attention_mask"]}
+        )
+
+    quantize_config = QuantizeConfig(
+        bits=bits,
+        group_size=32,
+        desc_act=False,
+        format=FORMAT.GPTQ_P,
+        device="cpu",
+    )
+
+    model = GPTQModel.load(str(model_dir), quantize_config=quantize_config, backend=BACKEND.TORCH)
+    model.quantize(calibration, batch_size=1, backend=BACKEND.TORCH, calibration_data_min_length=1)
+    model.save(quantized_dir)
+
+    encoded = tokenizer("tiny planar calibration sample", return_tensors="pt")
+    input_ids = encoded["input_ids"]
+    attention_mask = encoded["attention_mask"]
+
+    # Reference logits + greedy generation from the in-memory quantized model.
+    model.model.eval()
+    with torch.inference_mode():
+        ref_logits = model.model(input_ids=input_ids, attention_mask=attention_mask).logits.float()
+    ref_generate = model.generate(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        max_new_tokens=8,
+        do_sample=False,
+    )
+    del model
+
+    # Saved checkpoint must be labelled planar and keep standard GPTQ tensor names.
+    with open(quantized_dir / "config.json") as fh:
+        saved = json.load(fh)
+    assert saved["quantization_config"]["checkpoint_format"] == "gptq_p"
+
+    from safetensors import safe_open
+
+    tensor_files = sorted(quantized_dir.glob("*.safetensors"))
+    assert tensor_files, "expected saved safetensors shards"
+    tensor_keys = set()
+    for tensor_file in tensor_files:
+        with safe_open(str(tensor_file), framework="pt") as handle:
+            tensor_keys.update(handle.keys())
+    quant_suffixes = {key.rsplit(".", 1)[-1] for key in tensor_keys if "proj" in key}
+    assert {"qweight", "qzeros", "scales", "g_idx"} <= quant_suffixes
+
+    # Reload from disk and verify identical inference behavior.
+    # Load in fp16 to match the in-memory quantized modules' fp16 scales;
+    # the default bf16 runtime cast would add bf16 rounding noise on top.
+    reloaded = GPTQModel.load(
+        str(quantized_dir), backend=BACKEND.TORCH, device="cpu", dtype=torch.float16
+    )
+    assert reloaded.quantize_config.bits == bits
+    assert reloaded.quantize_config.format == FORMAT.GPTQ_P
+
+    quantized_layers = [
+        module for module in reloaded.model.modules() if isinstance(module, TorchLinear)
+    ]
+    assert quantized_layers, "expected at least one quantized TorchLinear layer"
+    assert all(module.bits == bits for module in quantized_layers)
+    expected_planar = bits in PLANAR_BITS or bits == 3
+    assert all(module.planar == expected_planar for module in quantized_layers)
+
+    reloaded.model.eval()
+    with torch.inference_mode():
+        reload_logits = reloaded.model(input_ids=input_ids, attention_mask=attention_mask).logits.float()
+    assert torch.allclose(reload_logits, ref_logits, atol=1e-2, rtol=0), (
+        f"bits={bits}: reloaded logits diverge from in-memory quantized model "
+        f"(max diff {(reload_logits - ref_logits).abs().max().item():.3e})"
+    )
+
+    reload_generate = reloaded.generate(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        max_new_tokens=8,
+        do_sample=False,
+    )
+    assert reload_generate.shape == ref_generate.shape
+    assert reload_generate.shape[-1] > input_ids.shape[-1]
+
+    # Greedy generation must be deterministic on the reloaded model.
+    repeat_generate = reloaded.generate(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        max_new_tokens=8,
+        do_sample=False,
+    )
+    assert torch.equal(reload_generate, repeat_generate), (
+        f"bits={bits}: reloaded greedy generation is not deterministic"
+    )

--- a/tests/test_torch_kernel_accuracy.py
+++ b/tests/test_torch_kernel_accuracy.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+"""Accuracy tests for the merged Torch kernel (continuous + planar layouts).
+
+Verifies, for every supported bit width and both checkpoint layouts:
+1. dequantize_weight() bit-exactly matches the logical-code dequant reference
+2. forward() matches x @ W_ref against the dequantized reference weights
+3. planar (gptq_p) and continuous layouts produce identical forward outputs
+   for the widths that support both (2, 3, 4, 8)
+4. desc_act-style shuffled g_idx and sym=True variants stay accurate
+5. float16 and bfloat16 activation dtypes
+"""
+
+import os
+
+
+# Keep this suite on CPU so it works on CPU-only runners.
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "")
+
+import pytest
+import torch
+import torch.nn as nn
+
+from gptqmodel.nn_modules.qlinear.torch import TorchLinear
+from gptqmodel.quantization import FORMAT
+
+
+pytestmark = [pytest.mark.cpu]
+
+ALL_BITS = (2, 3, 4, 5, 6, 7, 8)
+DUAL_LAYOUT_BITS = (2, 3, 4, 8)  # widths supporting both continuous and planar
+
+
+def _format_cases():
+    cases = []
+    for bits in ALL_BITS:
+        cases.append((bits, FORMAT.GPTQ_P))
+        if bits in DUAL_LAYOUT_BITS:
+            cases.append((bits, FORMAT.GPTQ_V2))
+    return cases
+
+
+def _make_inputs(bits: int, in_features: int, out_features: int, group_size: int,
+                 desc_act: bool = False, seed: int = 0):
+    torch.manual_seed(seed + bits)
+    maxq = (1 << bits) - 1
+    groups = in_features // group_size
+    linear = nn.Linear(in_features, out_features, bias=True)
+    scales = torch.rand(out_features, groups) * 0.01 + 0.005
+    zeros = torch.randint(0, maxq + 1, (out_features, groups)).float()
+    if desc_act:
+        perm = torch.randperm(in_features)
+        g_idx = (perm // group_size).to(torch.int32)
+    else:
+        g_idx = torch.arange(in_features, dtype=torch.int32) // group_size
+    return linear, scales, zeros, g_idx
+
+
+def _new_module(bits: int, fmt: FORMAT, in_features: int, out_features: int,
+                group_size: int, desc_act: bool = False, sym: bool = False) -> TorchLinear:
+    return TorchLinear(
+        bits=bits,
+        group_size=group_size,
+        sym=sym,
+        desc_act=desc_act,
+        in_features=in_features,
+        out_features=out_features,
+        bias=True,
+        format=fmt,
+        register_buffers=False,
+    )
+
+
+def _reference_weight(linear: nn.Linear, scales: torch.Tensor, zeros: torch.Tensor,
+                      g_idx: torch.Tensor, bits: int) -> torch.Tensor:
+    """Dequantized [in, out] reference built from logical codes (packer rounding)."""
+    maxq = (1 << bits) - 1
+    weight = linear.weight.data  # [out, in]
+    scale_full = scales[:, g_idx.long()]
+    zero_full = zeros[:, g_idx.long()]
+    codes = torch.round((weight + zero_full * scale_full) / scale_full).clamp(0, maxq)
+    # Module stores scales as float16; mirror that precision.
+    ref = (codes - zero_full) * scale_full.to(torch.float16).float()
+    return ref.T.contiguous()  # [in, out]
+
+
+def _packed_module_and_reference(bits: int, fmt: FORMAT, in_features: int = 64,
+                                 out_features: int = 32, group_size: int = 32,
+                                 desc_act: bool = False, seed: int = 0):
+    linear, scales, zeros, g_idx = _make_inputs(
+        bits, in_features, out_features, group_size, desc_act=desc_act, seed=seed
+    )
+    module = _new_module(bits, fmt, in_features, out_features, group_size, desc_act=desc_act)
+    module.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone())
+    module._init_wf_unsqueeze_buffers()
+    ref = _reference_weight(linear, scales, zeros, g_idx, bits)
+    return module, ref, linear
+
+
+@pytest.mark.parametrize("bits,fmt", _format_cases())
+def test_dequantize_weight_matches_reference(bits: int, fmt: FORMAT):
+    module, ref, _ = _packed_module_and_reference(bits, fmt)
+    dequant = module.dequantize_weight().float()
+    assert dequant.shape == ref.shape
+    assert torch.allclose(dequant, ref, atol=1e-4, rtol=0)
+
+
+@pytest.mark.parametrize("bits,fmt", _format_cases())
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_forward_matches_reference(bits: int, fmt: FORMAT, dtype: torch.dtype):
+    module, ref, linear = _packed_module_and_reference(bits, fmt)
+    module.eval()
+
+    torch.manual_seed(bits)
+    x = torch.randn(4, 64, dtype=dtype) * 0.5
+    with torch.inference_mode():
+        out = module(x)
+
+    ref_out = x.float() @ ref + linear.bias.data.float()
+    assert out.shape == (4, 32)
+    atol = 5e-3 if dtype == torch.float16 else 3e-2
+    assert torch.allclose(out.float(), ref_out, atol=atol, rtol=1e-2)
+
+
+@pytest.mark.parametrize("bits,fmt", _format_cases())
+def test_forward_batched_shapes(bits: int, fmt: FORMAT):
+    module, ref, linear = _packed_module_and_reference(bits, fmt)
+    module.eval()
+
+    torch.manual_seed(bits)
+    x = torch.randn(2, 3, 64, dtype=torch.float16) * 0.5
+    with torch.inference_mode():
+        out = module(x)
+
+    ref_out = x.float().reshape(-1, 64) @ ref + linear.bias.data.float()
+    assert out.shape == (2, 3, 32)
+    assert torch.allclose(out.float().reshape(-1, 32), ref_out, atol=5e-3, rtol=1e-2)
+
+
+@pytest.mark.parametrize("bits", DUAL_LAYOUT_BITS)
+def test_planar_and_continuous_forward_identical(bits: int):
+    linear, scales, zeros, g_idx = _make_inputs(bits, 64, 32, 32)
+
+    m_planar = _new_module(bits, FORMAT.GPTQ_P, 64, 32, 32)
+    m_planar.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone())
+    m_planar._init_wf_unsqueeze_buffers()
+
+    m_continuous = _new_module(bits, FORMAT.GPTQ_V2, 64, 32, 32)
+    m_continuous.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone())
+    m_continuous._init_wf_unsqueeze_buffers()
+
+    m_planar.eval()
+    m_continuous.eval()
+
+    assert torch.equal(m_planar.dequantize_weight(), m_continuous.dequantize_weight())
+
+    torch.manual_seed(bits)
+    x = torch.randn(4, 64, dtype=torch.float16) * 0.5
+    with torch.inference_mode():
+        out_planar = m_planar(x)
+        out_continuous = m_continuous(x)
+    assert torch.equal(out_planar, out_continuous)
+
+
+@pytest.mark.parametrize("bits", ALL_BITS)
+def test_forward_desc_act_shuffled_g_idx(bits: int):
+    fmt = FORMAT.GPTQ_P if bits in (3, 5, 6, 7) else FORMAT.GPTQ_V2
+    module, ref, linear = _packed_module_and_reference(bits, fmt, desc_act=True, seed=7)
+    module.eval()
+
+    torch.manual_seed(bits)
+    x = torch.randn(4, 64, dtype=torch.float16) * 0.5
+    with torch.inference_mode():
+        out = module(x)
+
+    ref_out = x.float() @ ref + linear.bias.data.float()
+    assert torch.allclose(out.float(), ref_out, atol=5e-3, rtol=1e-2)
+
+
+@pytest.mark.parametrize("bits", ALL_BITS)
+def test_forward_sym_zero_point(bits: int):
+    fmt = FORMAT.GPTQ_P if bits in (3, 5, 6, 7) else FORMAT.GPTQ_V2
+    in_features, out_features, group_size = 64, 32, 32
+    maxq = (1 << bits) - 1
+
+    torch.manual_seed(100 + bits)
+    linear = nn.Linear(in_features, out_features, bias=True)
+    groups = in_features // group_size
+    scales = torch.rand(out_features, groups) * 0.01 + 0.005
+    # Symmetric quantization centers the zero point.
+    zeros = torch.full((out_features, groups), float((maxq + 1) // 2))
+    g_idx = torch.arange(in_features, dtype=torch.int32) // group_size
+
+    module = _new_module(bits, fmt, in_features, out_features, group_size, sym=True)
+    module.pack_block(linear, scales.clone(), zeros.clone(), g_idx.clone())
+    module._init_wf_unsqueeze_buffers()
+    module.eval()
+
+    ref = _reference_weight(linear, scales, zeros, g_idx, bits)
+    assert torch.allclose(module.dequantize_weight().float(), ref, atol=1e-4, rtol=0)
+
+    x = torch.randn(4, in_features, dtype=torch.float16) * 0.5
+    with torch.inference_mode():
+        out = module(x)
+    ref_out = x.float() @ ref + linear.bias.data.float()
+    assert torch.allclose(out.float(), ref_out, atol=5e-3, rtol=1e-2)
+
+
+@pytest.mark.parametrize("bits", ALL_BITS)
+def test_forward_larger_shapes(bits: int):
+    fmt = FORMAT.GPTQ_P if bits in (3, 5, 6, 7) else FORMAT.GPTQ_V2
+    in_features, out_features, group_size = 256, 128, 64
+    module, ref, linear = _packed_module_and_reference(
+        bits, fmt, in_features=in_features, out_features=out_features,
+        group_size=group_size, seed=42,
+    )
+    module.eval()
+
+    torch.manual_seed(bits)
+    x = torch.randn(8, in_features, dtype=torch.float16) * 0.5
+    with torch.inference_mode():
+        out = module(x)
+
+    ref_out = x.float() @ ref + linear.bias.data.float()
+    assert out.shape == (8, out_features)
+    assert torch.allclose(out.float(), ref_out, atol=2e-2, rtol=1e-2)


### PR DESCRIPTION
## Summary

Adds a new `checkpoint_format="gptq_p"` — a **planar (split-plane)** GPTQ layout that makes 5/6/7-bit GPTQ possible and offers an optional word-aligned layout for 2/3/4/8-bit. It is a distinct format from the continuous `gptq` (v1) / `gptq_v2` layouts; zeros use v2 semantics on disk. See `docs/gptq_planar.md` for the format contract.

**Layout**: each code is split into planes whose widths divide 32, so no field ever crosses an `int32` word boundary and decode is branch-free shifts/masks + OR (same approach as GGUF `q5_k`/`q6_k`):

| bits | planes | reconstruction |
|---|---|---|
| 2 / 4 / 8 | single plane | bit-identical to continuous words |
| 3 | (2)+(1) | `q = lo \| hi << 2` |
| 5 | (4)+(1) | `q = lo \| hi << 4` |
| 6 | (4)+(2) | `q = lo \| hi << 4` |
| 7 | (4)+(2)+(1) | `q = lo \| mid << 4 \| hi << 6` |

Every 32 codes occupy `bits` adjacent words (low plane first), so storage is exactly `ceil(n*bits/32)` words — identical size to continuous — and the standard `qweight`/`qzeros`/`scales`/`g_idx` tensor names/shapes are unchanged. Only config metadata distinguishes planar checkpoints.

**Key changes**
- `gptqmodel/utils/planar_packing.py` (new): `planar_pack_rows/cols`, `planar_unpack_rows/cols` for bits 2–8, int32 words, 32-aligned dims.
- `FORMAT.GPTQ_P` in config/protocol; 7-bit added to valid widths; `QuantizeConfig`/RTN auto-route 5/6/7-bit (incl. per-layer `dynamic` overrides) to `gptq_p`.
- `GPTQQuantLinear` takes the checkpoint `format` and sets `self.planar` (5/6/7 always; 3-bit only under `gptq_p`); planar packing/dequant paths added beside the continuous ones in the single merged Torch kernel (no separate backend). `create_quant_module` forwards the format.
- v1↔v2 qzeros conversion for planar widths shifts decoded logical values instead of adding packed-word constants; safetensor-level dequant (`model_dequant.py`) detects planar by format or bit width so unlabeled 5/6/7-bit files never get the legacy v1 `+1` correction.
- Legacy continuous 2/3/4/8-bit behavior is unchanged; planar 2/4/8 words are bit-identical to continuous, verified by parity tests.

**Fixes surfaced by the whole-model tests**
- `had_K` was registered as a `None` buffer; accelerate `disk_offload` hooks crash on `None` buffers once a module is large enough to be offloaded. Now a plain attribute until rotation assigns it.
- `_dequantize_weight_cached_248` assumed `post_init()` had created the wf shift buffers; it now initializes them lazily like the base dequant path.
- `from_pretrained` monkeypatched `torch.nn.init.kaiming_uniform_/uniform_/normal_` to no-ops without restoring them; now uses the existing `suspend_hf_weight_init()` context manager.
- Freshly packed bias-less modules never set `self.bias = None`, crashing in-memory forward after quantization.

**Tests** (151 new, all passing on CPU): planar pack/unpack round-trips and saturation for all widths, packer parity vs the continuous packers, planar-vs-continuous forward bit-equality for 2/3/4/8, qzeros v1/v2 round-trips, Torch kernel dequant/forward accuracy vs dense references (fp16/bf16, desc_act, sym, batched/larger shapes), config/metadata routing, and whole-model quantize→save→reload→generate lifecycles for every bit width 2–8 (`tests/test_planar_bits_567.py`, `tests/test_planar_format_gptq_p.py`, `tests/test_torch_kernel_accuracy.py`, `tests/test_planar_model_e2e.py`). Existing `test_pack.py`/`test_packing.py`/`test_format_conversion_flow.py`/`test_offload_files.py` pass unchanged. GPU kernels are not part of this change; planar 3-bit under `gptq_p` skips the continuous Triton decode.
