### PR TITLE
feat: Swordfish kernel for Blackwell (GPTQ/AWQ) by AlpinDale

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,6 +1,7 @@
 # Credits
 
-* [Qubitium](https://x.com/qubitium) and [ModelCloud](https://x.com/ModelCloudAI) team for maintaining and improving GPT-QModel
+* [Qubitium](https://x.com/Qubitium) and [ModelCloud](https://x.com/ModelCloudAI) team for maintaining and improving GPT-QModel
+* [AlpinDale](https://x.com/AlpinDale) for creating the [Swordfish GPTQ/AWQ](https://blog.alpindale.net/posts/swordfish/) Blackwell (>= sm100/sm110) w4a16/w8a16 GEMM kernel family.
 * **Elias Frantar**, **Saleh Ashkboos**, **Torsten Hoefler** and **Dan Alistarh**: for creating [GPTQ](https://github.com/IST-DASLab/gptq) and [Marlin](https://github.com/IST-DASLab/marlin).
 * **PanQiWei**: for creation of [AutoGPTQ](https://github.com/autogptq/AutoGPTQ) which this project code is based upon.
 * **FXMarty**: for maintaining and support of [AutoGPTQ](https://github.com/autogptq/AutoGPTQ).

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,8 @@ recursive-include gptqmodel_ext/cutlass_extensions *.h *.hpp *.cuh *.cu *.cpp *.
 recursive-include gptqmodel_ext/paroquant *.h *.cuh *.cu *.cpp
 recursive-include gptqmodel_ext/qqq *.h *.cuh *.cu *.cpp
 recursive-include gptqmodel_ext/hadamard *.h *.cuh *.cu *.cpp LICENSE
+recursive-include gptqmodel_ext/swordfish *.h *.hpp *.cuh *.cu *.cpp *.py
+include gptqmodel_ext/swordfish/licenses/LICENSE
 recursive-include gptqmodel/exllamav3/util/hadamard_data *.txt
 include licenses/*
 include gptqmodel_ext/pack_block_cpu.cpp

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 ## Latest News
 
+* 08/04/2026 7.4.0 `main`: 🚀🔥⚡ Added `Swordfish` Blackwell (>= sm100) GPTQ/AWQ kernel from [AlpinDale](https://x.com/AlpinDale): [Paper](https://blog.alpindale.net/posts/swordfish/).
 * 07/24/2026 7.3.1 `main`: ✨ Added `solar_open` and `solar_open2` model support
 * 07/23/2026 7.3.1 `main`: ✨ Added `Intern S2 PreView` model support
 * 07/23/2026 7.3.1 `main`: ✨ Added `inkling_mm_model` model support
@@ -808,3 +809,7 @@ from gptqmodel import TritonPatch
 # Fix Triton crashing under nogil/free-threading Python 3.13+ where the kernel cache storage in Triton is not thread-safe
 TritonPatch.apply()
 ```
+
+## License
+
+GPT-QModel is licensed under the Apache-2.0 license. The optional Swordfish kernel sources vendored under `gptqmodel_ext/swordfish/` are licensed under the AGPL-3.0-or-later license and are only compiled/linked at runtime via JIT. A copy of the Swordfish license is included in `gptqmodel_ext/swordfish/licenses/LICENSE` and `licenses/SWORDFISH`.

--- a/gptqmodel/extension.py
+++ b/gptqmodel/extension.py
@@ -96,6 +96,13 @@ _EXTENSION_SPECS = (
         resolve=lambda: _resolve_extension_attr("gptqmodel.utils.marlin", "_MARLIN_BF16_TORCH_OPS_EXTENSION"),
     ),
     _ExtensionSpec(
+        name="swordfish",
+        aliases=("gptq_swordfish", "awq_swordfish"),
+        resolve=lambda: _resolve_extension_attr("gptqmodel.utils.swordfish", "_SWORDFISH_TORCH_OPS_EXTENSION"),
+        supported=lambda: _resolve_attr("gptqmodel.utils.swordfish", "_validate_swordfish_device_support")(),
+        unsupported_error=lambda: _resolve_attr("gptqmodel.utils.swordfish", "swordfish_runtime_error")(),
+    ),
+    _ExtensionSpec(
         name="paroquant",
         aliases=("paroquant_rotation",),
         resolve=lambda: _resolve_extension_attr("gptqmodel.utils.paroquant", "_PAROQUANT_ROTATION_EXTENSION"),

--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -66,6 +66,7 @@ from ..utils.inspect import safe_kwargs_call
 from ..utils.logger import setup_logger
 from ..utils.machete import _validate_machete_device_support
 from ..utils.marlin import _marlin_capability_supported, _validate_marlin_device_support
+from ..utils.swordfish import _validate_swordfish_device_support
 from ..utils.model import (
     auto_dtype,
     convert_gptq_v1_to_v2_format,
@@ -1422,6 +1423,7 @@ def ModelLoader(cls):
                     lm_head_name=cls.lm_head,
                     device=device,
                     dtype=dtype,
+                    is_sharded=is_sharded,
                 )
 
         if isinstance(requested_device_map, str) and requested_device_map not in [
@@ -1713,6 +1715,16 @@ def ModelLoader(cls):
             if backend == BACKEND.AWQ_MARLIN and dtype not in (torch.float16, torch.bfloat16):
                 raise ValueError("AWQ Marlin kernel requires dtype=torch.float16 or dtype=torch.bfloat16.")
 
+        if backend in [BACKEND.GPTQ_SWORDFISH, BACKEND.AWQ_SWORDFISH, BACKEND.SWORDFISH]:
+            if is_sharded:
+                raise ValueError(
+                    "Format: The loading of sharded checkpoints with Swordfish is currently not supported."
+                )
+            if not _validate_swordfish_device_support():
+                from ..utils.swordfish import swordfish_runtime_error
+                raise ValueError(f"Kernel: {swordfish_runtime_error()}")
+            if dtype not in (torch.float16, torch.bfloat16):
+                raise ValueError("Swordfish kernel requires dtype=torch.float16 or dtype=torch.bfloat16.")
 
         if backend in [BACKEND.GPTQ_BITBLAS, BACKEND.AWQ_BITBLAS]:
             from ..utils.bitblas import prepare_model_for_bitblas_load
@@ -1774,6 +1786,7 @@ def ModelLoader(cls):
                 quant_method=export_quant_method,
                 device=device,
                 pack_dtype=qcfg.pack_dtype,
+                is_sharded=is_sharded,
             )
 
         # == step4: set seqlen == #

--- a/gptqmodel/nn_modules/qlinear/swordfish.py
+++ b/gptqmodel/nn_modules/qlinear/swordfish.py
@@ -38,7 +38,7 @@ log = setup_logger()
 class SwordfishLinear(GPTQQuantLinear):
     SUPPORTS_BACKENDS = [BACKEND.GPTQ_SWORDFISH]
     SUPPORTS_METHODS = [METHOD.GPTQ]
-    SUPPORTS_FORMATS = {FORMAT.GPTQ: 95}
+    SUPPORTS_FORMATS = {FORMAT.GPTQ: 101}
     SUPPORTS_BITS = [4, 8]
     SUPPORTS_GROUP_SIZE = [-1, 32, 64, 128]
     SUPPORTS_DESC_ACT = [True, False]
@@ -396,7 +396,7 @@ def _undo_awq_interleave(values: torch.Tensor, num_bits: int) -> torch.Tensor:
 class AwqSwordfishLinear(AWQuantLinear):
     SUPPORTS_BACKENDS = [BACKEND.AWQ_SWORDFISH]
     SUPPORTS_METHODS = [METHOD.AWQ]
-    SUPPORTS_FORMATS = {FORMAT.GEMM: 95}
+    SUPPORTS_FORMATS = {FORMAT.GEMM: 101}
     SUPPORTS_BITS = [4]
     SUPPORTS_GROUP_SIZE = [-1, 32, 64, 128]
     SUPPORTS_DESC_ACT = [False]

--- a/gptqmodel/nn_modules/qlinear/swordfish.py
+++ b/gptqmodel/nn_modules/qlinear/swordfish.py
@@ -400,7 +400,7 @@ class AwqSwordfishLinear(AWQuantLinear):
     SUPPORTS_BITS = [4]
     SUPPORTS_GROUP_SIZE = [-1, 32, 64, 128]
     SUPPORTS_DESC_ACT = [False]
-    SUPPORTS_SYM = [False]
+    SUPPORTS_SYM = [True, False]
     SUPPORTS_SHARDS = False
     SUPPORTS_TRAINING = False
     SUPPORTS_AUTO_PADDING = False
@@ -418,7 +418,8 @@ class AwqSwordfishLinear(AWQuantLinear):
     QUANT_TYPE = "awq_swordfish"
 
     TYPE_MAP = {
-        4: scalar_types.uint4,
+        (4, True): scalar_types.uint4b8,
+        (4, False): scalar_types.uint4,
     }
 
     def __init__(
@@ -435,8 +436,8 @@ class AwqSwordfishLinear(AWQuantLinear):
         register_buffers: bool = False,
         **kwargs,
     ):
-        if bits not in self.TYPE_MAP:
-            raise ValueError(f"Unsupported num_bits = {bits}. Supported: {list(self.TYPE_MAP.keys())}")
+        if (bits, sym) not in self.TYPE_MAP:
+            raise ValueError(f"Unsupported quantization config: bits={bits}, sym={sym}")
 
         self.compute_dtype = kwargs.get("dtype") or torch.float16
 
@@ -500,8 +501,8 @@ class AwqSwordfishLinear(AWQuantLinear):
         else:
             self.bias = None
 
-        self.weight_type = self.TYPE_MAP[self.bits]
-        self.has_zero_points = True
+        self.weight_type = self.TYPE_MAP[(self.bits, self.sym)]
+        self.has_zero_points = not self.sym
 
         self.register_buffer("input_perm", torch.empty(0, dtype=torch.int32))
 
@@ -526,14 +527,13 @@ class AwqSwordfishLinear(AWQuantLinear):
 
         bits = args.get("bits")
         sym = args.get("sym", True)
-        if bits not in cls.TYPE_MAP:
-            return False, ValueError(f"AwqSwordfishLinear does not support bits={bits}")
-        if sym:
-            return False, ValueError("AwqSwordfishLinear requires sym=False for AWQ zero points")
-
-        quant_type = cls.TYPE_MAP[bits]
-        if quant_type not in query_swordfish_supported_quant_types(zero_points=True):
-            return False, ValueError(f"Swordfish does not support AWQ {bits}-bit weights with zero points")
+        quant_type = cls.TYPE_MAP.get((bits, sym))
+        if quant_type is None:
+            return False, ValueError(f"AwqSwordfishLinear does not support bits={bits}, sym={sym}")
+        if quant_type not in query_swordfish_supported_quant_types(zero_points=not sym):
+            return False, ValueError(
+                f"Swordfish does not support AWQ {bits}-bit weights with sym={sym} (zero_points={not sym})"
+            )
 
         group_size = args.get("group_size")
         dtype = args.get("dtype") or torch.float16
@@ -609,21 +609,30 @@ class AwqSwordfishLinear(AWQuantLinear):
         effective_group_size = self.in_features if self.requested_group_size == -1 else self.group_size
         num_groups = self.in_features // effective_group_size
 
-        qzeros_unpacked = _unpack_cols_torch(
-            self.qzeros,
-            self.bits,
-            num_groups,
-            self.out_features,
-        )
-        qzeros_unpacked = _undo_awq_interleave(qzeros_unpacked, self.bits)
+        if self.has_zero_points:
+            qzeros_unpacked = _unpack_cols_torch(
+                self.qzeros,
+                self.bits,
+                num_groups,
+                self.out_features,
+            )
+            qzeros_unpacked = _undo_awq_interleave(qzeros_unpacked, self.bits)
 
-        half_range = float(1 << (self.bits - 1))
-        qzeros_fp = ((half_range - qzeros_unpacked.to(scales.dtype)) * scales).contiguous()
-        replace_parameter(
-            self,
-            "qzeros",
-            torch.nn.Parameter(qzeros_fp, requires_grad=False),
-        )
+            half_range = float(1 << (self.bits - 1))
+            qzeros_fp = ((half_range - qzeros_unpacked.to(scales.dtype)) * scales).contiguous()
+            replace_parameter(
+                self,
+                "qzeros",
+                torch.nn.Parameter(qzeros_fp, requires_grad=False),
+            )
+        else:
+            replace_parameter(
+                self,
+                "qzeros",
+                torch.nn.Parameter(
+                    torch.empty(0, dtype=scales.dtype, device=device), requires_grad=False
+                ),
+            )
 
         self.input_perm = torch.empty(0, dtype=torch.int32, device=device)
 
@@ -651,8 +660,8 @@ class AwqSwordfishLinear(AWQuantLinear):
         if group_scales.dtype != input_2d.dtype:
             group_scales = group_scales.to(dtype=input_2d.dtype)
 
-        group_zeros = self.qzeros
-        if group_zeros.dtype != input_2d.dtype:
+        group_zeros = self.qzeros if self.has_zero_points else None
+        if group_zeros is not None and group_zeros.dtype != input_2d.dtype:
             group_zeros = group_zeros.to(dtype=input_2d.dtype)
 
         kernel_group_size = -1 if self.requested_group_size == -1 else self.group_size

--- a/gptqmodel/nn_modules/qlinear/swordfish.py
+++ b/gptqmodel/nn_modules/qlinear/swordfish.py
@@ -1,0 +1,680 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+"""Swordfish (Blackwell sm100/sm110) weight-quantized linear layer."""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional, Tuple
+
+import torch
+
+from ...adapter.adapter import Adapter, Lora
+from ...models._const import DEVICE, PLATFORM
+from ...nn_modules.qlinear import AWQuantLinear, GPTQQuantLinear
+from ...quantization import FORMAT, METHOD
+from ...utils.backend import BACKEND
+from ...utils.logger import setup_logger
+from ...utils.marlin import replace_parameter
+from ...utils.marlin_scalar_type import scalar_types
+
+from ...utils.rocm import IS_ROCM
+from ...utils.swordfish import (
+    _validate_swordfish_device_support,
+    check_swordfish_supports_shape,
+    query_swordfish_supported_group_sizes,
+    query_swordfish_supported_quant_types,
+    swordfish_mm,
+    swordfish_prepack_B,
+    swordfish_runtime_available,
+    swordfish_runtime_error,
+)
+
+log = setup_logger()
+
+
+class SwordfishLinear(GPTQQuantLinear):
+    SUPPORTS_BACKENDS = [BACKEND.GPTQ_SWORDFISH]
+    SUPPORTS_METHODS = [METHOD.GPTQ]
+    SUPPORTS_FORMATS = {FORMAT.GPTQ: 95}
+    SUPPORTS_BITS = [4, 8]
+    SUPPORTS_GROUP_SIZE = [-1, 32, 64, 128]
+    SUPPORTS_DESC_ACT = [True, False]
+    SUPPORTS_SYM = [True, False]
+    SUPPORTS_SHARDS = False
+    SUPPORTS_TRAINING = False
+    SUPPORTS_AUTO_PADDING = False
+    SUPPORTS_IN_FEATURES_DIVISIBLE_BY = [64]
+    SUPPORTS_OUT_FEATURES_DIVISIBLE_BY = [64]
+
+    SUPPORTS_DEVICES = [DEVICE.CUDA]
+    SUPPORTS_PLATFORM = [PLATFORM.LINUX]
+    SUPPORTS_PACK_DTYPES = [torch.int32]
+    SUPPORTS_ADAPTERS = [Lora]
+    SUPPORTS_DTYPES = [torch.float16, torch.bfloat16]
+
+    REQUIRES_FORMAT_V2 = True
+
+    QUANT_TYPE = "swordfish"
+
+    TYPE_MAP = {
+        (4, True): scalar_types.uint4b8,
+        (8, True): scalar_types.uint8b128,
+        (4, False): scalar_types.uint4,
+    }
+
+    def __init__(
+        self,
+        bits: int,
+        group_size: int,
+        desc_act: bool,
+        sym: bool,
+        in_features: int,
+        out_features: int,
+        bias: bool = False,
+        pack_dtype: torch.dtype = torch.int32,
+        register_buffers: bool = False,
+        adapter: Adapter = None,
+        format=None,
+        **kwargs,
+    ):
+        if (bits, sym) not in self.TYPE_MAP:
+            raise ValueError(f"Unsupported quantization config: bits={bits}, sym={sym}")
+
+        self.compute_dtype = kwargs.get("dtype") or torch.float16
+
+        super().__init__(
+            bits=bits,
+            group_size=group_size,
+            sym=sym,
+            desc_act=desc_act,
+            in_features=in_features,
+            out_features=out_features,
+            bias=bias,
+            pack_dtype=pack_dtype,
+            backend=kwargs.pop("backend", BACKEND.GPTQ_SWORDFISH),
+            adapter=adapter,
+            register_buffers=False,
+            format=format,
+            **kwargs,
+        )
+
+        # Pre-allocate checkpoint-compatible GPTQ buffer shapes so that
+        # `from_quantized` loading and manual `pack` both write to the same
+        # fields.  post_init() repacks qweight into the Swordfish ABI.
+        self.register_parameter(
+            "qweight",
+            torch.nn.Parameter(
+                torch.empty(
+                    (self.in_features // self.pack_factor, self.out_features),
+                    dtype=self.pack_dtype,
+                ),
+                requires_grad=False,
+            ),
+        )
+
+        self.register_parameter(
+            "g_idx",
+            torch.nn.Parameter(
+                torch.empty(self.in_features, dtype=torch.int32),
+                requires_grad=False,
+            ),
+        )
+
+        grouped_rows = math.ceil(self.in_features / self.group_size)
+        self.register_parameter(
+            "scales",
+            torch.nn.Parameter(
+                torch.empty(
+                    (grouped_rows, self.out_features),
+                    dtype=self.compute_dtype,
+                ),
+                requires_grad=False,
+            ),
+        )
+
+        self.register_parameter(
+            "qzeros",
+            torch.nn.Parameter(
+                torch.empty(
+                    (grouped_rows, self.out_features // self.pack_factor),
+                    dtype=self.pack_dtype,
+                ),
+                requires_grad=False,
+            ),
+        )
+
+        if bias:
+            self.register_buffer(
+                "bias",
+                torch.zeros((self.out_features,), dtype=self.compute_dtype),
+            )
+        else:
+            self.bias = None
+
+        self.weight_type = self.TYPE_MAP[(self.bits, self.sym)]
+        self.has_zero_points = False
+
+        self.register_buffer("input_perm", torch.empty(0, dtype=torch.int32))
+
+    @classmethod
+    def validate_once(cls) -> Tuple[bool, Optional[Exception]]:
+        if not swordfish_runtime_available():
+            return False, ImportError(swordfish_runtime_error())
+        return True, None
+
+    @classmethod
+    def validate(cls, **args) -> Tuple[bool, Optional[Exception]]:
+        ok, err = super().validate(**args)
+        if not ok:
+            return ok, err
+
+        in_features = args.get("in_features")
+        out_features = args.get("out_features")
+        if in_features is not None and out_features is not None:
+            supported, reason = check_swordfish_supports_shape(in_features, out_features)
+            if not supported:
+                return False, ValueError(reason)
+
+        bits = args.get("bits")
+        sym = args.get("sym", True)
+        desc_act = args.get("desc_act", False)
+        if bits == 8 and desc_act:
+            return False, ValueError("Swordfish 8-bit weights do not support activation reordering (desc_act).")
+        if bits == 8 and not sym:
+            return False, ValueError("Swordfish 8-bit weights do not support zero points (sym=False).")
+
+        quant_type = cls.TYPE_MAP.get((bits, sym))
+        if quant_type is None:
+            return False, ValueError(f"Swordfish does not support bits={bits}, sym={sym}")
+        if quant_type not in query_swordfish_supported_quant_types(zero_points=not sym):
+            return False, ValueError(f"Swordfish does not support bits={bits}, sym={sym}")
+
+        group_size = args.get("group_size")
+        dtype = args.get("dtype") or torch.float16
+        if group_size not in query_swordfish_supported_group_sizes(dtype):
+            return False, ValueError(
+                f"Swordfish does not support group_size={group_size} for dtype={dtype}"
+            )
+
+        if in_features is not None and group_size is not None and group_size != -1:
+            if in_features % group_size != 0 or group_size % 32 != 0:
+                return False, ValueError(
+                    f"Swordfish requires in_features % group_size == 0 and group_size % 32 == 0, "
+                    f"got in_features={in_features}, group_size={group_size}"
+                )
+
+        return True, None
+
+    @classmethod
+    def validate_device(cls, device: DEVICE):
+        super().validate_device(device)
+        if device == DEVICE.CUDA:
+            if IS_ROCM:
+                raise NotImplementedError("Swordfish kernel is not supported on ROCm.")
+            if not _validate_swordfish_device_support():
+                raise NotImplementedError(swordfish_runtime_error())
+
+    def post_init(self):
+        device = self.qweight.device
+
+        perm = None
+        if self.desc_act:
+            perm = torch.argsort(self.g_idx).to(torch.int32)
+            # g_idx is not needed at runtime once the permutation is folded
+            # into the packed weight.
+            replace_parameter(
+                self,
+                "g_idx",
+                torch.nn.Parameter(
+                    torch.empty(0, dtype=torch.int32, device=device),
+                    requires_grad=False,
+                ),
+            )
+
+        prepacked = swordfish_prepack_B(
+            self.qweight.data,
+            self.in_features,
+            self.out_features,
+            num_bits=self.bits,
+            perm=perm,
+        )
+        replace_parameter(
+            self,
+            "qweight",
+            torch.nn.Parameter(prepacked.contiguous(), requires_grad=False),
+        )
+
+        scales = self.scales.data.contiguous()
+        if scales.dtype != self.compute_dtype:
+            scales = scales.to(self.compute_dtype)
+        replace_parameter(
+            self,
+            "scales",
+            torch.nn.Parameter(scales, requires_grad=False),
+        )
+
+        if self.sym:
+            replace_parameter(
+                self,
+                "qzeros",
+                torch.nn.Parameter(
+                    torch.empty(0, dtype=self.pack_dtype, device=device),
+                    requires_grad=False,
+                ),
+            )
+            self.has_zero_points = False
+        else:
+            # AWQ-style zero points: fold (half_range - zp) * scale into fp group tensor.
+            from ...utils.machete import unpack_quantized_values_into_int32
+
+            half_range = float(1 << (self.bits - 1))
+            qzeros_unpacked = unpack_quantized_values_into_int32(
+                self.qzeros.data,
+                self.weight_type,
+                packed_dim=1,
+            )
+            qzeros_fp = ((half_range - qzeros_unpacked.to(scales.dtype)) * scales).contiguous()
+            replace_parameter(
+                self,
+                "qzeros",
+                torch.nn.Parameter(qzeros_fp, requires_grad=False),
+            )
+            self.has_zero_points = True
+
+        # Store the permutation for activation reordering in forward().
+        if perm is not None:
+            self.input_perm = perm.to(device=device)
+        else:
+            self.input_perm = torch.empty(0, dtype=torch.int32, device=device)
+
+        if self.bias is not None:
+            self.bias = self.bias.to(device=device, dtype=self.compute_dtype)
+
+        super().post_init()
+
+    def list_buffers(self) -> List:
+        buf = super().list_buffers()
+        if hasattr(self, "input_perm") and self.input_perm is not None:
+            buf.append(self.input_perm)
+        return buf
+
+    def forward(self, x: torch.Tensor):
+        if x.shape[0] == 0:
+            result = torch.empty(x.shape[:-1] + (self.out_features,), dtype=x.dtype, device=x.device)
+            if self.adapter is not None:
+                result = self.adapter.apply(x=x, out=result)
+            return result
+
+        input_2d = x.reshape(-1, x.shape[-1])
+
+        if self.input_perm.numel() > 0:
+            perm = self.input_perm
+            if perm.device != input_2d.device:
+                perm = perm.to(device=input_2d.device)
+            input_2d = input_2d[:, perm]
+
+        group_scales = self.scales
+        if group_scales.dtype != input_2d.dtype:
+            group_scales = group_scales.to(dtype=input_2d.dtype)
+
+        if self.has_zero_points:
+            assert self.qzeros is not None and self.qzeros.numel() > 0, (
+                "Asymmetric SwordfishLinear requires non-empty qzeros after post_init()."
+            )
+            group_zeros = self.qzeros
+            if group_zeros.dtype != input_2d.dtype:
+                group_zeros = group_zeros.to(dtype=input_2d.dtype)
+        else:
+            group_zeros = None
+
+        # Swordfish expects -1 for channelwise/per-output-channel; the base
+        # class stores that as in_features for its own shape bookkeeping.
+        kernel_group_size = -1 if self.requested_group_size == -1 else self.group_size
+        output = swordfish_mm(
+            a=input_2d,
+            b_packed=self.qweight,
+            group_scales=group_scales,
+            group_size=kernel_group_size,
+            size_k=self.in_features,
+            size_n=self.out_features,
+            group_zps=group_zeros,
+            num_bits=self.bits,
+        )
+
+        if self.bias is not None:
+            output.add_(self.bias.to(dtype=output.dtype))
+
+        result = output.reshape(x.shape[:-1] + (self.out_features,))
+        if self.adapter is not None:
+            result = self.adapter.apply(x=x, out=result)
+
+        return result
+
+
+def _unpack_cols_torch(
+    packed_q_w: torch.Tensor,
+    num_bits: int,
+    size_k: int,
+    size_n: int,
+) -> torch.Tensor:
+    """GPU-friendly unpacking of int32-packed quantized weights into columns."""
+    pack_factor = 32 // num_bits
+    assert size_n % pack_factor == 0, f"size_n={size_n} not divisible by pack_factor={pack_factor}"
+    assert packed_q_w.shape == (
+        size_k,
+        size_n // pack_factor,
+    ), f"packed_q_w.shape={packed_q_w.shape} != ({size_k}, {size_n // pack_factor})"
+
+    mask = (1 << num_bits) - 1
+    q_res = torch.zeros((size_k, size_n), dtype=torch.int32, device=packed_q_w.device)
+    for i in range(pack_factor):
+        vals = (packed_q_w & mask).to(torch.int32)
+        q_res[:, i::pack_factor] = vals
+        packed_q_w = packed_q_w >> num_bits
+
+    return q_res.contiguous()
+
+
+def _undo_awq_interleave(values: torch.Tensor, num_bits: int) -> torch.Tensor:
+    if num_bits == 4:
+        undo_interleave = [0, 4, 1, 5, 2, 6, 3, 7]
+    elif num_bits == 8:
+        undo_interleave = [0, 2, 1, 3]
+    else:
+        raise ValueError(f"Unsupported AWQ num_bits={num_bits}")
+
+    return (
+        values.reshape(-1, len(undo_interleave))[:, undo_interleave]
+        .reshape(values.shape)
+        .contiguous()
+    )
+
+
+class AwqSwordfishLinear(AWQuantLinear):
+    SUPPORTS_BACKENDS = [BACKEND.AWQ_SWORDFISH]
+    SUPPORTS_METHODS = [METHOD.AWQ]
+    SUPPORTS_FORMATS = {FORMAT.GEMM: 95}
+    SUPPORTS_BITS = [4]
+    SUPPORTS_GROUP_SIZE = [-1, 32, 64, 128]
+    SUPPORTS_DESC_ACT = [False]
+    SUPPORTS_SYM = [False]
+    SUPPORTS_SHARDS = False
+    SUPPORTS_TRAINING = False
+    SUPPORTS_AUTO_PADDING = False
+    SUPPORTS_IN_FEATURES_DIVISIBLE_BY = [64]
+    SUPPORTS_OUT_FEATURES_DIVISIBLE_BY = [64]
+
+    SUPPORTS_DEVICES = [DEVICE.CUDA]
+    SUPPORTS_PLATFORM = [PLATFORM.LINUX]
+    SUPPORTS_PACK_DTYPES = [torch.int32]
+    SUPPORTS_ADAPTERS = [Lora]
+    SUPPORTS_DTYPES = [torch.float16, torch.bfloat16]
+
+    REQUIRES_FORMAT_V2 = False
+
+    QUANT_TYPE = "awq_swordfish"
+
+    TYPE_MAP = {
+        4: scalar_types.uint4,
+    }
+
+    def __init__(
+        self,
+        bits: int,
+        group_size: int,
+        desc_act: bool,
+        sym: bool,
+        in_features: int,
+        out_features: int,
+        bias: bool = False,
+        pack_dtype: torch.dtype = torch.int32,
+        adapter: Adapter = None,
+        register_buffers: bool = False,
+        **kwargs,
+    ):
+        if bits not in self.TYPE_MAP:
+            raise ValueError(f"Unsupported num_bits = {bits}. Supported: {list(self.TYPE_MAP.keys())}")
+
+        self.compute_dtype = kwargs.get("dtype") or torch.float16
+
+        super().__init__(
+            bits=bits,
+            group_size=group_size,
+            sym=sym,
+            desc_act=desc_act,
+            in_features=in_features,
+            out_features=out_features,
+            bias=bias,
+            pack_dtype=pack_dtype,
+            backend=kwargs.pop("backend", BACKEND.AWQ_SWORDFISH),
+            adapter=adapter,
+            register_buffers=False,
+            **kwargs,
+        )
+
+        pack_factor = self.pack_dtype_bits // self.bits
+
+        self.register_parameter(
+            "qweight",
+            torch.nn.Parameter(
+                torch.empty(
+                    (self.in_features, self.out_features // pack_factor),
+                    dtype=self.pack_dtype,
+                ),
+                requires_grad=False,
+            ),
+        )
+
+        effective_group_size = self.in_features if self.requested_group_size == -1 else self.group_size
+        grouped_rows = math.ceil(self.in_features / effective_group_size)
+        self.register_parameter(
+            "scales",
+            torch.nn.Parameter(
+                torch.empty(
+                    (grouped_rows, self.out_features),
+                    dtype=self.compute_dtype,
+                ),
+                requires_grad=False,
+            ),
+        )
+
+        self.register_parameter(
+            "qzeros",
+            torch.nn.Parameter(
+                torch.empty(
+                    (grouped_rows, self.out_features // pack_factor),
+                    dtype=self.pack_dtype,
+                ),
+                requires_grad=False,
+            ),
+        )
+
+        if bias:
+            self.register_buffer(
+                "bias",
+                torch.zeros((self.out_features,), dtype=self.compute_dtype),
+            )
+        else:
+            self.bias = None
+
+        self.weight_type = self.TYPE_MAP[self.bits]
+        self.has_zero_points = True
+
+        self.register_buffer("input_perm", torch.empty(0, dtype=torch.int32))
+
+    @classmethod
+    def validate_once(cls) -> Tuple[bool, Optional[Exception]]:
+        if not swordfish_runtime_available():
+            return False, ImportError(swordfish_runtime_error())
+        return True, None
+
+    @classmethod
+    def validate(cls, **args) -> Tuple[bool, Optional[Exception]]:
+        ok, err = super().validate(**args)
+        if not ok:
+            return ok, err
+
+        in_features = args.get("in_features")
+        out_features = args.get("out_features")
+        if in_features is not None and out_features is not None:
+            supported, reason = check_swordfish_supports_shape(in_features, out_features)
+            if not supported:
+                return False, ValueError(reason)
+
+        bits = args.get("bits")
+        sym = args.get("sym", True)
+        if bits not in cls.TYPE_MAP:
+            return False, ValueError(f"AwqSwordfishLinear does not support bits={bits}")
+        if sym:
+            return False, ValueError("AwqSwordfishLinear requires sym=False for AWQ zero points")
+
+        quant_type = cls.TYPE_MAP[bits]
+        if quant_type not in query_swordfish_supported_quant_types(zero_points=True):
+            return False, ValueError(f"Swordfish does not support AWQ {bits}-bit weights with zero points")
+
+        group_size = args.get("group_size")
+        dtype = args.get("dtype") or torch.float16
+        if group_size not in query_swordfish_supported_group_sizes(dtype):
+            return False, ValueError(
+                f"Swordfish does not support group_size={group_size} for dtype={dtype}"
+            )
+
+        if in_features is not None and group_size is not None and group_size != -1:
+            if in_features % group_size != 0 or group_size % 32 != 0:
+                return False, ValueError(
+                    f"AwqSwordfishLinear requires in_features % group_size == 0 and group_size % 32 == 0, "
+                    f"got in_features={in_features}, group_size={group_size}"
+                )
+
+        return True, None
+
+    @classmethod
+    def validate_device(cls, device: DEVICE):
+        super().validate_device(device)
+        if device == DEVICE.CUDA:
+            if IS_ROCM:
+                raise NotImplementedError("Swordfish kernel is not supported on ROCm.")
+            if not _validate_swordfish_device_support():
+                raise NotImplementedError(swordfish_runtime_error())
+
+    def post_init(self):
+        device = self.qweight.device
+
+        # Convert AWQ-interleaved packed weights to GPTQ/Marlin layout.
+        qweight_int = _unpack_cols_torch(
+            self.qweight,
+            self.bits,
+            self.in_features,
+            self.out_features,
+        )
+        qweight_int = _undo_awq_interleave(qweight_int, self.bits)
+
+        # Repack the AWQ-unpacked integer weights into the GPTQ row-major
+        # layout expected by gptq_marlin_repack inside swordfish_prepack_B.
+        pack_factor = 32 // self.bits
+        qweight_int = qweight_int.view(
+            self.in_features // 32, 32 // pack_factor, pack_factor, self.out_features
+        )
+        shifts = torch.arange(
+            0, 32, self.bits, dtype=torch.int32, device=qweight_int.device
+        )
+        packed = (qweight_int << shifts.view(1, 1, pack_factor, 1)).sum(dim=2, dtype=torch.int32)
+        packed = packed.view(self.in_features // pack_factor, self.out_features).contiguous()
+
+        prepacked = swordfish_prepack_B(
+            packed,
+            self.in_features,
+            self.out_features,
+            num_bits=self.bits,
+            perm=None,
+        )
+        replace_parameter(
+            self,
+            "qweight",
+            torch.nn.Parameter(prepacked.contiguous(), requires_grad=False),
+        )
+
+        scales = self.scales.data.contiguous()
+        if scales.dtype != self.compute_dtype:
+            scales = scales.to(self.compute_dtype)
+        replace_parameter(
+            self,
+            "scales",
+            torch.nn.Parameter(scales, requires_grad=False),
+        )
+
+        effective_group_size = self.in_features if self.requested_group_size == -1 else self.group_size
+        num_groups = self.in_features // effective_group_size
+
+        qzeros_unpacked = _unpack_cols_torch(
+            self.qzeros,
+            self.bits,
+            num_groups,
+            self.out_features,
+        )
+        qzeros_unpacked = _undo_awq_interleave(qzeros_unpacked, self.bits)
+
+        half_range = float(1 << (self.bits - 1))
+        qzeros_fp = ((half_range - qzeros_unpacked.to(scales.dtype)) * scales).contiguous()
+        replace_parameter(
+            self,
+            "qzeros",
+            torch.nn.Parameter(qzeros_fp, requires_grad=False),
+        )
+
+        self.input_perm = torch.empty(0, dtype=torch.int32, device=device)
+
+        if self.bias is not None:
+            self.bias = self.bias.to(device=device, dtype=self.compute_dtype)
+
+        super().post_init()
+
+    def list_buffers(self) -> List:
+        buf = super().list_buffers()
+        if hasattr(self, "input_perm") and self.input_perm is not None:
+            buf.append(self.input_perm)
+        return buf
+
+    def forward(self, x: torch.Tensor):
+        if x.shape[0] == 0:
+            result = torch.empty(x.shape[:-1] + (self.out_features,), dtype=x.dtype, device=x.device)
+            if self.adapter is not None:
+                result = self.adapter.apply(x=x, out=result)
+            return result
+
+        input_2d = x.reshape(-1, x.shape[-1])
+
+        group_scales = self.scales
+        if group_scales.dtype != input_2d.dtype:
+            group_scales = group_scales.to(dtype=input_2d.dtype)
+
+        group_zeros = self.qzeros
+        if group_zeros.dtype != input_2d.dtype:
+            group_zeros = group_zeros.to(dtype=input_2d.dtype)
+
+        kernel_group_size = -1 if self.requested_group_size == -1 else self.group_size
+        output = swordfish_mm(
+            a=input_2d,
+            b_packed=self.qweight,
+            group_scales=group_scales,
+            group_size=kernel_group_size,
+            size_k=self.in_features,
+            size_n=self.out_features,
+            group_zps=group_zeros,
+            num_bits=self.bits,
+        )
+
+        if self.bias is not None:
+            output.add_(self.bias.to(dtype=output.dtype))
+
+        result = output.reshape(x.shape[:-1] + (self.out_features,))
+        if self.adapter is not None:
+            result = self.adapter.apply(x=x, out=result)
+
+        return result
+
+
+__all__ = ["SwordfishLinear", "AwqSwordfishLinear"]

--- a/gptqmodel/utils/backend.py
+++ b/gptqmodel/utils/backend.py
@@ -19,6 +19,7 @@ class BACKEND(str, Enum):
     BITSANDBYTES = "bitsandbytes"  # bitsandbytes 4-bit/8-bit kernel with optional CPU/CUDA support
     GPTQ_EXLLAMA_V2 = "gptq_exllama_v2"  # FASTER: optimized for batching > 1
     GPTQ_MACHETE = "gptq_machete"  # CUTLASS-based kernel optimized for Hopper (SM90+)
+    GPTQ_SWORDFISH = "gptq_swordfish"  # Blackwell (sm100/sm110) w4a16/w8a16 GEMM kernel
     GPTQ_MARLIN = "gptq_marlin"  # marlin reduce ops, fp32 by default; controlled by GPTQMODEL_MARLIN_USE_FP32
     GPTQ_BITBLAS = "gptq_bitblas"  # BitBLAS AOT-compiled GPTQ kernel
     GPTQ_TORCH_ATEN = "gptq_torch_aten"  # CPU int4pack ATen kernel folded into GPT-QModel
@@ -39,6 +40,7 @@ class BACKEND(str, Enum):
     AWQ_BITBLAS = "awq_bitblas"
     AWQ_MACHETE = "awq_machete"
     AWQ_MARLIN = "awq_marlin"
+    AWQ_SWORDFISH = "awq_swordfish"
     AWQ_EXLLAMA_V2 = "awq_exllama_v2"
 
     # ParoQuant kernels
@@ -71,6 +73,7 @@ class BACKEND(str, Enum):
     EXLLAMA_V2 = "exllama_v2"
     EXLLAMA_V3 = "exllama_v3"
     MACHETE = "machete"
+    SWORDFISH = "swordfish"
     MARLIN = "marlin"
     BITBLAS = "bitblas"
     GEMM = "gemm"
@@ -99,6 +102,7 @@ _LEGACY_BACKEND_BY_METHOD = {
         BACKEND.TRITON: BACKEND.GPTQ_TRITON,
         BACKEND.EXLLAMA_V2: BACKEND.GPTQ_EXLLAMA_V2,
         BACKEND.MACHETE: BACKEND.GPTQ_MACHETE,
+        BACKEND.SWORDFISH: BACKEND.GPTQ_SWORDFISH,
         BACKEND.MARLIN: BACKEND.GPTQ_MARLIN,
         BACKEND.BITBLAS: BACKEND.GPTQ_BITBLAS,
     },
@@ -117,6 +121,7 @@ _LEGACY_BACKEND_BY_METHOD = {
         BACKEND.BITBLAS_AWQ: BACKEND.AWQ_BITBLAS,
         BACKEND.MACHETE: BACKEND.AWQ_MACHETE,
         BACKEND.MARLIN: BACKEND.AWQ_MARLIN,
+        BACKEND.SWORDFISH: BACKEND.AWQ_SWORDFISH,
         BACKEND.EXLLAMA_V2: BACKEND.AWQ_EXLLAMA_V2,
     },
     "paroquant": {

--- a/gptqmodel/utils/cpp.py
+++ b/gptqmodel/utils/cpp.py
@@ -77,7 +77,24 @@ def _log_cache_clear_callsite(*, reason: str, target_path: str | Path) -> None:
 
 
 def _nvcc_path() -> Optional[str]:
-    return shutil.which("nvcc")
+    path = shutil.which("nvcc")
+    if path:
+        return path
+    # Prefer the CUDA toolkit that PyTorch will use for compilation.
+    if CUDA_HOME:
+        candidate = os.path.join(CUDA_HOME, "bin", "nvcc")
+        if os.path.isfile(candidate):
+            return candidate
+    for env in ("CUDA_HOME", "CUDAHOME"):
+        home = os.environ.get(env)
+        if home:
+            candidate = os.path.join(home, "bin", "nvcc")
+            if os.path.isfile(candidate):
+                return candidate
+    candidate = "/usr/local/cuda/bin/nvcc"
+    if os.path.isfile(candidate):
+        return candidate
+    return None
 
 
 def _nvcc_text(*args: str) -> str:

--- a/gptqmodel/utils/importer.py
+++ b/gptqmodel/utils/importer.py
@@ -508,6 +508,7 @@ def select_quant_linear(
         dtype: Optional[torch.dtype] = None,
         multi_select: bool = False, # return all valid kernels
         adapter: Optional[Adapter] = None,
+        is_sharded: bool = False,
 ) -> Union[Type[BaseQuantLinear], List[Type[BaseQuantLinear]]]:
     if isinstance(format, str):
         format = FORMAT(format.lower())
@@ -552,6 +553,10 @@ def select_quant_linear(
             if DEVICE.ALL not in cls.SUPPORTS_DEVICES and device is not None and device not in cls.SUPPORTS_DEVICES:
                 if os.environ.get("DEBUG"):
                     log.info(f"skip {k} for unsupported device `{device}`")
+                continue
+            if is_sharded and not cls.SUPPORTS_SHARDS:
+                if os.environ.get("DEBUG"):
+                    log.info(f"skip {k} because sharded checkpoints are not supported")
                 continue
 
             validated = False
@@ -616,6 +621,9 @@ def select_quant_linear(
 
     # Handle the case where backend is not AUTO.
     qlinear = get_kernel_for_backend(backend, quant_method, format)
+
+    if is_sharded and not qlinear.SUPPORTS_SHARDS:
+        raise ValueError(f"Selected backend `{backend}` with kernel `{qlinear.__name__}` does not support sharded checkpoints.")
 
     validate, err = qlinear.validate(
         bits=bits,

--- a/gptqmodel/utils/jit_compile_baselines.py
+++ b/gptqmodel/utils/jit_compile_baselines.py
@@ -25,6 +25,7 @@ JIT_COMPILE_BASELINE_SECONDS: dict[str, float] = {
     "gptqmodel_pack_block_cpu": 31.096,
     "gptqmodel_paroquant_rotation": 78.430,
     "gptqmodel_qqq_ops": 82.492,
+    "gptqmodel_swordfish_ops": 180.000,
 }
 
 

--- a/gptqmodel/utils/machete.py
+++ b/gptqmodel/utils/machete.py
@@ -439,8 +439,9 @@ def _machete_static_runtime_error() -> str:
     if capability != _MACHETE_REQUIRED_COMPUTE_CAPABILITY:
         props = torch.cuda.get_device_properties(torch.cuda.current_device())
         return (
-            "Machete kernel currently supports Hopper-class SM90 GPUs only; "
-            f"found `{props.name}` with compute capability {capability[0]}.{capability[1]}."
+            "Machete kernel is Hopper-only (SM90); its generated CUTLASS kernels "
+            f"target arch::Sm90 and have no Blackwell image. Found `{props.name}` with "
+            f"compute capability {capability[0]}.{capability[1]}."
         )
     props = torch.cuda.get_device_properties(torch.cuda.current_device())
     shared_memory_per_block_optin = getattr(

--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -406,6 +406,7 @@ def make_quant(
     device: DEVICE = None,
     from_quantized: bool = False,
     dtype: Optional[torch.dtype] = None,
+    is_sharded: bool = False,
 ) -> Type[BaseQuantLinear]:
 
     bits = qcfg.runtime_bits
@@ -444,6 +445,7 @@ def make_quant(
         dtype=dtype,
         multi_select=True,
         adapter=extension,
+        is_sharded=is_sharded,
     )
 
     log.info(f"Kernel: candidates -> `[{', '.join(cls.__name__ for cls in quant_linear_candidates)}]`")

--- a/gptqmodel/utils/swordfish.py
+++ b/gptqmodel/utils/swordfish.py
@@ -1,0 +1,392 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+"""Swordfish Blackwell (sm100/sm110) weight-quantized GEMM extension loader.
+
+Swordfish is vendored into gptqmodel_ext/swordfish under the GNU AGPL v3.0+
+(see that directory's LICENSE and the top-level licenses/SWORDFISH).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import torch
+
+from .cpp import (
+    TorchOpsJitExtension,
+    cuda_include_paths_with_fallback,
+    default_jit_cflags,
+    default_jit_cuda_cflags,
+    default_torch_ops_build_root,
+)
+from .logger import setup_logger
+from .marlin_scalar_type import ScalarType, scalar_types
+from .machete import _ensure_cutlass_source
+from .rocm import IS_ROCM
+
+log = setup_logger()
+
+_SWORDFISH_OPS_NAME = "gptqmodel_swordfish_ops"
+_SWORDFISH_OPS_NAMESPACE = "gptqmodel_swordfish"
+
+_SWORDFISH_MIN_REQUIRED_COMPUTE_CAPABILITY: Tuple[int, int] = (10, 0)
+_SWORDFISH_MAX_SUPPORTED_COMPUTE_CAPABILITY: Tuple[int, int] = (11, 0)
+
+_SWORDFISH_ARCH_FLAGS = (
+    # Blackwell TMA/tcgen05 features require the "a" (all) architecture suffix.
+    # The B300 in this environment reports compute capability 10.3 (sm_103a).
+    # Emit native cubins for the common Blackwell datacenter variants plus a
+    # forward-compatible PTX fallback.
+    "-gencode=arch=compute_100a,code=sm_100a",
+    "-gencode=arch=compute_103a,code=sm_103a",
+    "-gencode=arch=compute_110a,code=sm_110a",
+    "-gencode=arch=compute_103a,code=compute_103a",
+)
+
+_SWORDFISH_JIT_NVCC_THREADS = "16"
+
+_SWORDFISH_REQUIRED_TORCH_NVCC_UNDEFINES = (
+    "-U__CUDA_NO_HALF_OPERATORS__",
+    "-U__CUDA_NO_HALF_CONVERSIONS__",
+    "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+)
+
+_SWORDFISH_REQUIRED_CUDA_HEADERS = (
+    "cuda_runtime_api.h",
+    "cublas_v2.h",
+    "cublasLt.h",
+    "cusolverDn.h",
+)
+
+SWORDFISH_PREPACKED_BLOCK_SHAPE = (64, 64)
+
+
+def _swordfish_project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _swordfish_source_root() -> Path:
+    return _swordfish_project_root() / "gptqmodel_ext" / "swordfish"
+
+
+def _swordfish_sources() -> List[str]:
+    root = _swordfish_source_root()
+    return [
+        str(root / "swordfish_bindings.cpp"),
+        str(root / "libtorch_stable" / "quantization" / "marlin" / "gptq_marlin_repack.cu"),
+        str(root / "libtorch_stable" / "quantization" / "swordfish" / "swordfish_prepack.cu"),
+        str(root / "libtorch_stable" / "quantization" / "swordfish" / "swordfish_mm.cu"),
+        str(root / "libtorch_stable" / "quantization" / "swordfish" / "swordfish_dense_tier.cu"),
+        str(root / "libtorch_stable" / "quantization" / "swordfish" / "swordfish_prefill.cu"),
+        str(root / "libtorch_stable" / "quantization" / "swordfish" / "swordfish_prefill_f16.cu"),
+        str(root / "libtorch_stable" / "quantization" / "swordfish" / "swordfish_moe.cu"),
+    ]
+
+
+def _swordfish_include_paths() -> List[str]:
+    cutlass_root = _ensure_cutlass_source()
+    include_paths = [
+        str(_swordfish_source_root().resolve()),
+        str((cutlass_root / "include").resolve()),
+        str((cutlass_root / "tools" / "library" / "include").resolve()),
+        str((cutlass_root / "examples" / "common" / "include").resolve()),
+        str((cutlass_root / "tools" / "util" / "include").resolve()),
+    ]
+    # Only keep existing directories.
+    include_paths = [p for p in include_paths if Path(p).is_dir()]
+    return cuda_include_paths_with_fallback(
+        include_paths,
+        required_header_names=_SWORDFISH_REQUIRED_CUDA_HEADERS,
+    )
+
+
+def _swordfish_extra_cflags() -> List[str]:
+    return default_jit_cflags(enable_bf16=True)
+
+
+def _swordfish_extra_cuda_cflags() -> List[str]:
+    if _swordfish_static_runtime_error():
+        return []
+
+    # Only emit the sm100f/sm110f family gencodes when the local host could
+    # plausibly build them (CUDA 13+). The kernel targets these fixed Blackwell
+    # variants, so we do not merge a user-provided TORCH_CUDA_ARCH_LIST here.
+    arch_flags: Tuple[str, ...] = _SWORDFISH_ARCH_FLAGS
+
+    return [
+        "-DUSE_CUDA",
+        # CUTLASS 4.4 does not set CUDA_ARCH_FAMILY(1000) for the sm_100f
+        # target on all nvcc builds, which leaves TMA/tcgen05 feature macros
+        # disabled. Force-include an arch-macro shim that enables the family
+        # macros only in the device-code pass (__CUDA_ARCH__ is not defined
+        # during host compilation, so host-side paths keep their stubs).
+        "-include",
+        str(_swordfish_source_root() / "swordfish_arch_macros.cuh"),
+        *_SWORDFISH_REQUIRED_TORCH_NVCC_UNDEFINES,
+        *default_jit_cuda_cflags(
+            enable_bf16=True,
+            include_lineinfo=True,
+            include_nvcc_threads=True,
+            include_ptxas_optimizations=True,
+            include_ptxas_verbosity=False,
+            include_fatbin_compression=True,
+            include_diag_suppress=True,
+            nvcc_threads=_SWORDFISH_JIT_NVCC_THREADS,
+        ),
+        *arch_flags,
+    ]
+
+
+def _swordfish_extra_ldflags() -> List[str]:
+    return ["-lcuda", "-lcublas", "-lcublasLt"]
+
+
+_SWORDFISH_TORCH_OPS_EXTENSION = TorchOpsJitExtension(
+    name=_SWORDFISH_OPS_NAME,
+    namespace=_SWORDFISH_OPS_NAMESPACE,
+    required_ops=(
+        "swordfish_prepack_B",
+        "swordfish_mm",
+        "swordfish_dequant_dense",
+        "swordfish_moe_mm",
+        "swordfish_prefill_mm",
+    ),
+    sources=_swordfish_sources,
+    build_root_env="GPTQMODEL_SWORDFISH_BUILD_ROOT",
+    default_build_root=lambda: default_torch_ops_build_root("swordfish"),
+    display_name="Swordfish",
+    extra_cflags=_swordfish_extra_cflags,
+    extra_cuda_cflags=_swordfish_extra_cuda_cflags,
+    extra_include_paths=_swordfish_include_paths,
+    extra_ldflags=_swordfish_extra_ldflags,
+    force_rebuild_env="GPTQMODEL_SWORDFISH_FORCE_REBUILD",
+    verbose_env="GPTQMODEL_EXT_VERBOSE",
+    requires_cuda=True,
+    # The kernel targets sm100f/sm110f family; do not let PyTorch merge the
+    # visible sm103 capability into the arch list and drop the family flag.
+    merge_visible_cuda_arch_override=False,
+)
+
+
+def _extension_api():
+    from gptqmodel import extension as extension_api
+
+    return extension_api
+
+
+def _swordfish_static_runtime_error() -> str:
+    if IS_ROCM:
+        return "Swordfish kernel is not supported on ROCm."
+    if not torch.cuda.is_available():
+        return "Swordfish kernel requires CUDA."
+    major, minor = torch.cuda.get_device_capability()
+    if major < _SWORDFISH_MIN_REQUIRED_COMPUTE_CAPABILITY[0]:
+        return (
+            f"Swordfish kernel requires Blackwell (sm100+) GPUs; "
+            f"found compute capability {major}.{minor}."
+        )
+    if (
+        major > _SWORDFISH_MAX_SUPPORTED_COMPUTE_CAPABILITY[0]
+        or major == _SWORDFISH_MAX_SUPPORTED_COMPUTE_CAPABILITY[0]
+        and minor > _SWORDFISH_MAX_SUPPORTED_COMPUTE_CAPABILITY[1]
+    ):
+        return (
+            f"Swordfish kernel currently supports datacenter Blackwell "
+            f"(sm100/sm110) only; found compute capability {major}.{minor}."
+        )
+    return ""
+
+
+def _validate_swordfish_device_support() -> bool:
+    return _swordfish_static_runtime_error() == ""
+
+
+def swordfish_runtime_available() -> bool:
+    static_error = _swordfish_static_runtime_error()
+    if static_error:
+        return False
+    return _extension_api().is_available("swordfish")
+
+
+def swordfish_runtime_error() -> str:
+    static_error = _swordfish_static_runtime_error()
+    if static_error:
+        return static_error
+
+    extension_api = _extension_api()
+    if extension_api.is_available("swordfish"):
+        return ""
+    return extension_api.error("swordfish") or "Swordfish runtime unavailable."
+
+
+def clear_swordfish_extension_cache() -> None:
+    _SWORDFISH_TORCH_OPS_EXTENSION.clear_cache()
+
+
+def prewarm_swordfish_extension() -> bool:
+    return _extension_api().load(name="swordfish")["swordfish"]
+
+
+def swordfish_prepack_B(
+    b_q_weight: torch.Tensor,
+    size_k: int,
+    size_n: int,
+    num_bits: int = 4,
+    perm: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    return _extension_api().op("swordfish", "swordfish_prepack_B")(
+        b_q_weight, perm, size_k, size_n, num_bits
+    )
+
+
+def swordfish_mm(
+    a: torch.Tensor,
+    b_packed: torch.Tensor,
+    group_scales: torch.Tensor,
+    group_size: int,
+    size_k: int,
+    size_n: int,
+    group_zps: Optional[torch.Tensor] = None,
+    num_bits: int = 4,
+) -> torch.Tensor:
+    return _extension_api().op("swordfish", "swordfish_mm")(
+        a,
+        b_packed,
+        group_scales,
+        group_zps,
+        num_bits,
+        group_size,
+        size_k,
+        size_n,
+    )
+
+
+def swordfish_dequant_dense(
+    b_packed: torch.Tensor,
+    group_scales: torch.Tensor,
+    group_zps: Optional[torch.Tensor],
+    num_bits: int,
+    group_size: int,
+    size_k: int,
+    size_n: int,
+    transpose: bool = False,
+) -> torch.Tensor:
+    return _extension_api().op("swordfish", "swordfish_dequant_dense")(
+        b_packed,
+        group_scales,
+        group_zps,
+        num_bits,
+        group_size,
+        size_k,
+        size_n,
+        transpose,
+    )
+
+
+def swordfish_moe_mm(
+    a: torch.Tensor,
+    b_packed: torch.Tensor,
+    group_scales: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    topk_weights: Optional[torch.Tensor],
+    moe_block_size: int,
+    top_k: int,
+    mul_topk_weights: bool,
+    num_bits: int,
+    group_size: int,
+    size_k: int,
+    size_n: int,
+) -> torch.Tensor:
+    return _extension_api().op("swordfish", "swordfish_moe_mm")(
+        a,
+        b_packed,
+        group_scales,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        topk_weights,
+        moe_block_size,
+        top_k,
+        mul_topk_weights,
+        num_bits,
+        group_size,
+        size_k,
+        size_n,
+    )
+
+
+def swordfish_prefill_mm(
+    a: torch.Tensor,
+    b_packed: torch.Tensor,
+    group_scales: torch.Tensor,
+    group_size: int,
+    size_k: int,
+    size_n: int,
+    group_zps: Optional[torch.Tensor] = None,
+    num_bits: int = 4,
+) -> torch.Tensor:
+    return _extension_api().op("swordfish", "swordfish_prefill_mm")(
+        a,
+        b_packed,
+        group_scales,
+        group_zps,
+        num_bits,
+        group_size,
+        size_k,
+        size_n,
+    )
+
+
+def query_swordfish_supported_quant_types(zero_points: bool) -> List[ScalarType]:
+    # AWQ-style zero points are only supported for 4-bit weights; the kernel
+    # rejects zero points with 8-bit weights.
+    if zero_points:
+        return [scalar_types.uint4]
+    return [scalar_types.uint4b8, scalar_types.uint8b128]
+
+
+def query_swordfish_supported_act_types(_zero_points: bool) -> List[torch.dtype]:
+    return [torch.float16, torch.bfloat16]
+
+
+def query_swordfish_supported_group_sizes(_act_type: torch.dtype) -> List[int]:
+    return [-1, 32, 64, 128]
+
+
+def check_swordfish_supports_shape(
+    in_features: int,
+    out_features: int,
+) -> tuple[bool, Optional[str]]:
+    if in_features % SWORDFISH_PREPACKED_BLOCK_SHAPE[0] != 0:
+        return (
+            False,
+            f"Input features size must be divisible by {SWORDFISH_PREPACKED_BLOCK_SHAPE[0]}",
+        )
+    if out_features % SWORDFISH_PREPACKED_BLOCK_SHAPE[1] != 0:
+        return (
+            False,
+            f"Output features size must be divisible by {SWORDFISH_PREPACKED_BLOCK_SHAPE[1]}",
+        )
+    return (True, None)
+
+
+__all__ = [
+    "check_swordfish_supports_shape",
+    "clear_swordfish_extension_cache",
+    "prewarm_swordfish_extension",
+    "query_swordfish_supported_act_types",
+    "query_swordfish_supported_group_sizes",
+    "query_swordfish_supported_quant_types",
+    "swordfish_dequant_dense",
+    "swordfish_mm",
+    "swordfish_moe_mm",
+    "swordfish_prepack_B",
+    "swordfish_prefill_mm",
+    "swordfish_runtime_available",
+    "swordfish_runtime_error",
+]

--- a/gptqmodel/utils/swordfish.py
+++ b/gptqmodel/utils/swordfish.py
@@ -10,6 +10,7 @@ Swordfish is vendored into gptqmodel_ext/swordfish under the GNU AGPL v3.0+
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -32,8 +33,7 @@ log = setup_logger()
 _SWORDFISH_OPS_NAME = "gptqmodel_swordfish_ops"
 _SWORDFISH_OPS_NAMESPACE = "gptqmodel_swordfish"
 
-_SWORDFISH_MIN_REQUIRED_COMPUTE_CAPABILITY: Tuple[int, int] = (10, 0)
-_SWORDFISH_MAX_SUPPORTED_COMPUTE_CAPABILITY: Tuple[int, int] = (11, 0)
+_SWORDFISH_GENCODE_SM_RE = re.compile(r"code=sm_(\d+)(?:[a-z])?")
 
 _SWORDFISH_ARCH_FLAGS = (
     # Blackwell TMA/tcgen05 features require the "a" (all) architecture suffix.
@@ -177,25 +177,37 @@ def _extension_api():
     return extension_api
 
 
+def _swordfish_supported_compute_capabilities() -> set[Tuple[int, int]]:
+    """Parse _SWORDFISH_ARCH_FLAGS and return the real SMs with native cubins."""
+    caps: set[Tuple[int, int]] = set()
+    for flag in _SWORDFISH_ARCH_FLAGS:
+        for match in _SWORDFISH_GENCODE_SM_RE.finditer(flag):
+            cap = int(match.group(1))
+            caps.add((cap // 10, cap % 10))
+    if not caps:
+        # Fallback in case the gencode format ever changes unexpectedly.
+        caps = {(10, 0), (10, 3), (11, 0)}
+    return caps
+
+
+_SWORDFISH_SUPPORTED_COMPUTE_CAPABILITIES: set[Tuple[int, int]] = (
+    _swordfish_supported_compute_capabilities()
+)
+
+
 def _swordfish_static_runtime_error() -> str:
     if IS_ROCM:
         return "Swordfish kernel is not supported on ROCm."
     if not torch.cuda.is_available():
         return "Swordfish kernel requires CUDA."
     major, minor = torch.cuda.get_device_capability()
-    if major < _SWORDFISH_MIN_REQUIRED_COMPUTE_CAPABILITY[0]:
-        return (
-            f"Swordfish kernel requires Blackwell (sm100+) GPUs; "
-            f"found compute capability {major}.{minor}."
+    if (major, minor) not in _SWORDFISH_SUPPORTED_COMPUTE_CAPABILITIES:
+        supported = ", ".join(
+            f"sm{mj}{mn}" for mj, mn in sorted(_SWORDFISH_SUPPORTED_COMPUTE_CAPABILITIES)
         )
-    if (
-        major > _SWORDFISH_MAX_SUPPORTED_COMPUTE_CAPABILITY[0]
-        or major == _SWORDFISH_MAX_SUPPORTED_COMPUTE_CAPABILITY[0]
-        and minor > _SWORDFISH_MAX_SUPPORTED_COMPUTE_CAPABILITY[1]
-    ):
         return (
-            f"Swordfish kernel currently supports datacenter Blackwell "
-            f"(sm100/sm110) only; found compute capability {major}.{minor}."
+            f"Swordfish kernel only supports native Blackwell variants "
+            f"({supported}); found compute capability {major}.{minor}."
         )
     return ""
 

--- a/gptqmodel_ext/swordfish/LICENSE
+++ b/gptqmodel_ext/swordfish/LICENSE
@@ -1,0 +1,662 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+
+    Copyright (C) {{ year }}  {{ organization }}
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.

--- a/gptqmodel_ext/swordfish/core/scalar_type.hpp
+++ b/gptqmodel_ext/swordfish/core/scalar_type.hpp
@@ -1,0 +1,368 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <variant>
+
+// For STD_TORCH_CHECK
+#include <torch/headeronly/util/Exception.h>
+
+namespace aphrodite {
+
+//
+//  ScalarType can represent a wide range of floating point and integer types,
+//  in particular it can be used to represent sub-byte data types (something
+//  that torch.dtype currently does not support).
+//
+//  The type definitions on the Python side can be found in:
+//  aphrodite/scalar_type.py these type definitions should be kept up to date
+//  with any Python API changes here.
+//
+class ScalarType {
+ public:
+  enum NanRepr : uint8_t {
+    NAN_NONE = 0,                // nans are not supported
+    NAN_IEEE_754 = 1,            // nans are: exp all 1s, mantissa not all 0s
+    NAN_EXTD_RANGE_MAX_MIN = 2,  // nans are: exp all 1s, mantissa all 1s
+
+    NAN_REPR_ID_MAX
+  };
+
+  constexpr ScalarType(uint8_t exponent, uint8_t mantissa, bool signed_,
+                       int32_t bias, bool finite_values_only = false,
+                       NanRepr nan_repr = NAN_IEEE_754)
+      : exponent(exponent),
+        mantissa(mantissa),
+        signed_(signed_),
+        bias(bias),
+        finite_values_only(finite_values_only),
+        nan_repr(nan_repr) {};
+
+  static constexpr ScalarType int_(uint8_t size_bits, int32_t bias = 0) {
+    return ScalarType(0, size_bits - 1, true, bias);
+  }
+
+  static constexpr ScalarType uint(uint8_t size_bits, int32_t bias = 0) {
+    return ScalarType(0, size_bits, false, bias);
+  }
+
+  // IEEE 754 compliant floating point type
+  static constexpr ScalarType float_IEEE754(uint8_t exponent,
+                                            uint8_t mantissa) {
+    STD_TORCH_CHECK(mantissa > 0 && exponent > 0);
+    return ScalarType(exponent, mantissa, true, 0, false, NAN_IEEE_754);
+  }
+
+  // IEEE 754 non-compliant floating point type
+  static constexpr ScalarType float_(uint8_t exponent, uint8_t mantissa,
+                                     bool finite_values_only,
+                                     NanRepr nan_repr) {
+    STD_TORCH_CHECK(nan_repr < NAN_REPR_ID_MAX, "Invalid NanRepr");
+    STD_TORCH_CHECK(mantissa > 0 && exponent > 0);
+    STD_TORCH_CHECK(
+        nan_repr != NAN_IEEE_754,
+        "use `float_IEEE754` constructor for floating point types that "
+        "follow IEEE 754 conventions");
+    return ScalarType(exponent, mantissa, true, 0, finite_values_only,
+                      nan_repr);
+  }
+
+  uint8_t const exponent;  // size of the exponent field (0 for integer types)
+  uint8_t const mantissa;  // size of the mantissa field (size of the integer
+                           // excluding the sign bit for integer types)
+  bool const signed_;  // flag if the type supports negative numbers (i.e. has a
+                       // sign bit)
+  int32_t const bias;  // stored values equal value + bias,
+                       // used for quantized type
+
+  // Extra Floating point info
+  bool const finite_values_only;  // i.e. no +/-inf if true
+  NanRepr const nan_repr;         // how NaNs are represented
+                                  // (not applicable for integer types)
+
+  using Id = int64_t;
+
+ private:
+  // Field size in id
+  template <typename T_>
+  static constexpr size_t member_id_field_width() {
+    using T = std::decay_t<T_>;
+    return std::is_same_v<T, bool> ? 1 : sizeof(T) * 8;
+  }
+
+  template <typename Fn, typename Init, typename Member, typename... Rest>
+  static constexpr auto reduce_members_helper(Fn f, Init val, Member member,
+                                              Rest... rest) {
+    auto new_val = f(val, member);
+    if constexpr (sizeof...(rest) > 0) {
+      return reduce_members_helper(f, new_val, rest...);
+    } else {
+      return new_val;
+    };
+  }
+
+  template <typename Fn, typename Init>
+  constexpr auto reduce_members(Fn f, Init init) const {
+    // Should be in constructor order for `from_id`
+    return reduce_members_helper(f, init, exponent, mantissa, signed_, bias,
+                                 finite_values_only, nan_repr);
+  };
+
+  template <typename Fn, typename Init>
+  static constexpr auto reduce_member_types(Fn f, Init init) {
+    constexpr auto dummy_type = ScalarType(0, 0, false, 0, false, NAN_NONE);
+    return dummy_type.reduce_members(f, init);
+  };
+
+  static constexpr auto id_size_bits() {
+    return reduce_member_types(
+        [](int acc, auto member) -> int {
+          return acc + member_id_field_width<decltype(member)>();
+        },
+        0);
+  }
+
+ public:
+  // unique id for this scalar type that can be computed at compile time for
+  //  c++17 template specialization this is not needed once we migrate to
+  //  c++20 and can pass literal classes as template parameters
+  constexpr Id id() const {
+    static_assert(id_size_bits() <= sizeof(Id) * 8,
+                  "ScalarType id is too large to be stored");
+
+    auto or_and_advance = [](std::pair<Id, uint32_t> result,
+                             auto member) -> std::pair<Id, uint32_t> {
+      auto [id, bit_offset] = result;
+      auto constexpr bits = member_id_field_width<decltype(member)>();
+      return {id | (int64_t(member) & ((uint64_t(1) << bits) - 1))
+                       << bit_offset,
+              bit_offset + bits};
+    };
+    return reduce_members(or_and_advance, std::pair<Id, uint32_t>{}).first;
+  }
+
+  // create a ScalarType from an id, for c++17 template specialization,
+  //  this is not needed once we migrate to c++20 and can pass literal
+  //  classes as template parameters
+  static constexpr ScalarType from_id(Id id) {
+    auto extract_and_advance = [id](auto result, auto member) {
+      using T = decltype(member);
+      auto [tuple, bit_offset] = result;
+      auto constexpr bits = member_id_field_width<T>();
+      auto extracted_val = static_cast<T>((int64_t(id) >> bit_offset) &
+                                          ((uint64_t(1) << bits) - 1));
+      auto new_tuple = std::tuple_cat(tuple, std::make_tuple(extracted_val));
+      return std::pair<decltype(new_tuple), int>{new_tuple, bit_offset + bits};
+    };
+
+    auto [tuple_args, _] = reduce_member_types(extract_and_advance,
+                                               std::pair<std::tuple<>, int>{});
+    return std::apply([](auto... args) { return ScalarType(args...); },
+                      tuple_args);
+  }
+
+  constexpr int64_t size_bits() const {
+    return mantissa + exponent + is_signed();
+  }
+  constexpr bool is_signed() const { return signed_; }
+  constexpr bool is_integer() const { return exponent == 0; }
+  constexpr bool is_floating_point() const { return exponent > 0; }
+  constexpr bool is_ieee_754() const {
+    return is_floating_point() && finite_values_only == false &&
+           nan_repr == NAN_IEEE_754;
+  }
+  constexpr bool has_nans() const {
+    return is_floating_point() && nan_repr != NAN_NONE;
+  }
+  constexpr bool has_infs() const {
+    return is_floating_point() && finite_values_only == false;
+  }
+  constexpr bool has_bias() const { return bias != 0; }
+
+ private:
+  double _floating_point_max() const {
+    STD_TORCH_CHECK(mantissa <= 52 && exponent <= 11,
+                    "Cannot represent max/min as a double for type ", str());
+
+    uint64_t max_mantissa = (uint64_t(1) << mantissa) - 1;
+    if (nan_repr == NAN_EXTD_RANGE_MAX_MIN) {
+      max_mantissa -= 1;
+    }
+
+    uint64_t max_exponent = (uint64_t(1) << exponent) - 2;
+    if (nan_repr == NAN_EXTD_RANGE_MAX_MIN || nan_repr == NAN_NONE) {
+      STD_TORCH_CHECK(exponent < 11,
+                      "Cannot represent max/min as a double for type ", str());
+      max_exponent += 1;
+    }
+
+    // adjust the exponent to match that of a double
+    //  for now we assume the exponent bias is the standard 2^(e-1) -1, (where e
+    //  is the exponent bits), there is some precedent for non-standard biases,
+    //  example `float8_e4m3b11fnuz` here: https://github.com/jax-ml/ml_dtypes
+    //  but to avoid premature over complication we are just assuming the
+    //  standard exponent bias until there is a need to support non-standard
+    //  biases
+    uint64_t exponent_bias = (uint64_t(1) << (exponent - 1)) - 1;
+    uint64_t exponent_bias_double = (uint64_t(1) << 10) - 1;  // double e = 11
+
+    uint64_t max_exponent_double =
+        max_exponent - exponent_bias + exponent_bias_double;
+
+    // shift the mantissa into the position for a double and
+    // the exponent
+    uint64_t double_raw =
+        (max_mantissa << (52 - mantissa)) | (max_exponent_double << 52);
+
+    return *reinterpret_cast<double*>(&double_raw);
+  }
+
+  constexpr std::variant<int64_t, double> _raw_max() const {
+    if (is_floating_point()) {
+      return {_floating_point_max()};
+    } else {
+      STD_TORCH_CHECK(size_bits() < 64 || size_bits() == 64 && is_signed(),
+                      "Cannot represent max as a int64_t");
+      return {(int64_t(1) << mantissa) - 1};
+    }
+  }
+
+  constexpr std::variant<int64_t, double> _raw_min() const {
+    if (is_floating_point()) {
+      STD_TORCH_CHECK(
+          is_signed(),
+          "We currently assume all floating point types are signed");
+      constexpr uint64_t sign_bit_double = (uint64_t(1) << 63);
+
+      double max = _floating_point_max();
+      uint64_t max_raw = *reinterpret_cast<uint64_t*>(&max);
+      uint64_t min_raw = max_raw | sign_bit_double;
+      return {*reinterpret_cast<double*>(&min_raw)};
+    } else {
+      STD_TORCH_CHECK(!is_signed() || size_bits() <= 64,
+                      "Cannot represent min as a int64_t");
+      if (is_signed()) {
+        // set the top bit to 1 (i.e. INT64_MIN) and the rest to 0
+        // then perform an arithmetic shift right to set all the bits above
+        // (size_bits() - 1) to 1
+        return {INT64_MIN >> (64 - size_bits())};
+      } else {
+        return {int64_t(0)};
+      }
+    }
+  }
+
+ public:
+  // Max representable value for this scalar type.
+  // (accounting for bias if there is one)
+  constexpr std::variant<int64_t, double> max() const {
+    return std::visit(
+        [this](auto x) -> std::variant<int64_t, double> { return {x - bias}; },
+        _raw_max());
+  }
+
+  // Min representable value for this scalar type.
+  // (accounting for bias if there is one)
+  constexpr std::variant<int64_t, double> min() const {
+    return std::visit(
+        [this](auto x) -> std::variant<int64_t, double> { return {x - bias}; },
+        _raw_min());
+  }
+
+  std::string str() const {
+    /* naming generally follows: https://github.com/jax-ml/ml_dtypes
+     * for floating point types (leading f) the scheme is:
+     *  `float<size_bits>_e<exponent_bits>m<mantissa_bits>[flags]`
+     *  flags:
+     *  - no-flags: means it follows IEEE 754 conventions
+     *  - f: means finite values only (no infinities)
+     *  - n: means nans are supported (non-standard encoding)
+     * for integer types the scheme is:
+     *  `[u]int<size_bits>[b<bias>]`
+     *  - if bias is not present it means its zero
+     */
+    if (is_floating_point()) {
+      auto ret = "float" + std::to_string(size_bits()) + "_e" +
+                 std::to_string(exponent) + "m" + std::to_string(mantissa);
+      if (!is_ieee_754()) {
+        if (finite_values_only) {
+          ret += "f";
+        }
+        if (nan_repr != NAN_NONE) {
+          ret += "n";
+        }
+      }
+      return ret;
+    } else {
+      auto ret = ((is_signed()) ? "int" : "uint") + std::to_string(size_bits());
+      if (has_bias()) {
+        ret += "b" + std::to_string(bias);
+      }
+      return ret;
+    }
+  }
+
+  constexpr bool operator==(ScalarType const& other) const {
+    return mantissa == other.mantissa && exponent == other.exponent &&
+           bias == other.bias && signed_ == other.signed_ &&
+           finite_values_only == other.finite_values_only &&
+           nan_repr == other.nan_repr;
+  }
+};
+
+using ScalarTypeId = ScalarType::Id;
+
+// "rust style" names generally following:
+//   https://github.com/pytorch/pytorch/blob/6d9f74f0af54751311f0dd71f7e5c01a93260ab3/torch/csrc/api/include/torch/types.h#L60-L70
+static inline constexpr auto kS4 = ScalarType::int_(4);
+static inline constexpr auto kU4 = ScalarType::uint(4);
+static inline constexpr auto kU4B8 = ScalarType::uint(4, 8);
+static inline constexpr auto kS8 = ScalarType::int_(8);
+static inline constexpr auto kU8 = ScalarType::uint(8);
+static inline constexpr auto kU8B128 = ScalarType::uint(8, 128);
+
+static inline constexpr auto kFE2M1f =
+    ScalarType::float_(2, 1, true, ScalarType::NAN_NONE);
+static inline constexpr auto kFE3M2f =
+    ScalarType::float_(3, 2, true, ScalarType::NAN_NONE);
+static inline constexpr auto kFE4M3fn =
+    ScalarType::float_(4, 3, true, ScalarType::NAN_EXTD_RANGE_MAX_MIN);
+static inline constexpr auto kFE8M0fnu =
+    ScalarType(8, 0, false, 0, true, ScalarType::NAN_EXTD_RANGE_MAX_MIN);
+static inline constexpr auto kFE5M2 = ScalarType::float_IEEE754(5, 2);
+static inline constexpr auto kFE8M7 = ScalarType::float_IEEE754(8, 7);
+static inline constexpr auto kFE5M10 = ScalarType::float_IEEE754(5, 10);
+
+// Fixed width style names, generally following:
+//  https://github.com/pytorch/pytorch/blob/6d9f74f0af54751311f0dd71f7e5c01a93260ab3/torch/csrc/api/include/torch/types.h#L47-L57
+static inline constexpr auto kInt4 = kS4;
+static inline constexpr auto kUint4 = kU4;
+static inline constexpr auto kUint4b8 = kU4B8;
+static inline constexpr auto kInt8 = kS8;
+static inline constexpr auto kUint8 = kU8;
+static inline constexpr auto kUint8b128 = kU8B128;
+
+static inline constexpr auto kFloat4_e2m1f = kFE2M1f;
+static inline constexpr auto kFloat6_e3m2f = kFE3M2f;
+static inline constexpr auto kFloat8_e4m3fn = kFE4M3fn;
+static inline constexpr auto kFloat8_e5m2 = kFE5M2;
+static inline constexpr auto kFloat16_e8m7 = kFE8M7;
+static inline constexpr auto kFloat16_e5m10 = kFE5M10;
+
+// colloquial names
+static inline constexpr auto kHalf = kFE5M10;
+static inline constexpr auto kFloat16 = kHalf;
+static inline constexpr auto kBFloat16 = kFE8M7;
+
+static inline constexpr auto kFloat16Id = kFloat16.id();
+};  // namespace aphrodite

--- a/gptqmodel_ext/swordfish/libtorch_stable/ops.h
+++ b/gptqmodel_ext/swordfish/libtorch_stable/ops.h
@@ -1,0 +1,725 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+#pragma once
+
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <torch/csrc/stable/ops.h>
+
+inline torch::stable::Tensor weak_ref_tensor(torch::stable::Tensor& tensor) {
+  // Ensure tensor is on CUDA
+  STD_TORCH_CHECK(tensor.device().is_cuda(), "Tensor must be on CUDA device");
+
+  // Get the raw data pointer
+  void* data_ptr = tensor.mutable_data_ptr();
+
+  /// Create a new tensor from the raw data pointer
+  return torch::stable::from_blob(data_ptr, tensor.sizes(), tensor.strides(),
+                                  tensor.device(), tensor.scalar_type());
+}
+
+void per_token_group_quant_fp8(const torch::stable::Tensor& input,
+                               torch::stable::Tensor& output_q,
+                               torch::stable::Tensor& output_s,
+                               int64_t group_size, double eps, double fp8_min,
+                               double fp8_max, bool scale_ue8m0,
+                               bool dummy_is_scale_transposed,
+                               bool dummy_is_tma_aligned);
+
+// Fused activation quantisation + DeepGEMM-compatible UE8M0-packed scales.
+void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,
+                                       torch::stable::Tensor& output_q,
+                                       torch::stable::Tensor& output_s_packed,
+                                       int64_t group_size, double eps,
+                                       double min_8bit, double max_8bit);
+
+void per_token_group_quant_int8(const torch::stable::Tensor& input,
+                                torch::stable::Tensor& output_q,
+                                torch::stable::Tensor& output_s,
+                                int64_t group_size, double eps, double int8_min,
+                                double int8_max);
+
+torch::stable::Tensor permute_cols(torch::stable::Tensor const& A,
+                                   torch::stable::Tensor const& perm);
+
+std::tuple<torch::stable::Tensor, torch::stable::Tensor, torch::stable::Tensor>
+dry_scan_penalties_cpu(const torch::stable::Tensor& token_history_ids,
+                       const torch::stable::Tensor& token_history_lens,
+                       const torch::stable::Tensor& dry_multiplier,
+                       const torch::stable::Tensor& allowed_lengths,
+                       const torch::stable::Tensor& sequence_breakers_ids,
+                       const torch::stable::Tensor& ranges,
+                       const torch::stable::Tensor& max_ngram,
+                       const torch::stable::Tensor& max_occurrences,
+                       const torch::stable::Tensor& early_exit_match_len,
+                       int64_t vocab_size);
+
+#ifndef USE_ROCM
+bool cutlass_scaled_mm_supports_fp8(int64_t cuda_device_capability);
+bool cutlass_scaled_mm_supports_block_fp8(int64_t cuda_device_capability);
+bool cutlass_group_gemm_supported(int64_t cuda_device_capability);
+
+void cutlass_scaled_mm(torch::stable::Tensor& out,
+                       torch::stable::Tensor const& a,
+                       torch::stable::Tensor const& b,
+                       torch::stable::Tensor const& a_scales,
+                       torch::stable::Tensor const& b_scales,
+                       std::optional<torch::stable::Tensor> const& bias);
+
+void cutlass_moe_mm(torch::stable::Tensor& out_tensors,
+                    torch::stable::Tensor const& a_tensors,
+                    torch::stable::Tensor const& b_tensors,
+                    torch::stable::Tensor const& a_scales,
+                    torch::stable::Tensor const& b_scales,
+                    torch::stable::Tensor const& expert_offsets,
+                    torch::stable::Tensor const& problem_sizes,
+                    torch::stable::Tensor const& a_strides,
+                    torch::stable::Tensor const& b_strides,
+                    torch::stable::Tensor const& c_strides, bool per_act_token,
+                    bool per_out_ch);
+
+void cutlass_scaled_mm_azp(torch::stable::Tensor& out,
+                           torch::stable::Tensor const& a,
+                           torch::stable::Tensor const& b,
+                           torch::stable::Tensor const& a_scales,
+                           torch::stable::Tensor const& b_scales,
+                           torch::stable::Tensor const& azp_adj,
+                           std::optional<torch::stable::Tensor> const& azp,
+                           std::optional<torch::stable::Tensor> const& bias);
+
+void get_cutlass_moe_mm_data(
+    const torch::stable::Tensor& topk_ids,
+    torch::stable::Tensor& expert_offsets,
+    torch::stable::Tensor& problem_sizes1,
+    torch::stable::Tensor& problem_sizes2,
+    torch::stable::Tensor& input_permutation,
+    torch::stable::Tensor& output_permutation, const int64_t num_experts,
+    const int64_t n, const int64_t k,
+    const std::optional<torch::stable::Tensor>& blockscale_offsets,
+    const bool is_gated);
+
+void get_cutlass_moe_mm_problem_sizes_from_expert_offsets(
+    const torch::stable::Tensor& expert_first_token_offset,
+    torch::stable::Tensor& problem_sizes1,
+    torch::stable::Tensor& problem_sizes2, const int64_t n, const int64_t k,
+    const bool swap_ab);
+
+void get_cutlass_batched_moe_mm_data(
+    torch::stable::Tensor& expert_offsets,
+    torch::stable::Tensor& problem_sizes1,
+    torch::stable::Tensor& problem_sizes2,
+    const torch::stable::Tensor& expert_num_tokens,
+    const int64_t num_local_experts, const int64_t padded_m, const int64_t n,
+    const int64_t k);
+
+// FP4/NVFP4 ops
+bool cutlass_scaled_mm_supports_fp4(int64_t cuda_device_capability);
+
+void cutlass_scaled_fp4_mm(torch::stable::Tensor& D,
+                           torch::stable::Tensor const& A,
+                           torch::stable::Tensor const& B,
+                           torch::stable::Tensor const& A_sf,
+                           torch::stable::Tensor const& B_sf,
+                           torch::stable::Tensor const& alpha);
+
+void cutlass_fp4_group_mm(torch::stable::Tensor& output,
+                          const torch::stable::Tensor& a,
+                          const torch::stable::Tensor& b,
+                          const torch::stable::Tensor& a_blockscale,
+                          const torch::stable::Tensor& b_blockscales,
+                          const torch::stable::Tensor& alphas,
+                          const torch::stable::Tensor& problem_sizes,
+                          const torch::stable::Tensor& expert_offsets,
+                          const torch::stable::Tensor& sf_offsets);
+
+std::tuple<torch::stable::Tensor, torch::stable::Tensor> scaled_fp4_quant_func(
+    torch::stable::Tensor const& input,
+    torch::stable::Tensor const& input_scale, bool is_sf_swizzled_layout);
+
+void scaled_fp4_quant_out(torch::stable::Tensor const& input,
+                          torch::stable::Tensor const& input_scale,
+                          bool is_sf_swizzled_layout,
+                          torch::stable::Tensor& output,
+                          torch::stable::Tensor& output_scale);
+
+void scaled_fp4_experts_quant(
+    torch::stable::Tensor& output, torch::stable::Tensor& output_scale,
+    torch::stable::Tensor const& input,
+    torch::stable::Tensor const& input_global_scale,
+    torch::stable::Tensor const& input_offset_by_experts,
+    torch::stable::Tensor const& output_scale_offset_by_experts);
+
+void silu_and_mul_scaled_fp4_experts_quant(
+    torch::stable::Tensor& output, torch::stable::Tensor& output_scale,
+    torch::stable::Tensor const& input,
+    torch::stable::Tensor const& input_global_scale,
+    torch::stable::Tensor const& input_offset_by_experts,
+    torch::stable::Tensor const& output_scale_offset_by_experts);
+
+void silu_and_mul_nvfp4_quant(torch::stable::Tensor& out,
+                              torch::stable::Tensor& output_block_scale,
+                              torch::stable::Tensor& input,
+                              torch::stable::Tensor& input_global_scale);
+
+void cutlass_mxfp4_group_mm(torch::stable::Tensor& output,
+                            const torch::stable::Tensor& a,
+                            const torch::stable::Tensor& b,
+                            const torch::stable::Tensor& a_blockscale,
+                            const torch::stable::Tensor& b_blockscales,
+                            const torch::stable::Tensor& problem_sizes,
+                            const torch::stable::Tensor& expert_offsets,
+                            const torch::stable::Tensor& sf_offsets);
+
+// AWQ ops
+torch::stable::Tensor awq_gemm(torch::stable::Tensor _in_feats,
+                               torch::stable::Tensor _kernel,
+                               torch::stable::Tensor _scaling_factors,
+                               torch::stable::Tensor _zeros,
+                               int64_t split_k_iters);
+
+torch::stable::Tensor awq_dequantize(torch::stable::Tensor _kernel,
+                                     torch::stable::Tensor _scaling_factors,
+                                     torch::stable::Tensor _zeros,
+                                     int64_t split_k_iters, int64_t thx,
+                                     int64_t thy);
+
+// DSV3 fused A GEMM: conditionally compiled so declaration and impl
+// registration are in the source file (dsv3_fused_a_gemm.cu)
+
+// AllSpark ops: declarations are in the source files
+// (allspark_repack.cu and allspark_qgemm_w8a16.cu)
+
+#endif
+
+// CPU tensor -> CUDA UVA view (shared CUDA/ROCm)
+torch::stable::Tensor get_cuda_view_from_cpu_tensor(
+    torch::stable::Tensor& cpu_tensor);
+
+// Attention kernels (shared CUDA/ROCm)
+void merge_attn_states(
+    torch::stable::Tensor& output,
+    std::optional<torch::stable::Tensor> output_lse,
+    const torch::stable::Tensor& prefix_output,
+    const torch::stable::Tensor& prefix_lse,
+    const torch::stable::Tensor& suffix_output,
+    const torch::stable::Tensor& suffix_lse,
+    const std::optional<int64_t> prefill_tokens_with_context,
+    const std::optional<torch::stable::Tensor>& output_scale = std::nullopt);
+
+torch::stable::Tensor hadacore_transform(torch::stable::Tensor& x,
+                                         bool inplace);
+
+// Layernorm kernels (shared CUDA/ROCm)
+void rms_norm(torch::stable::Tensor& out, torch::stable::Tensor& input,
+              std::optional<torch::stable::Tensor> weight, double epsilon);
+
+void fused_add_rms_norm(torch::stable::Tensor& input,
+                        torch::stable::Tensor& residual,
+                        std::optional<torch::stable::Tensor> weight,
+                        double epsilon);
+
+// Layernorm-quant kernels (shared CUDA/ROCm)
+void rms_norm_static_fp8_quant(torch::stable::Tensor& out,
+                               torch::stable::Tensor& input,
+                               torch::stable::Tensor& weight,
+                               torch::stable::Tensor& scale, double epsilon);
+
+void fused_add_rms_norm_static_fp8_quant(torch::stable::Tensor& out,
+                                         torch::stable::Tensor& input,
+                                         torch::stable::Tensor& residual,
+                                         torch::stable::Tensor& weight,
+                                         torch::stable::Tensor& scale,
+                                         double epsilon);
+
+// Fused layernorm + dynamic per-token quant kernels (shared CUDA/ROCm)
+void rms_norm_dynamic_per_token_quant(
+    torch::stable::Tensor& out, torch::stable::Tensor const& input,
+    torch::stable::Tensor const& weight, torch::stable::Tensor& scales,
+    double const var_epsilon, std::optional<torch::stable::Tensor> scale_ub,
+    std::optional<torch::stable::Tensor> residual);
+
+void rms_norm_per_block_quant(torch::stable::Tensor& out,
+                              torch::stable::Tensor const& input,
+                              torch::stable::Tensor const& weight,
+                              torch::stable::Tensor& scales,
+                              double const var_epsilon,
+                              std::optional<torch::stable::Tensor> scale_ub,
+                              std::optional<torch::stable::Tensor> residual,
+                              int64_t group_size, bool is_scale_transposed);
+
+void silu_and_mul_per_block_quant(torch::stable::Tensor& out,
+                                  torch::stable::Tensor const& input,
+                                  torch::stable::Tensor& scales,
+                                  int64_t group_size,
+                                  std::optional<torch::stable::Tensor> scale_ub,
+                                  bool is_scale_transposed);
+
+// Positional encoding kernels (shared CUDA/ROCm)
+void rotary_embedding(torch::stable::Tensor& positions,
+                      torch::stable::Tensor& query,
+                      std::optional<torch::stable::Tensor> key,
+                      int64_t head_size, torch::stable::Tensor& cos_sin_cache,
+                      bool is_neox, int64_t rope_dim_offset, bool inverse);
+
+void fused_qk_norm_rope(torch::stable::Tensor& qkv, int64_t num_heads_q,
+                        int64_t num_heads_k, int64_t num_heads_v,
+                        int64_t head_dim, double eps,
+                        torch::stable::Tensor& q_weight,
+                        torch::stable::Tensor& k_weight,
+                        torch::stable::Tensor& cos_sin_cache, bool is_neox,
+                        torch::stable::Tensor& position_ids,
+                        int64_t forced_token_heads_per_warp);
+
+torch::stable::Tensor fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert(
+    torch::stable::Tensor const& q_in, torch::stable::Tensor& q_out,
+    torch::stable::Tensor const& kv, torch::stable::Tensor& k_cache,
+    torch::stable::Tensor const& slot_mapping,
+    torch::stable::Tensor const& position_ids,
+    torch::stable::Tensor const& cos_sin_cache, int64_t q_head_padded,
+    double eps, int64_t cache_block_size);
+
+void fused_deepseek_v4_qnorm_rope_kv_rope_full_cache_bf16_insert(
+    torch::stable::Tensor& q, torch::stable::Tensor const& kv,
+    torch::stable::Tensor& k_cache, torch::stable::Tensor const& slot_mapping,
+    torch::stable::Tensor const& position_ids,
+    torch::stable::Tensor const& cos_sin_cache, double eps,
+    int64_t cache_block_size);
+
+void fused_kimi_k3_mla_key_concat_kv_cache_insert(
+    torch::stable::Tensor& q, torch::stable::Tensor const& k_nope,
+    torch::stable::Tensor const& k_pe, torch::stable::Tensor const& kv_c_normed,
+    torch::stable::Tensor& k_out, torch::stable::Tensor& k_cache,
+    torch::stable::Tensor const& slot_mapping, int64_t cache_block_size,
+    std::optional<torch::stable::Tensor> position_ids,
+    std::optional<torch::stable::Tensor> cos_sin_cache);
+
+void fused_kimi_k3_mla_key_concat_ds_mla_insert(
+    torch::stable::Tensor& q, torch::stable::Tensor const& k_nope,
+    torch::stable::Tensor const& k_pe, torch::stable::Tensor const& kv_c_normed,
+    torch::stable::Tensor& k_out, torch::stable::Tensor& k_cache,
+    torch::stable::Tensor const& slot_mapping, int64_t cache_block_size,
+    std::optional<torch::stable::Tensor> position_ids,
+    std::optional<torch::stable::Tensor> cos_sin_cache);
+
+void fused_kimi_k3_mla_qkv_quant_kv_cache_fp8_insert(
+    torch::stable::Tensor const& q, torch::stable::Tensor const& k_nope,
+    torch::stable::Tensor const& k_pe, torch::stable::Tensor const& kv_c_normed,
+    torch::stable::Tensor const& v, torch::stable::Tensor& q_fp8,
+    torch::stable::Tensor& k_fp8, torch::stable::Tensor& v_fp8,
+    torch::stable::Tensor& k_cache, torch::stable::Tensor const& slot_mapping,
+    torch::stable::Tensor const& q_scale_inv,
+    torch::stable::Tensor const& k_scale_inv,
+    torch::stable::Tensor const& v_scale_inv,
+    torch::stable::Tensor const& cache_scale_inv, int64_t cache_block_size,
+    std::optional<torch::stable::Tensor> position_ids,
+    std::optional<torch::stable::Tensor> cos_sin_cache);
+
+void fused_kimi_k3_mla_decode_q_concat_kv_cache_insert(
+    torch::stable::Tensor const& ql_nope, torch::stable::Tensor const& q_pe,
+    torch::stable::Tensor const& kv_c_normed, torch::stable::Tensor const& k_pe,
+    torch::stable::Tensor& mqa_q, torch::stable::Tensor& k_cache,
+    torch::stable::Tensor const& slot_mapping, int64_t cache_block_size,
+    std::optional<torch::stable::Tensor> position_ids,
+    std::optional<torch::stable::Tensor> cos_sin_cache);
+
+void fused_kimi_k3_mla_decode_q_concat_kv_cache_fp8_insert(
+    torch::stable::Tensor const& ql_nope, torch::stable::Tensor const& q_pe,
+    torch::stable::Tensor const& kv_c_normed, torch::stable::Tensor const& k_pe,
+    torch::stable::Tensor& mqa_q, torch::stable::Tensor& k_cache,
+    torch::stable::Tensor const& slot_mapping,
+    torch::stable::Tensor const& q_scale_inv,
+    torch::stable::Tensor const& cache_scale_inv, int64_t cache_block_size,
+    std::optional<torch::stable::Tensor> position_ids,
+    std::optional<torch::stable::Tensor> cos_sin_cache);
+
+void fused_kimi_k3_mla_decode_q_concat_ds_mla_insert(
+    torch::stable::Tensor const& ql_nope, torch::stable::Tensor const& q_pe,
+    torch::stable::Tensor const& kv_c_normed, torch::stable::Tensor const& k_pe,
+    torch::stable::Tensor& mqa_q, torch::stable::Tensor& k_cache,
+    torch::stable::Tensor const& slot_mapping, int64_t cache_block_size,
+    std::optional<torch::stable::Tensor> position_ids,
+    std::optional<torch::stable::Tensor> cos_sin_cache);
+
+void fused_deepseek_v4_qnorm_rope_kv_rope_full_cache_fp8_insert(
+    torch::stable::Tensor const& q, torch::stable::Tensor const& kv,
+    torch::stable::Tensor& q_fp8, torch::stable::Tensor& k_cache,
+    torch::stable::Tensor const& slot_mapping,
+    torch::stable::Tensor const& position_ids,
+    torch::stable::Tensor const& cos_sin_cache,
+    torch::stable::Tensor const& fp8_scale,
+    torch::stable::Tensor const& q_fp8_scale_inv, double eps,
+    int64_t cache_block_size);
+
+#ifndef USE_ROCM
+std::tuple<torch::stable::Tensor, torch::stable::Tensor>
+minimax_allreduce_rms_qk(torch::stable::Tensor qkv,
+                         torch::stable::Tensor const& norm_weight_q,
+                         torch::stable::Tensor const& norm_weight_k,
+                         torch::stable::Tensor workspace, int64_t const q_size,
+                         int64_t const kv_size, int64_t const rank,
+                         int64_t const nranks, double const eps);
+#endif
+
+// Horizontally-fused MiniMax-M3 QK-norm + partial NeoX RoPE (+ optional KV /
+// index-cache insert). Dense layer: norm+RoPE only; sparse layer: also packs
+// the index branch and scatters k/v/index_k into their paged caches.
+void fused_minimax_m3_qknorm_rope_kv_insert(
+    torch::stable::Tensor& qkv, torch::stable::Tensor const& q_norm_weight,
+    torch::stable::Tensor const& k_norm_weight,
+    torch::stable::Tensor const& cos_sin_cache,
+    torch::stable::Tensor const& positions, int64_t num_heads,
+    int64_t num_kv_heads, int64_t rotary_dim, double eps,
+    std::optional<torch::stable::Tensor> index_q_norm_weight,
+    std::optional<torch::stable::Tensor> index_k_norm_weight,
+    int64_t num_index_heads, std::optional<torch::stable::Tensor> slot_mapping,
+    std::optional<torch::stable::Tensor> index_slot_mapping,
+    std::optional<torch::stable::Tensor> kv_cache,
+    std::optional<torch::stable::Tensor> index_cache, int64_t block_size,
+    std::optional<torch::stable::Tensor> q_out,
+    std::optional<torch::stable::Tensor> index_q_out,
+    const std::string& kv_cache_dtype, bool skip_index_branch);
+
+#ifdef APHRODITE_ENABLE_FUSED_KDA_DECODE
+void fused_kda_decode(
+    torch::stable::Tensor const& x, torch::stable::Tensor const& weight,
+    std::optional<torch::stable::Tensor> bias,
+    torch::stable::Tensor& conv_state, torch::stable::Tensor const& raw_g,
+    torch::stable::Tensor const& raw_beta, torch::stable::Tensor const& a_log,
+    torch::stable::Tensor const& dt_bias,
+    torch::stable::Tensor const& state_indices, torch::stable::Tensor& state,
+    torch::stable::Tensor& out, std::optional<double> lower_bound,
+    std::optional<torch::stable::Tensor> output_gate,
+    std::optional<torch::stable::Tensor> norm_weight, double norm_eps);
+#endif
+
+#ifdef APHRODITE_ENABLE_KIMI_K3_ATTN_RES
+void kimi_k3_attn_res(torch::stable::Tensor& prefix,
+                      torch::stable::Tensor const& delta,
+                      torch::stable::Tensor const& blocks,
+                      torch::stable::Tensor const& norm_weight,
+                      torch::stable::Tensor const& qk_weight,
+                      torch::stable::Tensor const& output_norm_weight,
+                      torch::stable::Tensor& output, int64_t num_blocks,
+                      double eps, double output_norm_eps);
+#endif
+
+// Sampler kernels (shared CUDA/ROCm)
+void apply_repetition_penalties_(
+    torch::stable::Tensor& logits, const torch::stable::Tensor& prompt_mask,
+    const torch::stable::Tensor& output_mask,
+    const torch::stable::Tensor& repetition_penalties);
+
+void top_k_per_row_prefill(const torch::stable::Tensor& logits,
+                           const torch::stable::Tensor& rowStarts,
+                           const torch::stable::Tensor& rowEnds,
+                           torch::stable::Tensor& indices, int64_t numRows,
+                           int64_t stride0, int64_t stride1, int64_t topK);
+
+void top_k_per_row_decode(const torch::stable::Tensor& logits, int64_t next_n,
+                          const torch::stable::Tensor& seqLens,
+                          torch::stable::Tensor& indices, int64_t numRows,
+                          int64_t stride0, int64_t stride1, int64_t topK);
+
+void persistent_topk(const torch::stable::Tensor& logits,
+                     const torch::stable::Tensor& lengths,
+                     torch::stable::Tensor& output,
+                     torch::stable::Tensor& workspace, int64_t k,
+                     int64_t max_seq_len);
+
+#ifdef APHRODITE_ENABLE_COOPERATIVE_TOPK
+void cooperative_topk(const torch::stable::Tensor& logits,
+                      const torch::stable::Tensor& lengths,
+                      torch::stable::Tensor& output,
+                      torch::stable::Tensor& workspace, int64_t k,
+                      int64_t max_seq_len);
+#endif
+
+#ifdef APHRODITE_ENABLE_SM89_DSA
+// sm89 DeepSeek sparse attention kernels; impls are registered in
+// csrc/libtorch_stable/attention/sm89_dsa/.
+void sm89_fp8_paged_mqa_logits(const torch::stable::Tensor& q,
+                               const torch::stable::Tensor& pool,
+                               const torch::stable::Tensor& weights,
+                               const torch::stable::Tensor& seq_lens,
+                               const torch::stable::Tensor& block_table,
+                               const torch::stable::Tensor& sched,
+                               torch::stable::Tensor& logits,
+                               bool clean_logits);
+
+void sm89_paged_mqa_logits_metadata(const torch::stable::Tensor& seq_lens,
+                                    torch::stable::Tensor& sched,
+                                    int64_t next_n);
+
+void sm89_fp8_mqa_logits(const torch::stable::Tensor& q,
+                         const torch::stable::Tensor& kv,
+                         const torch::stable::Tensor& kv_scales,
+                         const torch::stable::Tensor& weights,
+                         const torch::stable::Tensor& cu_seqlen_ks,
+                         const torch::stable::Tensor& cu_seqlen_ke,
+                         torch::stable::Tensor& logits);
+
+void sm89_sparse_mla_fwd(const torch::stable::Tensor& q,
+                         const torch::stable::Tensor& pool,
+                         const torch::stable::Tensor& indices,
+                         torch::stable::Tensor& out, torch::stable::Tensor& lse,
+                         double sm_scale,
+                         std::optional<torch::stable::Tensor> topk_lens);
+#endif
+
+void selective_scan_fwd(
+    const torch::stable::Tensor& u, const torch::stable::Tensor& delta,
+    const torch::stable::Tensor& A, const torch::stable::Tensor& B,
+    const torch::stable::Tensor& C,
+    const std::optional<torch::stable::Tensor>& D_,
+    const std::optional<torch::stable::Tensor>& z_,
+    const std::optional<torch::stable::Tensor>& delta_bias_,
+    bool delta_softplus,
+    const std::optional<torch::stable::Tensor>& query_start_loc,
+    const std::optional<torch::stable::Tensor>& cache_indices,
+    const std::optional<torch::stable::Tensor>& has_initial_state,
+    const torch::stable::Tensor& ssm_states, int64_t null_block_id,
+    int64_t block_size,
+    const std::optional<torch::stable::Tensor>& block_idx_first_scheduled_token,
+    const std::optional<torch::stable::Tensor>& block_idx_last_scheduled_token,
+    const std::optional<torch::stable::Tensor>& initial_state_idx,
+    const std::optional<torch::stable::Tensor>& cu_chunk_seqlen,
+    const std::optional<torch::stable::Tensor>& last_chunk_indices);
+
+using fptr_t = int64_t;
+fptr_t init_custom_ar(const std::vector<int64_t>& fake_ipc_ptrs,
+                      torch::stable::Tensor& rank_data, int64_t rank,
+                      bool fully_connected);
+void all_reduce(fptr_t _fa, torch::stable::Tensor& inp,
+                torch::stable::Tensor& out, fptr_t reg_buffer,
+                int64_t reg_buffer_sz_bytes);
+void custom_all_gather(fptr_t _fa, torch::stable::Tensor& inp,
+                       torch::stable::Tensor& out, fptr_t reg_buffer,
+                       int64_t reg_buffer_sz_bytes);
+void mnnvl_lamport_all_gather(fptr_t _fa, torch::stable::Tensor& inp,
+                              torch::stable::Tensor& out, fptr_t local_buffer,
+                              fptr_t multicast_buffer, fptr_t epoch_buffer,
+                              int64_t stage_sz_bytes);
+void custom_reduce_scatter(fptr_t _fa, torch::stable::Tensor& inp,
+                           torch::stable::Tensor& out, fptr_t reg_buffer,
+                           int64_t reg_buffer_sz_bytes);
+void mnnvl_lamport_reduce_scatter(fptr_t _fa, torch::stable::Tensor& inp,
+                                  torch::stable::Tensor& out,
+                                  fptr_t local_buffer, fptr_t epoch_buffer,
+                                  int64_t stage_sz_bytes);
+void dispose(fptr_t _fa);
+int64_t meta_size();
+void register_buffer(fptr_t _fa, const std::vector<int64_t>& fake_ipc_ptrs);
+std::tuple<std::vector<int64_t>, std::vector<int64_t>>
+get_graph_buffer_ipc_meta(fptr_t _fa);
+void register_graph_buffers(fptr_t _fa,
+                            const std::vector<std::vector<int64_t>>& handles,
+                            const std::vector<std::vector<int64_t>>& offsets);
+std::tuple<int64_t, torch::stable::Tensor> allocate_shared_buffer_and_handle(
+    int64_t size);
+int64_t open_mem_handle(torch::stable::Tensor& mem_handle);
+void free_shared_buffer(int64_t buffer);
+
+// Activation kernels (shared CUDA/ROCm)
+void silu_and_mul(torch::stable::Tensor& out, torch::stable::Tensor& input);
+void silu_and_mul_clamp(torch::stable::Tensor& out,
+                        torch::stable::Tensor& input, double limit,
+                        double alpha = 1.0, double beta = 0.0);
+
+void silu_and_mul_quant(torch::stable::Tensor& out,
+                        torch::stable::Tensor& input,
+                        torch::stable::Tensor& scale);
+
+void persistent_masked_m_silu_mul_quant(
+    const torch::stable::Tensor& input,              // (E, T, 2*H)
+    const torch::stable::Tensor& tokens_per_expert,  // (E)
+    torch::stable::Tensor& y_q,                      // (E, T, H) [OUT]
+    torch::stable::Tensor& y_s,  // (E, T, H//group_size) [OUT]
+    bool use_ue8m0);
+
+void mul_and_silu(torch::stable::Tensor& out, torch::stable::Tensor& input);
+void gelu_and_mul(torch::stable::Tensor& out, torch::stable::Tensor& input);
+void gelu_tanh_and_mul(torch::stable::Tensor& out,
+                       torch::stable::Tensor& input);
+void fatrelu_and_mul(torch::stable::Tensor& out, torch::stable::Tensor& input,
+                     double threshold);
+void swigluoai_and_mul(torch::stable::Tensor& out, torch::stable::Tensor& input,
+                       double alpha = 1.702, double limit = 7.0);
+void situ_and_mul(torch::stable::Tensor& out, torch::stable::Tensor& input,
+                  double beta = 1.0, double linear_beta = -1.0);
+void masked_situ_and_mul(torch::stable::Tensor& out,
+                         torch::stable::Tensor& input,
+                         const torch::stable::Tensor& expert_num_tokens,
+                         double beta = 1.0, double linear_beta = -1.0);
+void gelu_new(torch::stable::Tensor& out, torch::stable::Tensor& input);
+void gelu_fast(torch::stable::Tensor& out, torch::stable::Tensor& input);
+void gelu_quick(torch::stable::Tensor& out, torch::stable::Tensor& input);
+void relu_squared(torch::stable::Tensor& out, torch::stable::Tensor& input);
+
+// INT8 quantization kernels (shared CUDA/ROCm)
+void static_scaled_int8_quant(torch::stable::Tensor& out,
+                              torch::stable::Tensor const& input,
+                              torch::stable::Tensor const& scale,
+                              std::optional<torch::stable::Tensor> const& azp);
+
+void dynamic_scaled_int8_quant(torch::stable::Tensor& out,
+                               torch::stable::Tensor const& input,
+                               torch::stable::Tensor& scales,
+                               std::optional<torch::stable::Tensor> const& azp);
+
+// FP8 quantization kernels (shared CUDA/ROCm)
+void static_scaled_fp8_quant(
+    torch::stable::Tensor& out, torch::stable::Tensor const& input,
+    torch::stable::Tensor const& scale,
+    std::optional<torch::headeronly::IntHeaderOnlyArrayRef> group_shape =
+        std::nullopt);
+
+void dynamic_scaled_fp8_quant(torch::stable::Tensor& out,
+                              torch::stable::Tensor const& input,
+                              torch::stable::Tensor& scale);
+
+void dynamic_per_token_scaled_fp8_quant(
+    torch::stable::Tensor& out, torch::stable::Tensor const& input,
+    torch::stable::Tensor& scale,
+    std::optional<torch::stable::Tensor> const& scale_ub);
+
+// GPTQ kernels (shared CUDA/ROCm)
+torch::stable::Tensor gptq_gemm(torch::stable::Tensor a,
+                                torch::stable::Tensor b_q_weight,
+                                torch::stable::Tensor b_gptq_qzeros,
+                                torch::stable::Tensor b_gptq_scales,
+                                torch::stable::Tensor b_g_idx, bool use_exllama,
+                                bool use_v2_format, int64_t bit);
+
+void gptq_shuffle(torch::stable::Tensor q_weight, torch::stable::Tensor q_perm,
+                  int64_t bit);
+
+// Cache ops (shared CUDA/ROCm)
+void swap_blocks(torch::stable::Tensor& src, torch::stable::Tensor& dst,
+                 int64_t block_size_in_bytes,
+                 const torch::stable::Tensor& block_mapping);
+
+// Batch swap: submit all block copies in a single driver call.
+void swap_blocks_batch(const torch::stable::Tensor& src_ptrs,
+                       const torch::stable::Tensor& dst_ptrs,
+                       const torch::stable::Tensor& sizes,
+                       bool is_src_access_order_any);
+
+void reshape_and_cache(torch::stable::Tensor& key, torch::stable::Tensor& value,
+                       torch::stable::Tensor& key_cache,
+                       torch::stable::Tensor& value_cache,
+                       torch::stable::Tensor& slot_mapping,
+                       const std::string& kv_cache_dtype,
+                       torch::stable::Tensor& k_scale,
+                       torch::stable::Tensor& v_scale);
+
+void reshape_and_cache_flash(
+    torch::stable::Tensor& key, torch::stable::Tensor& value,
+    torch::stable::Tensor& key_cache, torch::stable::Tensor& value_cache,
+    torch::stable::Tensor& slot_mapping, const std::string& kv_cache_dtype,
+    torch::stable::Tensor& k_scale, torch::stable::Tensor& v_scale);
+
+void concat_and_cache_mla(torch::stable::Tensor& kv_c,
+                          torch::stable::Tensor& k_pe,
+                          torch::stable::Tensor& kv_cache,
+                          torch::stable::Tensor& slot_mapping,
+                          const std::string& kv_cache_dtype,
+                          torch::stable::Tensor& scale);
+
+void concat_and_cache_mla_grouped(torch::stable::Tensor& kv_c,
+                                  torch::stable::Tensor& k_pe,
+                                  torch::stable::Tensor& kv_cache_ptrs,
+                                  torch::stable::Tensor& slot_mapping,
+                                  int64_t block_size, int64_t block_stride,
+                                  int64_t entry_stride);
+
+// NOTE: k_pe and kv_c order is flipped compared to concat_and_cache_mla
+void concat_and_cache_mla_rope_fused(
+    torch::stable::Tensor& positions, torch::stable::Tensor& q_pe,
+    torch::stable::Tensor& k_pe, torch::stable::Tensor& kv_c,
+    torch::stable::Tensor& rope_cos_sin_cache, bool rope_is_neox,
+    torch::stable::Tensor& slot_mapping, torch::stable::Tensor& kv_cache,
+    const std::string& kv_cache_dtype,
+    torch::stable::Tensor& kv_cache_quant_scale);
+
+// Just for unittest
+void convert_fp8(torch::stable::Tensor& dst_cache,
+                 torch::stable::Tensor& src_cache, const double scale,
+                 const std::string& kv_cache_dtype);
+
+void gather_and_maybe_dequant_cache(
+    torch::stable::Tensor const& src_cache,     // [NUM_BLOCKS, BLOCK_SIZE,
+                                                // ENTRIES...]
+    torch::stable::Tensor const& dst,           // [TOT_TOKENS, ENTRIES...]
+    torch::stable::Tensor const& block_table,   // [BATCH, BLOCK_INDICES]
+    torch::stable::Tensor const& cu_seq_lens,   // [BATCH+1]
+    torch::stable::Tensor const& token_to_seq,  // [MAX_TOKEN_ACROSS_CHUNKS]
+    int64_t num_tokens, const std::string& kv_cache_dtype,
+    torch::stable::Tensor const& scale,
+    std::optional<torch::stable::Tensor> seq_starts = std::nullopt);
+
+// TODO(hc): cp_gather_cache need support scaled kvcahe in the future.
+void cp_gather_cache(
+    torch::stable::Tensor const& src_cache,    // [NUM_BLOCKS, BLOCK_SIZE,
+                                               // ENTRIES...]
+    torch::stable::Tensor const& dst,          // [TOT_TOKENS, ENTRIES...]
+    torch::stable::Tensor const& block_table,  // [BATCH, BLOCK_INDICES]
+    torch::stable::Tensor const& cu_seq_lens,  // [BATCH+1]
+    int64_t batch_size,
+    std::optional<torch::stable::Tensor> seq_starts = std::nullopt);
+
+// Gather and upconvert FP8 KV cache to BF16 workspace
+void cp_gather_and_upconvert_fp8_kv_cache(
+    torch::stable::Tensor const& src_cache,         // [NUM_BLOCKS, BLOCK_SIZE,
+                                                    // 656]
+    torch::stable::Tensor const& dst,               // [TOT_TOKENS, 576]
+    torch::stable::Tensor const& block_table,       // [BATCH, BLOCK_INDICES]
+    torch::stable::Tensor const& workspace_starts,  // [BATCH]
+    int64_t batch_size,
+    std::optional<torch::stable::Tensor> seq_starts = std::nullopt);
+
+// Indexer K quantization and cache function
+void indexer_k_quant_and_cache(
+    torch::stable::Tensor& k,             // [num_tokens, head_dim]
+    torch::stable::Tensor& kv_cache,      // [num_blocks, block_size,
+                                          // cache_stride]
+    torch::stable::Tensor& slot_mapping,  // [num_tokens]
+    int64_t quant_block_size,             // quantization block size
+    const std::string& scale_fmt);
+
+// Concatenate query nope and rope for MLA/DSA attention
+void concat_mla_q(
+    torch::stable::Tensor& ql_nope,  // [num_tokens, num_heads, nope_dim]
+    torch::stable::Tensor& q_pe,     // [num_tokens, num_heads, rope_dim]
+    torch::stable::Tensor& q_out);   // [num_tokens, num_heads, nope_dim +
+                                     // rope_dim]
+
+// Extract function to gather quantized K cache
+void cp_gather_indexer_k_quant_cache(
+    const torch::stable::Tensor& kv_cache,      // [num_blocks, block_size,
+                                                // cache_stride]
+    torch::stable::Tensor& dst_k,               // [num_tokens, head_dim]
+    torch::stable::Tensor& dst_scale,           // [num_tokens, head_dim /
+                                                // quant_block_size * 4]
+    const torch::stable::Tensor& block_table,   // [batch_size, num_blocks]
+    const torch::stable::Tensor& cu_seq_lens);  // [batch_size + 1]
+
+// LongCat n-gram embedding index kernel (see ngram_embedding_kernels.cu).
+void ngram_compute_n_gram_ids(
+    int64_t ne_n, int64_t ne_k, torch::stable::Tensor& ne_weights,
+    torch::stable::Tensor& ne_mods,
+    torch::stable::Tensor& exclusive_ne_embedder_size_sums,
+    torch::stable::Tensor& exclusive_req_len_sums,
+    torch::stable::Tensor& ne_token_table, torch::stable::Tensor& row_indices,
+    torch::stable::Tensor& column_starts, torch::stable::Tensor& n_gram_ids);

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/marlin/dequant.h
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/marlin/dequant.h
@@ -1,0 +1,619 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+/*
+Fast Dequantization (Converting INT4/INT8/FP4/FP8 to FP16/BF16)
+
+The process of fast dequantization can be summarized as a combination
+of bitwise operations and floating-point computations:
+
+weight =>(bit_op / bitwise operations)=>
+f16_value =>(flop / floating-point computation)=>
+dequantized_weight
+
+Since the dequantized weights typically require subtracting the zero point and
+applying a scale factor, the floating-point computation step can be fused with
+the zero-point subtraction and scaling operations.
+
+The following are the parts that need to be modified for the fused operation
+of zero-point subtraction and scaling.
+
+## INT4 => FP16/BF16 or INT8 => FP16
+
+The floating-point computation is `__hsub2`
+
+If has zero points:
+
+    flop(bit_op(weight)) - flop(bit_op(zp))
+  = sub(bit_op(weight), bias) - sub(bit_op(zp), bias)
+  = bit_op(weight) - bit_op(zp)
+
+so we don't need additional modification.
+
+If has float zero points:
+
+    flop(bit_op(weight)) - fzp
+  = sub(bit_op(weight), bias) - fzp
+  = bit_op(weight) - (fzp + bias)
+
+where the `fzp + bias` can be computed at weight loading. But this
+may have accuracy issue, so we should not use this in most cases.
+
+If has not zero points:
+
+    scale(flop(bit_op(weight)))
+  = scale(sub(bit_op(weight), bias))
+  = scale(bit_op(weight)) - scale(bias)
+  = fma(bit_op(weight), scale_factor, scale(bias))
+
+where the `scale(bias)` can be cached. But this may have accuracy issue,
+so we should not use this in most cases.
+
+
+## INT8 => BF16
+
+INT8 => BF16 is a special case, it use byte_perm instead of flop.
+We cannot fused byte_perm with scaling.
+
+
+## FP4/FP8 => FP16/BF16
+
+    scale(flop(bit_op(weight)))
+  = scale(mul(bit_op(weight), multiplier))
+  = mul(bit_op(weight), scale_factor * multiplier)
+
+where `scale_factor * multiplier` can be computed at weight loading.
+
+*/
+
+#include "marlin_dtypes.cuh"
+
+namespace MARLIN_NAMESPACE_NAME {
+
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 750
+// Lookup-table based 3-input logical operation; explicitly used for
+// dequantization as the compiler does not seem to automatically recognize it in
+// all cases.
+template <int lut>
+__device__ inline int lop3(int a, int b, int c) {
+  int res;
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(res)
+               : "r"(a), "r"(b), "r"(c), "n"(lut));
+  return res;
+}
+
+// Constructs destination register by taking bytes from 2 sources (based on
+// mask)
+template <int start_byte, int mask>
+__device__ inline uint32_t prmt(uint32_t a) {
+  uint32_t res;
+  asm volatile("prmt.b32 %0, %1, %2, %3;\n"
+               : "=r"(res)
+               : "r"(a), "n"(start_byte), "n"(mask));
+  return res;
+}
+
+template <typename scalar_t2, aphrodite::ScalarTypeId w_type_id,
+          bool skip_flop = false>
+__device__ inline void dequant(int q, scalar_t2* frag_b);
+
+//
+// Efficiently dequantize 4bit values packed in an int32 value into a full
+// B-fragment of 4 fp16 values. We mostly follow the strategy in the link below,
+// with some small changes:
+// - FP16:
+// https://github.com/NVIDIA/FasterTransformer/blob/release/v5.3_tag/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h#L215-L287
+// - BF16:
+// https://github.com/NVIDIA/FasterTransformer/blob/release/v5.3_tag/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h#L327-L385
+//
+template <>
+__device__ inline void dequant<half2, aphrodite::kU4B8.id(), true>(
+    int q, half2* frag_b) {
+  const int MASK = 0x000f000f;
+  const int EX = 0x64006400;
+  // Guarantee that the `(a & b) | c` operations are LOP3s.
+  int lo = lop3<(0xf0 & 0xcc) | 0xaa>(q, MASK, EX);
+  q >>= 4;
+  int hi = lop3<(0xf0 & 0xcc) | 0xaa>(q, MASK, EX);
+
+  frag_b[0] = *reinterpret_cast<half2*>(&lo);
+  frag_b[1] = *reinterpret_cast<half2*>(&hi);
+}
+
+template <>
+__device__ inline void dequant<half2, aphrodite::kU4B8.id(), false>(
+    int q, half2* frag_b) {
+  const int LO = 0x000f000f;
+  const int HI = 0x00f000f0;
+  const int EX = 0x64006400;
+  // Guarantee that the `(a & b) | c` operations are LOP3s.
+  // clang-format off
+  int lo = lop3<(0xf0 & 0xcc) | 0xaa>(q, LO, EX);
+  int hi = lop3<(0xf0 & 0xcc) | 0xaa>(q, HI, EX);
+  // clang-format on
+  // We want signed int4 outputs, hence we fuse the `-8` symmetric zero point
+  // directly into `SUB` and `ADD`.
+  const int SUB = 0x64086408;
+  const int MUL = 0x2c002c00;
+  const int ADD = 0xd480d480;
+  frag_b[0] = __hsub2(*reinterpret_cast<half2*>(&lo),
+                      *reinterpret_cast<const half2*>(&SUB));
+  frag_b[1] = __hfma2(*reinterpret_cast<half2*>(&hi),
+                      *reinterpret_cast<const half2*>(&MUL),
+                      *reinterpret_cast<const half2*>(&ADD));
+}
+
+template <>
+__device__ inline void dequant<half2, aphrodite::kU4.id(), true>(
+    int q, half2* frag_b) {
+  dequant<half2, aphrodite::kU4B8.id(), true>(q, frag_b);
+}
+
+template <>
+__device__ inline void dequant<half2, aphrodite::kU4.id(), false>(
+    int q, half2* frag_b) {
+  const int LO = 0x000f000f;
+  const int HI = 0x00f000f0;
+  const int EX = 0x64006400;
+  // Guarantee that the `(a & b) | c` operations are LOP3s.
+  // clang-format off
+  int lo = lop3<(0xf0 & 0xcc) | 0xaa>(q, LO, EX);
+  int hi = lop3<(0xf0 & 0xcc) | 0xaa>(q, HI, EX);
+  // clang-format on
+  // We want signed int4 outputs, hence we fuse the `-8` symmetric zero point
+  // directly into `SUB` and `ADD`.
+  const int SUB = 0x64006400;
+  const int MUL = 0x2c002c00;
+  const int ADD = 0xd400d400;
+  frag_b[0] = __hsub2(*reinterpret_cast<half2*>(&lo),
+                      *reinterpret_cast<const half2*>(&SUB));
+  frag_b[1] = __hfma2(*reinterpret_cast<half2*>(&hi),
+                      *reinterpret_cast<const half2*>(&MUL),
+                      *reinterpret_cast<const half2*>(&ADD));
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, aphrodite::kU4B8.id(), true>(
+    int q, nv_bfloat162* frag_b) {
+  static constexpr uint32_t MASK = 0x000f000f;
+  static constexpr uint32_t EX = 0x43004300;
+
+  // Guarantee that the `(a & b) | c` operations are LOP3s.
+  // clang-format off
+  int lo = lop3<(0xf0 & 0xcc) | 0xaa>(q, MASK, EX);
+  q >>= 4;
+  int hi = lop3<(0xf0 & 0xcc) | 0xaa>(q, MASK, EX);
+  // clang-format on
+
+  frag_b[0] = *reinterpret_cast<nv_bfloat162*>(&lo);
+  frag_b[1] = *reinterpret_cast<nv_bfloat162*>(&hi);
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, aphrodite::kU4B8.id(), false>(
+    int q, nv_bfloat162* frag_b) {
+  dequant<nv_bfloat162, aphrodite::kU4B8.id(), true>(q, frag_b);
+
+  static constexpr uint32_t SUB = 0x43084308;
+
+  frag_b[0] = __hsub2(frag_b[0], *reinterpret_cast<const nv_bfloat162*>(&SUB));
+  frag_b[1] = __hsub2(frag_b[1], *reinterpret_cast<const nv_bfloat162*>(&SUB));
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, aphrodite::kU4.id(), true>(
+    int q, nv_bfloat162* frag_b) {
+  dequant<nv_bfloat162, aphrodite::kU4B8.id(), true>(q, frag_b);
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, aphrodite::kU4.id(), false>(
+    int q, nv_bfloat162* frag_b) {
+  dequant<nv_bfloat162, aphrodite::kU4.id(), true>(q, frag_b);
+
+  static constexpr uint32_t SUB = 0x43004300;
+
+  frag_b[0] = __hsub2(frag_b[0], *reinterpret_cast<const nv_bfloat162*>(&SUB));
+  frag_b[1] = __hsub2(frag_b[1], *reinterpret_cast<const nv_bfloat162*>(&SUB));
+}
+
+//
+// Fast Int8ToFp16/Int8ToBf16: Efficiently dequantize 8bit int values to fp16 or
+// bf16 Reference:
+// - FP16:
+// https://github.com/NVIDIA/FasterTransformer/blob/release/v5.3_tag/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h#L53-L85
+// - BF16:
+// https://github.com/NVIDIA/FasterTransformer/blob/release/v5.3_tag/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h#L125-L175
+//
+template <>
+__device__ inline void dequant<half2, aphrodite::kU8B128.id(), true>(
+    int q, half2* frag_b) {
+  static constexpr uint32_t mask_for_elt_01 = 0x5250;
+  static constexpr uint32_t mask_for_elt_23 = 0x5351;
+  static constexpr uint32_t start_byte_for_fp16 = 0x64646464;
+
+  uint32_t lo = prmt<start_byte_for_fp16, mask_for_elt_01>(q);
+  uint32_t hi = prmt<start_byte_for_fp16, mask_for_elt_23>(q);
+
+  frag_b[0] = *reinterpret_cast<half2*>(&lo);
+  frag_b[1] = *reinterpret_cast<half2*>(&hi);
+}
+
+template <>
+__device__ inline void dequant<half2, aphrodite::kU8B128.id(), false>(
+    int q, half2* frag_b) {
+  dequant<half2, aphrodite::kU8B128.id(), true>(q, frag_b);
+
+  static constexpr uint32_t I8s_TO_F16s_MAGIC_NUM = 0x64806480;
+  frag_b[0] = __hsub2(frag_b[0],
+                      *reinterpret_cast<const half2*>(&I8s_TO_F16s_MAGIC_NUM));
+  frag_b[1] = __hsub2(frag_b[1],
+                      *reinterpret_cast<const half2*>(&I8s_TO_F16s_MAGIC_NUM));
+}
+
+template <>
+__device__ inline void dequant<half2, aphrodite::kU8.id(), true>(
+    int q, half2* frag_b) {
+  dequant<half2, aphrodite::kU8B128.id(), true>(q, frag_b);
+}
+
+template <>
+__device__ inline void dequant<half2, aphrodite::kU8.id(), false>(
+    int q, half2* frag_b) {
+  dequant<half2, aphrodite::kU8.id(), true>(q, frag_b);
+
+  static constexpr uint32_t I8s_TO_F16s_MAGIC_NUM = 0x64006400;
+  frag_b[0] = __hsub2(frag_b[0],
+                      *reinterpret_cast<const half2*>(&I8s_TO_F16s_MAGIC_NUM));
+  frag_b[1] = __hsub2(frag_b[1],
+                      *reinterpret_cast<const half2*>(&I8s_TO_F16s_MAGIC_NUM));
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, aphrodite::kU8B128.id(), false>(
+    int q, nv_bfloat162* frag_b) {
+  float fp32_intermediates[4];
+  uint32_t* fp32_intermediates_casted =
+      reinterpret_cast<uint32_t*>(fp32_intermediates);
+
+  static constexpr uint32_t fp32_base = 0x4B000000;
+  fp32_intermediates_casted[0] = __byte_perm(q, fp32_base, 0x7650);
+  fp32_intermediates_casted[1] = __byte_perm(q, fp32_base, 0x7652);
+  fp32_intermediates_casted[2] = __byte_perm(q, fp32_base, 0x7651);
+  fp32_intermediates_casted[3] = __byte_perm(q, fp32_base, 0x7653);
+
+  fp32_intermediates[0] -= 8388736.f;
+  fp32_intermediates[1] -= 8388736.f;
+  fp32_intermediates[2] -= 8388736.f;
+  fp32_intermediates[3] -= 8388736.f;
+
+  uint32_t* bf16_result_ptr = reinterpret_cast<uint32_t*>(frag_b);
+  bf16_result_ptr[0] = __byte_perm(fp32_intermediates_casted[0],
+                                   fp32_intermediates_casted[1], 0x7632);
+  bf16_result_ptr[1] = __byte_perm(fp32_intermediates_casted[2],
+                                   fp32_intermediates_casted[3], 0x7632);
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, aphrodite::kU8.id(), false>(
+    int q, nv_bfloat162* frag_b) {
+  float fp32_intermediates[4];
+  uint32_t* fp32_intermediates_casted =
+      reinterpret_cast<uint32_t*>(fp32_intermediates);
+
+  static constexpr uint32_t fp32_base = 0x4B000000;
+  fp32_intermediates_casted[0] = __byte_perm(q, fp32_base, 0x7650);
+  fp32_intermediates_casted[1] = __byte_perm(q, fp32_base, 0x7652);
+  fp32_intermediates_casted[2] = __byte_perm(q, fp32_base, 0x7651);
+  fp32_intermediates_casted[3] = __byte_perm(q, fp32_base, 0x7653);
+
+  fp32_intermediates[0] -= 8388608.f;
+  fp32_intermediates[1] -= 8388608.f;
+  fp32_intermediates[2] -= 8388608.f;
+  fp32_intermediates[3] -= 8388608.f;
+
+  uint32_t* bf16_result_ptr = reinterpret_cast<uint32_t*>(frag_b);
+  bf16_result_ptr[0] = __byte_perm(fp32_intermediates_casted[0],
+                                   fp32_intermediates_casted[1], 0x7632);
+  bf16_result_ptr[1] = __byte_perm(fp32_intermediates_casted[2],
+                                   fp32_intermediates_casted[3], 0x7632);
+}
+
+template <>
+__device__ inline void dequant<half2, aphrodite::kFE4M3fn.id(), true>(
+    int q, half2* frag_b) {
+  // Constants for FP8 (E4M3) and FP16 formats
+  constexpr int FP8_EXPONENT = 4, FP16_EXPONENT = 5;
+  constexpr int RIGHT_SHIFT = FP16_EXPONENT - FP8_EXPONENT;
+  constexpr int MASK = 0x7F007F00;
+
+  // Extract and shift FP8 values to FP16 format
+  int Out1 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+  q <<= 8;
+  int Out2 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = *reinterpret_cast<const half2*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const half2*>(&Out2);
+}
+
+template <>
+__device__ inline void dequant<half2, aphrodite::kFE4M3fn.id(), false>(
+    int q, half2* frag_b) {
+  dequant<half2, aphrodite::kFE4M3fn.id(), true>(q, frag_b);
+
+  // Constants for FP8 (E4M3) and FP16 formats
+  constexpr int FP8_EXPONENT = 4, FP16_EXPONENT = 5;
+
+  // Construct and apply exponent bias
+  constexpr int BIAS_OFFSET =
+      (1 << (FP16_EXPONENT - 1)) - (1 << (FP8_EXPONENT - 1));
+  const half2 bias_reg = __float2half2_rn(float(1 << BIAS_OFFSET));
+
+  // Convert to half2 and apply bias
+  frag_b[1] = __hmul2(frag_b[1], bias_reg);
+  frag_b[0] = __hmul2(frag_b[0], bias_reg);
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, aphrodite::kFE4M3fn.id(), true>(
+    int q, nv_bfloat162* frag_b) {
+  // Constants for FP8 (E4M3) and BF16 formats
+  constexpr int FP8_EXPONENT = 4, BF16_EXPONENT = 8;
+  constexpr int RIGHT_SHIFT = BF16_EXPONENT - FP8_EXPONENT;
+
+  constexpr int MASK = 0x7F007F00;
+
+  // Extract and shift FP8 values to BF16 format
+  int Out1 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+  q <<= 8;
+  int Out2 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, aphrodite::kFE4M3fn.id(), false>(
+    int q, nv_bfloat162* frag_b) {
+  dequant<nv_bfloat162, aphrodite::kFE4M3fn.id(), true>(q, frag_b);
+
+  // Constants for FP8 (E4M3) and BF16 formats
+  constexpr int FP8_EXPONENT = 4, BF16_EXPONENT = 8;
+
+  // Construct and apply exponent bias
+  constexpr int BIAS_OFFSET =
+      (1 << (BF16_EXPONENT - 1)) - (1 << (FP8_EXPONENT - 1));
+  // Add 127 (float exponent bias) to BIAS_OFFSET and shift to float exponent
+  // position
+  constexpr uint32_t BIAS = (BIAS_OFFSET + 127) << 23;
+  const nv_bfloat162 bias_reg =
+      __float2bfloat162_rn(*reinterpret_cast<const float*>(&BIAS));
+
+  // Convert to bfloat162 and apply bias
+  frag_b[1] = __hmul2(frag_b[1], bias_reg);
+  frag_b[0] = __hmul2(frag_b[0], bias_reg);
+}
+
+template <>
+__device__ inline void dequant<half2, aphrodite::kFE2M1f.id(), true>(
+    int q, half2* frag_b) {
+  // Constants for FP4 (E2M1) and FP16 formats
+  constexpr int FP4_EXPONENT = 2, FP16_EXPONENT = 5;
+  constexpr int RIGHT_SHIFT = FP16_EXPONENT - FP4_EXPONENT;
+  constexpr int MASK = 0x70007000;
+
+  // Extract and shift FP4 values to FP16 format
+  int Out1 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+  q <<= 4;
+  int Out2 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = *reinterpret_cast<const half2*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const half2*>(&Out2);
+}
+
+template <>
+__device__ inline void dequant<half2, aphrodite::kFE2M1f.id(), false>(
+    int q, half2* frag_b) {
+  dequant<half2, aphrodite::kFE2M1f.id(), true>(q, frag_b);
+
+  // Constants for FP4 (E2M1) and FP16 formats
+  constexpr int FP4_EXPONENT = 2, FP16_EXPONENT = 5;
+
+  // Construct and apply exponent bias
+  constexpr int BIAS_OFFSET =
+      (1 << (FP16_EXPONENT - 1)) - (1 << (FP4_EXPONENT - 1));
+  const half2 bias_reg = __float2half2_rn(float(1 << BIAS_OFFSET));
+
+  // Convert to half2 and apply bias
+  frag_b[1] = __hmul2(frag_b[1], bias_reg);
+  frag_b[0] = __hmul2(frag_b[0], bias_reg);
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, aphrodite::kFE2M1f.id(), true>(
+    int q, nv_bfloat162* frag_b) {
+  // Constants for FP4 (E2M1) and FP16 formats
+  constexpr int FP4_EXPONENT = 2, BF16_EXPONENT = 8;
+  constexpr int RIGHT_SHIFT = BF16_EXPONENT - FP4_EXPONENT;
+  constexpr int MASK = 0x70007000;
+
+  // Extract and shift FP4 values to FP16 format
+  int Out1 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+  q <<= 4;
+  int Out2 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
+}
+
+template <>
+__device__ inline void dequant<nv_bfloat162, aphrodite::kFE2M1f.id(), false>(
+    int q, nv_bfloat162* frag_b) {
+  dequant<nv_bfloat162, aphrodite::kFE2M1f.id(), true>(q, frag_b);
+
+  // Constants for FP4 (E2M1) and BF16 formats
+  constexpr int FP4_EXPONENT = 2, BF16_EXPONENT = 8;
+
+  // Construct and apply exponent bias
+  constexpr int BIAS_OFFSET =
+      (1 << (BF16_EXPONENT - 1)) - (1 << (FP4_EXPONENT - 1));
+  // Add 127 (float exponent bias) to BIAS_OFFSET and shift to float exponent
+  // position
+  constexpr uint32_t BIAS = (BIAS_OFFSET + 127) << 23;
+  const nv_bfloat162 bias_reg =
+      __float2bfloat162_rn(*reinterpret_cast<const float*>(&BIAS));
+
+  // Convert to half2 and apply bias
+  frag_b[1] = __hmul2(frag_b[1], bias_reg);
+  frag_b[0] = __hmul2(frag_b[0], bias_reg);
+}
+
+template <>
+__device__ inline void dequant<__nv_fp8x4_e4m3, aphrodite::kFE2M1f.id(), true>(
+    int q, __nv_fp8x4_e4m3* frag_b) {
+  // Constants for FP4 (E2M1) and FP16 formats
+  constexpr int FP4_EXPONENT = 2, FP8_EXPONENT = 4;
+  constexpr int RIGHT_SHIFT = FP8_EXPONENT - FP4_EXPONENT;
+  constexpr int MASK = 0x70707070;
+
+  // Extract and shift FP4 values to FP16 format
+  int Out1 = (q & 0x80808080) | ((q & MASK) >> RIGHT_SHIFT);
+  q <<= 4;
+  int Out2 = (q & 0x80808080) | ((q & MASK) >> RIGHT_SHIFT);
+
+  // Note1: reverse indexing is intentional because weights are permuted
+  // Note2: when dequant to 8bit type, we write to `frag_b[2]` instead of
+  //        `frag_b[1]` to fit the layout of tensorcore
+  frag_b[1] = *reinterpret_cast<const __nv_fp8x4_e4m3*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const __nv_fp8x4_e4m3*>(&Out2);
+}
+
+template <>
+__device__ inline void dequant<int32_t, aphrodite::kU4B8.id(), true>(
+    int q, int32_t* frag_b) {
+  constexpr int repeated_zp = 0x08080808;
+  constexpr int MASK = 0x80808080;
+
+  frag_b[0] = ((q & 0x0F0F0F0F | MASK) - repeated_zp) ^ MASK;
+  q >>= 4;
+  frag_b[1] = ((q & 0x0F0F0F0F | MASK) - repeated_zp) ^ MASK;
+}
+
+template <>
+__device__ inline void dequant<__nv_fp8x4_e4m3, aphrodite::kU4B8.id(), true>(
+    int q, __nv_fp8x4_e4m3* frag_b) {
+  int s = q & 0x08080808;
+  int Out1 = ((q & 0x07070707) | (s << 4)) + (s >> 3);
+  q >>= 4;
+  s = q & 0x08080808;
+  int Out2 = ((q & 0x07070707) | (s << 4)) + (s >> 3);
+
+  frag_b[0] = *reinterpret_cast<const __nv_fp8x4_e4m3*>(&Out1);
+  frag_b[1] = *reinterpret_cast<const __nv_fp8x4_e4m3*>(&Out2);
+}
+
+template <typename scalar_t2, aphrodite::ScalarTypeId s_type_id>
+__device__ inline void dequant_fp8_scales(int q, scalar_t2* frag_b);
+
+template <>
+__device__ inline void dequant_fp8_scales<half2, aphrodite::kFE4M3fn.id()>(
+    int q, half2* frag_b) {
+  int Out1 = (q & 0xFF00FF00) >> 1;
+  ;
+  q <<= 8;
+  int Out2 = (q & 0xFF00FF00) >> 1;
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = *reinterpret_cast<const half2*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const half2*>(&Out2);
+};
+
+template <>
+__device__ inline void
+dequant_fp8_scales<nv_bfloat162, aphrodite::kFE4M3fn.id()>(
+    int q, nv_bfloat162* frag_b) {
+  constexpr int FP8_EXPONENT = 4, BF16_EXPONENT = 8;
+  constexpr int RIGHT_SHIFT = BF16_EXPONENT - FP8_EXPONENT;
+  constexpr int MASK = 0x7F007F00;
+
+  // Extract and shift FP8 values to BF16 format
+  int Out1 = ((q & 0x80008000) >> 1) | ((q & MASK) >> RIGHT_SHIFT);
+  q <<= 8;
+  int Out2 = ((q & 0x80008000) >> 1) | ((q & MASK) >> RIGHT_SHIFT);
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
+}
+
+template <>
+__device__ inline void
+dequant_fp8_scales<nv_bfloat162, aphrodite::kFE8M0fnu.id()>(
+    int q, nv_bfloat162* frag_b) {
+  // In this conversion, 2 ** -127 in FP8E8M0 would become 0 in BF16,
+  // but we assume that such a extreme value would not occur in real models.
+  int Out1 = (q & 0xFF00FF00) >> 1;
+  q <<= 7;
+  int Out2 = q & 0x7F807F80;
+
+  // Note: reverse indexing is intentional because weights are permuted
+  frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
+};
+
+// subtract zero point in quanted format and then dequant
+template <typename scalar_t2, aphrodite::ScalarTypeId w_type_id,
+          bool skip_flop = false>
+__device__ inline void sub_zp_and_dequant(int q, scalar_t2* frag_b, int zp);
+
+template <>
+__device__ inline void sub_zp_and_dequant<int32_t, aphrodite::kU4.id(), true>(
+    int q, int32_t* frag_b, int zp) {
+  // INT4 with zp -> INT8
+  // see https://github.com/vllm-project/vllm/pull/24722
+  int repeated_zp = 0x01010101 * zp;
+  int MASK = 0x80808080;
+
+  frag_b[0] = ((q & 0x0F0F0F0F | MASK) - repeated_zp) ^ MASK;
+  q >>= 4;
+  frag_b[1] = ((q & 0x0F0F0F0F | MASK) - repeated_zp) ^ MASK;
+}
+
+template <>
+__device__ inline void sub_zp_and_dequant<__nv_fp8x4_e4m3, aphrodite::kU4.id(),
+                                          true>(int q, __nv_fp8x4_e4m3* frag_b,
+                                                int zp) {
+  // INT4 with zp -> FP8
+  // see https://github.com/vllm-project/vllm/pull/24722
+  uint32_t u_q = *reinterpret_cast<uint32_t*>(&q);
+  uint32_t u_zp = *reinterpret_cast<uint32_t*>(&zp);
+  uint32_t u_zp1 = u_zp + 1;
+  uint32_t repeated_zp = 0x01010101 * u_zp;
+
+  uint32_t q0, s;
+  q0 = (u_q & 0x0F0F0F0F) | 0x70707070;
+  s = (q0 + repeated_zp) & 0x80808080;
+  uint32_t Out1 = (q0 + (s >> 7) * u_zp1) & 0x0F0F0F0F | s;
+
+  u_q >>= 4;
+  q0 = (u_q & 0x0F0F0F0F) | 0x70707070;
+  s = (q0 + repeated_zp) & 0x80808080;
+  uint32_t Out2 = (q0 + (s >> 7) * u_zp1) & 0x0F0F0F0F | s;
+
+  frag_b[0] = *reinterpret_cast<const __nv_fp8x4_e4m3*>(&Out1);
+  frag_b[1] = *reinterpret_cast<const __nv_fp8x4_e4m3*>(&Out2);
+}
+
+#endif
+
+}  // namespace MARLIN_NAMESPACE_NAME

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/marlin/gptq_marlin_repack.cu
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/marlin/gptq_marlin_repack.cu
@@ -1,0 +1,371 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+#include "marlin.cuh"
+
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include "libtorch_stable/torch_utils.h"
+
+namespace marlin {
+
+template <int const num_threads, int const num_bits, bool const has_perm,
+          bool is_a_8bit>
+__global__ void gptq_marlin_repack_kernel(
+    uint32_t const* __restrict__ b_q_weight_ptr,
+    uint32_t const* __restrict__ perm_ptr, uint32_t* __restrict__ out_ptr,
+    int size_k, int size_n) {
+  constexpr int pack_factor = 32 / num_bits;
+
+  constexpr int target_tile_n_size = tile_n_size / (is_a_8bit ? 2 : 1);
+  constexpr int target_tile_k_size = tile_k_size * (is_a_8bit ? 2 : 1);
+  int k_tiles = size_k / target_tile_k_size;
+  int n_tiles = size_n / target_tile_n_size;
+  int block_k_tiles = div_ceil(k_tiles, gridDim.x);
+
+  auto start_k_tile = blockIdx.x * block_k_tiles;
+  if (start_k_tile >= k_tiles) {
+    return;
+  }
+
+  int finish_k_tile = min(start_k_tile + block_k_tiles, k_tiles);
+
+  // Wait until the next thread tile has been loaded to shared memory.
+  auto wait_for_stage = [&]() {
+    // We only have `stages - 2` active fetches since we are double buffering
+    // and can only issue the next fetch when it is guaranteed that the previous
+    // shared memory load is fully complete (as it may otherwise be
+    // overwritten).
+    cp_async_wait<repack_stages - 2>();
+    __syncthreads();
+  };
+
+  extern __shared__ int4 sh[];
+
+  constexpr int perm_size = target_tile_k_size / 4;
+
+  int4* sh_perm_ptr = sh;
+  int4* sh_pipe_ptr = sh_perm_ptr;
+  if constexpr (has_perm) {
+    sh_pipe_ptr += perm_size;
+  }
+
+  constexpr int tile_ints = target_tile_k_size / pack_factor;
+
+  constexpr int stage_n_threads = target_tile_n_size / 4;
+  constexpr int stage_k_threads = has_perm ? target_tile_k_size : tile_ints;
+  constexpr int stage_size = stage_k_threads * stage_n_threads;
+
+  auto load_perm_to_shared = [&](int k_tile_id) {
+    int first_k_int4 = (k_tile_id * target_tile_k_size) / 4;
+
+    int4 const* perm_int4_ptr = reinterpret_cast<int4 const*>(perm_ptr);
+
+    if (threadIdx.x < perm_size) {
+      sh_perm_ptr[threadIdx.x] = perm_int4_ptr[first_k_int4 + threadIdx.x];
+    }
+    __syncthreads();
+  };
+
+  auto fetch_to_shared = [&](int pipe, int k_tile_id, int n_tile_id) {
+    if (n_tile_id >= n_tiles) {
+      cp_async_fence();
+      return;
+    }
+
+    int first_n = n_tile_id * target_tile_n_size;
+
+    int4* sh_ptr = sh_pipe_ptr + stage_size * pipe;
+
+    if constexpr (has_perm) {
+      if (threadIdx.x < stage_size) {
+        auto k_id = threadIdx.x / stage_n_threads;
+        auto n_id = threadIdx.x % stage_n_threads;
+
+        uint32_t const* sh_perm_int_ptr =
+            reinterpret_cast<uint32_t const*>(sh_perm_ptr);
+
+        int src_k = sh_perm_int_ptr[k_id];
+        int src_k_packed = src_k / pack_factor;
+
+        cp_async4(
+            &sh_ptr[k_id * stage_n_threads + n_id],
+            reinterpret_cast<int4 const*>(&(
+                b_q_weight_ptr[src_k_packed * size_n + first_n + (n_id * 4)])));
+      }
+
+    } else {
+      if (threadIdx.x < stage_size) {
+        auto k_id = threadIdx.x / stage_n_threads;
+        auto n_id = threadIdx.x % stage_n_threads;
+
+        int first_k = k_tile_id * target_tile_k_size;
+        int first_k_packed = first_k / pack_factor;
+
+        cp_async4(&sh_ptr[k_id * stage_n_threads + n_id],
+                  reinterpret_cast<int4 const*>(
+                      &(b_q_weight_ptr[(first_k_packed + k_id) * size_n +
+                                       first_n + (n_id * 4)])));
+      }
+    }
+
+    cp_async_fence();
+  };
+
+  auto repack_tile = [&](int pipe, int k_tile_id, int n_tile_id) {
+    if (n_tile_id >= n_tiles) {
+      return;
+    }
+
+    auto warp_id = threadIdx.x / 32;
+    auto th_id = threadIdx.x % 32;
+
+    if (warp_id >= 4) {
+      return;
+    }
+
+    int tc_col = th_id / 4;
+    int tc_row = (th_id % 4) * (is_a_8bit ? 4 : 2);
+
+    constexpr int tc_offsets[4] = {0, 1, 8, 9};
+
+    int cur_n = (warp_id / (is_a_8bit ? 2 : 1)) * 16 + tc_col;
+
+    constexpr int sh_stride = target_tile_n_size;
+    constexpr uint32_t mask = (1 << num_bits) - 1;
+
+    int4* sh_stage_ptr = sh_pipe_ptr + stage_size * pipe;
+    uint32_t* sh_stage_int_ptr = reinterpret_cast<uint32_t*>(sh_stage_ptr);
+
+    uint32_t* sh_perm_int_ptr = reinterpret_cast<uint32_t*>(sh_perm_ptr);
+
+    uint32_t vals[8];
+
+    if constexpr (has_perm) {
+      static_assert(!is_a_8bit);
+      for (int i = 0; i < 4; i++) {
+        int k_idx = tc_row + tc_offsets[i];
+
+        uint32_t src_k = sh_perm_int_ptr[k_idx];
+        uint32_t src_k_pos = src_k % pack_factor;
+
+        uint32_t b1_val = sh_stage_int_ptr[k_idx * sh_stride + cur_n];
+        uint32_t b1_cur_val = (b1_val >> (src_k_pos * num_bits)) & mask;
+
+        uint32_t b2_val = sh_stage_int_ptr[k_idx * sh_stride + cur_n + 8];
+        uint32_t b2_cur_val = (b2_val >> (src_k_pos * num_bits)) & mask;
+
+        vals[i] = b1_cur_val;
+        vals[4 + i] = b2_cur_val;
+      }
+
+    } else {
+      uint32_t b1_vals[tile_ints];
+      uint32_t b2_vals[tile_ints];
+
+#pragma unroll
+      for (int i = 0; i < tile_ints; i++) {
+        if constexpr (is_a_8bit) {
+          b1_vals[i] =
+              sh_stage_int_ptr[cur_n + sh_stride * i + (warp_id % 2) * 8];
+        } else {
+          b1_vals[i] = sh_stage_int_ptr[cur_n + sh_stride * i];
+          b2_vals[i] = sh_stage_int_ptr[cur_n + 8 + sh_stride * i];
+        }
+      }
+
+#pragma unroll
+      for (int i = 0; i < 4; i++) {
+        int cur_elem = tc_row + (is_a_8bit ? i : tc_offsets[i]);
+        int cur_int = cur_elem / pack_factor;
+        int cur_pos = cur_elem % pack_factor;
+
+        vals[i] = (b1_vals[cur_int] >> (cur_pos * num_bits)) & mask;
+        if constexpr (is_a_8bit)
+          vals[4 + i] =
+              (b1_vals[cur_int + tile_ints / 2] >> (cur_pos * num_bits)) & mask;
+        else
+          vals[4 + i] = (b2_vals[cur_int] >> (cur_pos * num_bits)) & mask;
+      }
+    }
+
+    constexpr int tile_size =
+        target_tile_k_size * target_tile_n_size / pack_factor;
+    int out_offset = (k_tile_id * n_tiles + n_tile_id) * tile_size;
+
+    // Result of:
+    // https://github.com/NVIDIA/FasterTransformer/blob/main/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h
+    if constexpr (!is_a_8bit && num_bits == 4) {
+      int pack_idx[8] = {0, 2, 4, 6, 1, 3, 5, 7};
+
+      uint32_t res = 0;
+#pragma unroll
+      for (int i = 0; i < 8; i++) {
+        res |= vals[pack_idx[i]] << (i * 4);
+      }
+
+      out_ptr[out_offset + th_id * 4 + warp_id] = res;
+
+    } else if constexpr (is_a_8bit && num_bits == 4) {
+      int pack_idx[8] = {0, 4, 1, 5, 2, 6, 3, 7};
+
+      uint32_t res = 0;
+#pragma unroll
+      for (int i = 0; i < 8; i++) {
+        res |= vals[pack_idx[i]] << (i * 4);
+      }
+
+      out_ptr[out_offset + th_id * 4 + warp_id] = res;
+
+    } else {
+      constexpr int pack_idx[4] = {0, 2, 1, 3};
+
+      uint32_t res1 = 0;
+      uint32_t res2 = 0;
+#pragma unroll
+      for (int i = 0; i < 4; i++) {
+        const int ii = is_a_8bit ? i : pack_idx[i];
+        res1 |= vals[ii] << (i * 8);
+        res2 |= vals[4 + ii] << (i * 8);
+      }
+
+      out_ptr[out_offset + th_id * 8 + (warp_id * 2) + 0] = res1;
+      out_ptr[out_offset + th_id * 8 + (warp_id * 2) + 1] = res2;
+    }
+  };
+
+  auto start_pipes = [&](int k_tile_id, int n_tile_id) {
+#pragma unroll
+    for (int pipe = 0; pipe < repack_stages - 1; pipe++) {
+      fetch_to_shared(pipe, k_tile_id, n_tile_id + pipe);
+    }
+
+    wait_for_stage();
+  };
+#pragma unroll
+  for (int k_tile_id = start_k_tile; k_tile_id < finish_k_tile; k_tile_id++) {
+    int n_tile_id = 0;
+
+    if constexpr (has_perm) {
+      load_perm_to_shared(k_tile_id);
+    }
+
+    start_pipes(k_tile_id, n_tile_id);
+
+    while (n_tile_id < n_tiles) {
+#pragma unroll
+      for (int pipe = 0; pipe < repack_stages; pipe++) {
+        fetch_to_shared((pipe + repack_stages - 1) % repack_stages, k_tile_id,
+                        n_tile_id + pipe + repack_stages - 1);
+        repack_tile(pipe, k_tile_id, n_tile_id + pipe);
+        wait_for_stage();
+      }
+      n_tile_id += repack_stages;
+    }
+  }
+}
+
+}  // namespace marlin
+
+#define CALL_IF(NUM_BITS, HAS_PERM, IS_A_8BIT)                              \
+  else if (num_bits == NUM_BITS && has_perm == HAS_PERM &&                  \
+           is_a_8bit == IS_A_8BIT) {                                        \
+    cudaFuncSetAttribute(                                                   \
+        marlin::gptq_marlin_repack_kernel<marlin::repack_threads, NUM_BITS, \
+                                          HAS_PERM, IS_A_8BIT>,             \
+        cudaFuncAttributeMaxDynamicSharedMemorySize, max_shared_mem);       \
+    marlin::gptq_marlin_repack_kernel<marlin::repack_threads, NUM_BITS,     \
+                                      HAS_PERM, IS_A_8BIT>                  \
+        <<<blocks, marlin::repack_threads, max_shared_mem, stream>>>(       \
+            b_q_weight_ptr, perm_ptr, out_ptr, size_k, size_n);             \
+  }
+
+torch::stable::Tensor gptq_marlin_repack(torch::stable::Tensor& b_q_weight,
+                                         torch::stable::Tensor& perm,
+                                         int64_t size_k, int64_t size_n,
+                                         int64_t num_bits, bool is_a_8bit) {
+  // Verify compatibility with marlin tile of 16x64
+  STD_TORCH_CHECK(size_k % marlin::tile_k_size == 0, "size_k = ", size_k,
+                  " is not divisible by tile_k_size = ", marlin::tile_k_size);
+  STD_TORCH_CHECK(size_n % marlin::tile_n_size == 0, "size_n = ", size_n,
+                  " is not divisible by tile_n_size = ", marlin::tile_n_size);
+
+  STD_TORCH_CHECK(num_bits == 4 || num_bits == 8,
+                  "num_bits must be 4 or 8. Got = ", num_bits);
+  int const pack_factor = 32 / num_bits;
+
+  // Verify B
+  STD_TORCH_CHECK((size_k / pack_factor) == b_q_weight.size(0),
+                  "Shape mismatch: b_q_weight.size(0) = ", b_q_weight.size(0),
+                  ", size_k = ", size_k, ", pack_factor = ", pack_factor);
+  STD_TORCH_CHECK(b_q_weight.size(1) == size_n,
+                  "b_q_weight.size(1) = ", b_q_weight.size(1),
+                  " is not size_n = ", size_n);
+
+  // Verify device and strides
+  STD_TORCH_CHECK(b_q_weight.is_cuda(), "b_q_weight is not on GPU");
+  STD_TORCH_CHECK(b_q_weight.is_contiguous(), "b_q_weight is not contiguous");
+  STD_TORCH_CHECK(
+      b_q_weight.scalar_type() == torch::headeronly::ScalarType::Int,
+      "b_q_weight type is not kInt");
+
+  STD_TORCH_CHECK(perm.is_cuda(), "perm is not on GPU");
+  STD_TORCH_CHECK(perm.is_contiguous(), "perm is not contiguous");
+  STD_TORCH_CHECK(perm.scalar_type() == torch::headeronly::ScalarType::Int,
+                  "perm type is not at::kInt");
+
+  const int32_t device_index = b_q_weight.get_device_index();
+  torch::stable::accelerator::DeviceGuard device_guard(device_index);
+  const cudaStream_t stream = get_current_cuda_stream(device_index);
+
+  // Alloc buffers
+  torch::stable::Tensor out = torch::stable::empty(
+      {size_k / marlin::tile_size, size_n * marlin::tile_size / pack_factor},
+      b_q_weight.scalar_type(), std::nullopt, b_q_weight.device());
+
+  // Detect if there is act_order
+  bool has_perm = perm.size(0) != 0;
+
+  // Get ptrs
+  uint32_t const* b_q_weight_ptr =
+      reinterpret_cast<uint32_t const*>(b_q_weight.const_data_ptr());
+  uint32_t const* perm_ptr =
+      reinterpret_cast<uint32_t const*>(perm.const_data_ptr());
+  uint32_t* out_ptr = reinterpret_cast<uint32_t*>(out.mutable_data_ptr());
+
+  int blocks;
+  cudaDeviceGetAttribute(&blocks, cudaDevAttrMultiProcessorCount, device_index);
+
+  int max_shared_mem = 0;
+  cudaDeviceGetAttribute(&max_shared_mem,
+                         cudaDevAttrMaxSharedMemoryPerBlockOptin, device_index);
+  STD_TORCH_CHECK(max_shared_mem > 0);
+
+  if (false) {
+  }
+  CALL_IF(4, false, false)
+  CALL_IF(4, true, false)
+  CALL_IF(8, false, false)
+  CALL_IF(8, true, false)
+
+  CALL_IF(4, false, true)
+  CALL_IF(8, false, true)
+
+  else {
+    STD_TORCH_CHECK(false, "Unsupported repack config: num_bits = ", num_bits,
+                    ", has_perm = ", has_perm, ", is_a_8bit = ", is_a_8bit);
+  }
+
+  return out;
+}
+

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/marlin/marlin.cuh
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/marlin/marlin.cuh
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+#pragma once
+
+#ifndef _marlin_cuh
+  #define _marlin_cuh
+  #include <cuda.h>
+  #include <cuda_fp16.h>
+  #include <cuda_runtime.h>
+  #include <iostream>
+
+  #ifndef MARLIN_NAMESPACE_NAME
+    #define MARLIN_NAMESPACE_NAME marlin
+  #endif
+
+namespace MARLIN_NAMESPACE_NAME {
+
+// Marlin params
+
+// 8 warps are a good choice since every SM has 4 schedulers and having more
+// than 1 warp per schedule allows some more latency hiding. At the same time,
+// we want relatively few warps to have many registers per warp and small tiles.
+static constexpr int default_threads = 256;
+
+static constexpr int pipe_stages =
+    4;  // 4 pipeline stages fit into shared memory
+
+static constexpr int min_thread_n = 64;
+static constexpr int min_thread_k = 64;
+static constexpr int max_thread_n = 256;
+
+static constexpr int tile_size = 16;
+static constexpr int max_par = 16;
+
+// Repack params
+static constexpr int repack_stages = 8;
+
+static constexpr int repack_threads = 256;
+
+static constexpr int tile_k_size = tile_size;
+static constexpr int tile_n_size = tile_k_size * 4;
+
+// Helpers
+template <typename T, int n>
+struct Vec {
+  T elems[n];
+  __device__ T& operator[](int i) { return elems[i]; }
+};
+
+using I4 = Vec<int, 4>;
+
+constexpr int div_ceil(int a, int b) { return (a + b - 1) / b; }
+
+  #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+
+__device__ inline void cp_async1_ca_pred(void* smem_ptr, const void* glob_ptr,
+                                         bool pred = true) {
+  if (pred) {
+    reinterpret_cast<int32_t*>(smem_ptr)[0] =
+        reinterpret_cast<const int32_t*>(glob_ptr)[0];
+  }
+}
+
+__device__ inline void cp_async2_ca_pred(void* smem_ptr, const void* glob_ptr,
+                                         bool pred = true) {
+  if (pred) {
+    reinterpret_cast<int64_t*>(smem_ptr)[0] =
+        reinterpret_cast<const int64_t*>(glob_ptr)[0];
+  }
+}
+
+__device__ inline void cp_async4_ca_pred(void* smem_ptr, const void* glob_ptr,
+                                         bool pred = true) {
+  if (pred) {
+    reinterpret_cast<int4*>(smem_ptr)[0] =
+        reinterpret_cast<const int4*>(glob_ptr)[0];
+  }
+}
+
+__device__ inline void cp_async4_pred(void* smem_ptr, const void* glob_ptr,
+                                      bool pred = true) {
+  if (pred) {
+    reinterpret_cast<int4*>(smem_ptr)[0] =
+        reinterpret_cast<const int4*>(glob_ptr)[0];
+  }
+}
+
+__device__ inline void cp_async4(void* smem_ptr, const void* glob_ptr) {
+  reinterpret_cast<int4*>(smem_ptr)[0] =
+      reinterpret_cast<const int4*>(glob_ptr)[0];
+}
+
+__device__ inline void cp_async_fence() {}
+
+template <int n>
+__device__ inline void cp_async_wait() {}
+
+  #else
+
+__device__ inline void cp_async1_ca_pred(void* smem_ptr, const void* glob_ptr,
+                                         bool pred = true) {
+  const int BYTES = 4;
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+      "{\n"
+      "   .reg .pred p;\n"
+      "   setp.ne.b32 p, %0, 0;\n"
+      "   @p cp.async.ca.shared.global [%1], [%2], %3;\n"
+      "}\n" ::"r"((int)pred),
+      "r"(smem), "l"(glob_ptr), "n"(BYTES));
+}
+
+__device__ inline void cp_async2_ca_pred(void* smem_ptr, const void* glob_ptr,
+                                         bool pred = true) {
+  const int BYTES = 8;
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+      "{\n"
+      "   .reg .pred p;\n"
+      "   setp.ne.b32 p, %0, 0;\n"
+      "   @p cp.async.ca.shared.global [%1], [%2], %3;\n"
+      "}\n" ::"r"((int)pred),
+      "r"(smem), "l"(glob_ptr), "n"(BYTES));
+}
+
+__device__ inline void cp_async4_ca_pred(void* smem_ptr, const void* glob_ptr,
+                                         bool pred = true) {
+  const int BYTES = 16;
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+      "{\n"
+      "   .reg .pred p;\n"
+      "   setp.ne.b32 p, %0, 0;\n"
+      "   @p cp.async.ca.shared.global [%1], [%2], %3;\n"
+      "}\n" ::"r"((int)pred),
+      "r"(smem), "l"(glob_ptr), "n"(BYTES));
+}
+
+__device__ inline void cp_async4_pred(void* smem_ptr, const void* glob_ptr,
+                                      bool pred = true) {
+  const int BYTES = 16;
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+      "{\n"
+      "   .reg .pred p;\n"
+      "   setp.ne.b32 p, %0, 0;\n"
+      "   @p cp.async.cg.shared.global [%1], [%2], %3;\n"
+      "}\n" ::"r"((int)pred),
+      "r"(smem), "l"(glob_ptr), "n"(BYTES));
+}
+
+__device__ inline void cp_async4(void* smem_ptr, const void* glob_ptr) {
+  const int BYTES = 16;
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+      "{\n"
+      "   cp.async.cg.shared.global [%0], [%1], %2;\n"
+      "}\n" ::"r"(smem),
+      "l"(glob_ptr), "n"(BYTES));
+}
+
+__device__ inline void cp_async_fence() {
+  asm volatile("cp.async.commit_group;\n" ::);
+}
+
+template <int n>
+__device__ inline void cp_async_wait() {
+  asm volatile("cp.async.wait_group %0;\n" ::"n"(n));
+}
+
+  #endif
+
+}  // namespace MARLIN_NAMESPACE_NAME
+
+#endif

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/marlin/marlin_dtypes.cuh
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/marlin/marlin_dtypes.cuh
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+
+#ifndef _data_types_cuh
+#define _data_types_cuh
+#include "marlin.cuh"
+#include "core/scalar_type.hpp"
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+#ifndef MARLIN_NAMESPACE_NAME
+  #define MARLIN_NAMESPACE_NAME marlin
+#endif
+
+namespace MARLIN_NAMESPACE_NAME {
+
+template <long scalar_type_id>
+class MarlinScalarType {};
+
+template <>
+class MarlinScalarType<aphrodite::kFloat16.id()> {
+ public:
+  using scalar_t = half;
+  using scalar_t2 = half2;
+  using scalar_t4 = half2;
+  using scalar_32bit_t = half2;
+
+  // Matrix fragments for tensor core instructions; their precise layout is
+  // documented here:
+  // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m16n8k16-with-floating-point-type
+  using FragA = Vec<half2, 4>;
+  using FragB = Vec<half2, 2>;
+  using FragC = Vec<float, 4>;
+  using FragS = Vec<half2, 1>;
+  using FragS0 = Vec<__nv_fp8x2_e4m3, 1>;
+  using FragZP = Vec<half2, 4>;
+
+  static __device__ float inline num2float(const half x) {
+    return __half2float(x);
+  }
+
+  static __device__ half2 inline num2num2(const half x) {
+    return __half2half2(x);
+  }
+
+  static __device__ half2 inline nums2num2(const half x1, const half x2) {
+    return __halves2half2(x1, x2);
+  }
+
+  static __host__ __device__ half inline float2num(const float x) {
+    return __float2half(x);
+  }
+
+  static __host__ __device__ float2 inline num22float2(const half2 x) {
+    return __half22float2(x);
+  }
+};
+
+template <>
+class MarlinScalarType<aphrodite::kBFloat16.id()> {
+ public:
+  using scalar_t = nv_bfloat16;
+  using scalar_t2 = nv_bfloat162;
+  using scalar_t4 = nv_bfloat162;
+  using scalar_32bit_t = nv_bfloat162;
+
+  using FragA = Vec<nv_bfloat162, 4>;
+  using FragB = Vec<nv_bfloat162, 2>;
+  using FragC = Vec<float, 4>;
+  using FragS = Vec<nv_bfloat162, 1>;
+  using FragS0 = Vec<__nv_fp8x2_e4m3, 1>;
+  using FragZP = Vec<nv_bfloat162, 4>;
+
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 800
+  static __device__ float inline num2float(const nv_bfloat16 x) {
+    return __bfloat162float(x);
+  }
+
+  static __device__ nv_bfloat162 inline num2num2(const nv_bfloat16 x) {
+    return __bfloat162bfloat162(x);
+  }
+
+  static __device__ nv_bfloat162 inline nums2num2(const nv_bfloat16 x1,
+                                                  const nv_bfloat16 x2) {
+    return __halves2bfloat162(x1, x2);
+  }
+
+  static __host__ __device__ nv_bfloat16 inline float2num(const float x) {
+    return __float2bfloat16(x);
+  }
+
+  static __host__ __device__ float2 inline num22float2(const nv_bfloat162 x) {
+    return __bfloat1622float2(x);
+  }
+#endif
+};
+
+template <>
+class MarlinScalarType<aphrodite::kFE4M3fn.id()> {
+ public:
+  using scalar_t = __nv_fp8_e4m3;
+  using scalar_t2 = __nv_fp8x2_e4m3;
+  using scalar_t4 = __nv_fp8x4_e4m3;
+  using scalar_32bit_t = __nv_fp8x4_e4m3;
+
+  using FragA = Vec<__nv_fp8x4_e4m3, 4>;
+  using FragB = Vec<__nv_fp8x4_e4m3, 2>;
+  using FragC = Vec<float, 4>;
+  using FragZP = Vec<__nv_fp8x2_e4m3, 4>;
+
+  static __host__ __device__
+      float2 inline num22float2(const __nv_fp8x2_e4m3 x) {
+    return (float2)x;
+  }
+};
+
+template <>
+class MarlinScalarType<aphrodite::kS8.id()> {
+ public:
+  using scalar_t = int8_t;
+  using scalar_t2 = int16_t;
+  using scalar_t4 = int32_t;
+  using scalar_32bit_t = int32_t;
+
+  using FragA = Vec<int32_t, 4>;
+  using FragB = Vec<int32_t, 2>;
+  using FragC = Vec<float, 4>;
+  using FragZP = Vec<int16_t, 4>;
+};
+
+template <typename scalar_t>
+class MarlinScalarType2 {};
+
+template <>
+class MarlinScalarType2<half>
+    : public MarlinScalarType<aphrodite::kFloat16.id()> {};
+
+template <>
+class MarlinScalarType2<nv_bfloat16>
+    : public MarlinScalarType<aphrodite::kBFloat16.id()> {};
+
+template <>
+class MarlinScalarType2<__nv_fp8_e4m3>
+    : public MarlinScalarType<aphrodite::kFE4M3fn.id()> {};
+
+template <>
+class MarlinScalarType2<int8_t> : public MarlinScalarType<aphrodite::kS8.id()> {
+};
+
+}  // namespace MARLIN_NAMESPACE_NAME
+
+#endif

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/marlin/marlin_mma.h
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/marlin/marlin_mma.h
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+
+#include "marlin_dtypes.cuh"
+
+namespace MARLIN_NAMESPACE_NAME {
+
+// m16n8k16 tensor core mma instruction with fp16 inputs and fp32
+// output/accumulation.
+template <aphrodite::ScalarTypeId type_id, bool use_fp16_accum, int k_size = 16>
+__device__ inline void mma(
+    const typename MarlinScalarType<type_id>::FragA& a_frag,
+    const typename MarlinScalarType<type_id>::FragB& frag_b,
+    typename MarlinScalarType<type_id>::FragC& frag_c, int idx = 0) {
+  const uint32_t* a = reinterpret_cast<const uint32_t*>(&a_frag);
+  const uint32_t* b = reinterpret_cast<const uint32_t*>(&frag_b);
+  using scalar_t = typename MarlinScalarType<type_id>::scalar_t;
+  if constexpr (!std::is_same<scalar_t, half>::value || k_size != 16) {
+    static_assert(!use_fp16_accum);
+  }
+
+  if constexpr (k_size == 16) {
+    if constexpr (std::is_same<scalar_t, half>::value && !use_fp16_accum) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
+      float* c = reinterpret_cast<float*>(&frag_c);
+      asm volatile(
+          "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+          "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
+          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+          : "r"(a[0]), "r"(a[1]), "r"(b[0]), "f"(c[0]), "f"(c[1]), "f"(c[2]),
+            "f"(c[3]));
+      asm volatile(
+          "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+          "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
+          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+          : "r"(a[2]), "r"(a[3]), "r"(b[1]), "f"(c[0]), "f"(c[1]), "f"(c[2]),
+            "f"(c[3]));
+#else
+      float* c = reinterpret_cast<float*>(&frag_c);
+      asm volatile(
+          "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+          "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+          : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]),
+            "f"(c[0]), "f"(c[1]), "f"(c[2]), "f"(c[3]));
+#endif
+    } else if constexpr (std::is_same<scalar_t, half>::value &&
+                         use_fp16_accum) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
+      uint32_t* c = reinterpret_cast<uint32_t*>(&frag_c);
+      asm volatile(
+          "mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16 "
+          "{%0,%1}, {%2,%3}, {%4}, {%5,%6};\n"
+          : "=r"(c[0]), "=r"(c[1])
+          : "r"(a[0]), "r"(a[1]), "r"(b[0]), "r"(c[0]), "r"(c[1]));
+      asm volatile(
+          "mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16 "
+          "{%0,%1}, {%2,%3}, {%4}, {%5,%6};\n"
+          : "=r"(c[0]), "=r"(c[1])
+          : "r"(a[2]), "r"(a[3]), "r"(b[1]), "r"(c[0]), "r"(c[1]));
+#else
+      uint32_t* c = reinterpret_cast<uint32_t*>(&frag_c);
+      asm volatile(
+          "mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16 "
+          "{%0,%1}, {%2,%3,%4,%5}, {%6,%7}, {%8,%9};\n"
+          : "=r"(c[0]), "=r"(c[1])
+          : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]),
+            "r"(c[0]), "r"(c[1]));
+#endif
+    } else if constexpr (std::is_same<scalar_t, nv_bfloat16>::value) {
+      float* c = reinterpret_cast<float*>(&frag_c);
+      asm volatile(
+          "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+          "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+          : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]),
+            "f"(c[0]), "f"(c[1]), "f"(c[2]), "f"(c[3]));
+    } else if constexpr (std::is_same<scalar_t, __nv_fp8_e4m3>::value) {
+      float* c = reinterpret_cast<float*>(&frag_c);
+      asm volatile(
+          "mma.sync.aligned.m16n8k16.row.col.f32.e4m3.e4m3.f32 "
+          "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
+          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+          : "r"(a[idx * 2]), "r"(a[idx * 2 + 1]), "r"(b[idx]), "f"(c[0]),
+            "f"(c[1]), "f"(c[2]), "f"(c[3]));
+    } else if constexpr (std::is_same<scalar_t, int8_t>::value) {
+      int32_t* c = reinterpret_cast<int32_t*>(&frag_c);
+      asm volatile(
+          "mma.sync.aligned.m16n8k16.row.col.s32.s8.s8.s32.satfinite "
+          "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
+          : "=r"(c[0]), "=r"(c[1]), "=r"(c[2]), "=r"(c[3])
+          : "r"(a[idx * 2]), "r"(a[idx * 2 + 1]), "r"(b[idx]), "r"(c[0]),
+            "r"(c[1]), "r"(c[2]), "r"(c[3]));
+    }
+  } else if (k_size == 32) {
+    if constexpr (std::is_same<scalar_t, __nv_fp8_e4m3>::value) {
+      float* c = reinterpret_cast<float*>(&frag_c);
+      asm volatile(
+          "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
+          "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+          : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]),
+            "f"(c[0]), "f"(c[1]), "f"(c[2]), "f"(c[3]));
+    } else if constexpr (std::is_same<scalar_t, int8_t>::value) {
+      int32_t* c = reinterpret_cast<int32_t*>(&frag_c);
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
+      asm volatile(
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32.satfinite "
+          "{%0,%1}, {%2}, {%3}, {%4,%5};\n"
+          : "=r"(c[0]), "=r"(c[1])
+          : "r"(a[0]), "r"(b[0]), "r"(c[0]), "r"(c[1]));
+      asm volatile(
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32.satfinite "
+          "{%0,%1}, {%2}, {%3}, {%4,%5};\n"
+          : "=r"(c[2]), "=r"(c[3])
+          : "r"(a[1]), "r"(b[0]), "r"(c[2]), "r"(c[3]));
+      asm volatile(
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32.satfinite "
+          "{%0,%1}, {%2}, {%3}, {%4,%5};\n"
+          : "=r"(c[0]), "=r"(c[1])
+          : "r"(a[2]), "r"(b[1]), "r"(c[0]), "r"(c[1]));
+      asm volatile(
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32.satfinite "
+          "{%0,%1}, {%2}, {%3}, {%4,%5};\n"
+          : "=r"(c[2]), "=r"(c[3])
+          : "r"(a[3]), "r"(b[1]), "r"(c[2]), "r"(c[3]));
+#else
+      asm volatile(
+          "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32.satfinite "
+          "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+          : "=r"(c[0]), "=r"(c[1]), "=r"(c[2]), "=r"(c[3])
+          : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]),
+            "r"(c[0]), "r"(c[1]), "r"(c[2]), "r"(c[3]));
+#endif
+    }
+  }
+}
+
+template <aphrodite::ScalarTypeId type_id, bool use_fp16_accum, int k_size = 16>
+__device__ inline void mma_trans(
+    const typename MarlinScalarType<type_id>::FragA& a_frag,
+    const typename MarlinScalarType<type_id>::FragB& frag_b,
+    const typename MarlinScalarType<type_id>::FragB& frag_b2,
+    typename MarlinScalarType<type_id>::FragC& frag_c) {
+  const uint32_t* a = reinterpret_cast<const uint32_t*>(&a_frag);
+  const uint32_t* b = reinterpret_cast<const uint32_t*>(&frag_b);
+  const uint32_t* b2 = reinterpret_cast<const uint32_t*>(&frag_b2);
+  float* c = reinterpret_cast<float*>(&frag_c);
+  using scalar_t = typename MarlinScalarType<type_id>::scalar_t;
+  if constexpr (!std::is_same<scalar_t, half>::value || k_size != 16) {
+    static_assert(!use_fp16_accum);
+  }
+
+  if constexpr (k_size == 16) {
+    if constexpr (std::is_same<scalar_t, half>::value && !use_fp16_accum) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
+      float* c = reinterpret_cast<float*>(&frag_c);
+      asm volatile(
+          "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+          "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
+          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+          : "r"(b[0]), "r"(b2[0]), "r"(a[0]), "f"(c[0]), "f"(c[1]), "f"(c[2]),
+            "f"(c[3]));
+      asm volatile(
+          "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
+          "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
+          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+          : "r"(b[1]), "r"(b2[1]), "r"(a[1]), "f"(c[0]), "f"(c[1]), "f"(c[2]),
+            "f"(c[3]));
+#else
+      float* c = reinterpret_cast<float*>(&frag_c);
+      asm volatile(
+          "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+          "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+          : "r"(b[0]), "r"(b2[0]), "r"(b[1]), "r"(b2[1]), "r"(a[0]), "r"(a[1]),
+            "f"(c[0]), "f"(c[1]), "f"(c[2]), "f"(c[3]));
+#endif
+    } else if constexpr (std::is_same<scalar_t, half>::value &&
+                         use_fp16_accum) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
+      uint32_t* c = reinterpret_cast<uint32_t*>(&frag_c);
+      asm volatile(
+          "mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16 "
+          "{%0,%1}, {%2,%3}, {%4}, {%5,%6};\n"
+          : "=r"(c[0]), "=r"(c[1])
+          : "r"(b[0]), "r"(b2[0]), "r"(a[0]), "r"(c[0]), "r"(c[1]));
+      asm volatile(
+          "mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16 "
+          "{%0,%1}, {%2,%3}, {%4}, {%5,%6};\n"
+          : "=r"(c[0]), "=r"(c[1])
+          : "r"(b[1]), "r"(b2[1]), "r"(a[1]), "r"(c[0]), "r"(c[1]));
+#else
+      uint32_t* c = reinterpret_cast<uint32_t*>(&frag_c);
+      asm volatile(
+          "mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16 "
+          "{%0,%1}, {%2,%3,%4,%5}, {%6,%7}, {%8,%9};\n"
+          : "=r"(c[0]), "=r"(c[1])
+          : "r"(b[0]), "r"(b2[0]), "r"(b[1]), "r"(b2[1]), "r"(a[0]), "r"(a[1]),
+            "r"(c[0]), "r"(c[1]));
+#endif
+    } else if constexpr (std::is_same<scalar_t, nv_bfloat16>::value) {
+      float* c = reinterpret_cast<float*>(&frag_c);
+      asm volatile(
+          "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+          "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+          : "r"(b[0]), "r"(b2[0]), "r"(b[1]), "r"(b2[1]), "r"(a[0]), "r"(a[1]),
+            "f"(c[0]), "f"(c[1]), "f"(c[2]), "f"(c[3]));
+    } else if constexpr (std::is_same<scalar_t, __nv_fp8_e4m3>::value) {
+      float* c = reinterpret_cast<float*>(&frag_c);
+      asm volatile(
+          "mma.sync.aligned.m16n8k16.row.col.f32.e4m3.e4m3.f32 "
+          "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
+          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+          : "r"(b[0]), "r"(b2[0]), "r"(a[0]), "f"(c[0]), "f"(c[1]), "f"(c[2]),
+            "f"(c[3]));
+    } else if constexpr (std::is_same<scalar_t, int8_t>::value) {
+      int32_t* c = reinterpret_cast<int32_t*>(&frag_c);
+      asm volatile(
+          "mma.sync.aligned.m16n8k16.row.col.s32.s8.s8.s32.satfinite "
+          "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
+          : "=r"(c[0]), "=r"(c[1]), "=r"(c[2]), "=r"(c[3])
+          : "r"(b[0]), "r"(b2[0]), "r"(a[0]), "r"(c[0]), "r"(c[1]), "r"(c[2]),
+            "r"(c[3]));
+    }
+  } else {
+    if constexpr (std::is_same<scalar_t, __nv_fp8_e4m3>::value) {
+      float* c = reinterpret_cast<float*>(&frag_c);
+      asm volatile(
+          "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
+          "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+          : "r"(b[0]), "r"(b2[0]), "r"(b[1]), "r"(b2[1]), "r"(a[0]), "r"(a[1]),
+            "f"(c[0]), "f"(c[1]), "f"(c[2]), "f"(c[3]));
+    } else if constexpr (std::is_same<scalar_t, int8_t>::value) {
+      int32_t* c = reinterpret_cast<int32_t*>(&frag_c);
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
+      asm volatile(
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32.satfinite "
+          "{%0,%1}, {%2}, {%3}, {%4,%5};\n"
+          : "=r"(c[0]), "=r"(c[1])
+          : "r"(b[0]), "r"(a[0]), "r"(c[0]), "r"(c[1]));
+      asm volatile(
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32.satfinite "
+          "{%0,%1}, {%2}, {%3}, {%4,%5};\n"
+          : "=r"(c[2]), "=r"(c[3])
+          : "r"(b2[1]), "r"(a[0]), "r"(c[2]), "r"(c[3]));
+      asm volatile(
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32.satfinite "
+          "{%0,%1}, {%2}, {%3}, {%4,%5};\n"
+          : "=r"(c[0]), "=r"(c[1])
+          : "r"(b[0]), "r"(a[1]), "r"(c[0]), "r"(c[1]));
+      asm volatile(
+          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32.satfinite "
+          "{%0,%1}, {%2}, {%3}, {%4,%5};\n"
+          : "=r"(c[2]), "=r"(c[3])
+          : "r"(b2[1]), "r"(a[1]), "r"(c[2]), "r"(c[3]));
+#else
+      asm volatile(
+          "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32.satfinite "
+          "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+          : "=r"(c[0]), "=r"(c[1]), "=r"(c[2]), "=r"(c[3])
+          : "r"(b[0]), "r"(b2[0]), "r"(b[1]), "r"(b2[1]), "r"(a[0]), "r"(a[1]),
+            "r"(c[0]), "r"(c[1]), "r"(c[2]), "r"(c[3]));
+#endif
+    }
+  }
+}
+
+}  // namespace MARLIN_NAMESPACE_NAME

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_abi.cuh
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_abi.cuh
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+// Swordfish ABI v1 address math, shared by the prepack kernel and both
+// mainloops. Single source of truth for the (NB, KB, tile) block-linear
+// layout; the in-tile permutation is Marlin's.
+#pragma once
+
+#include "swordfish_types.cuh"
+
+namespace swordfish {
+
+// Byte offset of packed block (nb, kb) in a (NB, KB, kBlockBytes) tensor.
+__host__ __device__ inline constexpr int64_t block_byte_offset(int64_t nb,
+                                                               int64_t kb,
+                                                               int64_t num_kb) {
+  return (nb * num_kb + kb) * kBlockBytes;
+}
+
+// Byte offset of the k16-slice sub-tile `t` (0..3) within a block.
+__host__ __device__ inline constexpr int64_t subtile_byte_offset(int t) {
+  return int64_t(t) * kSubTileBytes;
+}
+
+// Mapping from the Marlin flat repack layout to Swordfish blocks.
+//
+// gptq_marlin_repack emits int32[K/16][N*16/8] = int32[K/16][N*2]; row r is
+// the k16-slice starting at k = 16*r; within a row, each Marlin 16x64 n-tile
+// occupies 128 consecutive int32 (64 cols * 16 rows / 8 nibbles-per-int32).
+// Swordfish block (nb, kb) gathers rows {4*kb .. 4*kb+3}, int32 columns
+// [128*nb, 128*(nb+1)), i.e. int32 index
+//   marlin_idx(row, col) = row * (N*2) + col
+//   swordfish word w of block (nb,kb):  t = w / 128, c = w % 128
+//     -> marlin row = 4*kb + t, marlin col = 128*nb + c
+// kTileInt32 = int32 words per marlin 16x64 tile: 128 at 4-bit, 256 at
+// 8-bit (where the flat layout is int32[K/16][N*4]).
+template <int kTileInt32 = 128>
+__host__ __device__ inline constexpr int64_t marlin_word_index(int64_t nb,
+                                                               int64_t kb,
+                                                               int w,
+                                                               int64_t n) {
+  const int t = w / kTileInt32;
+  const int c = w % kTileInt32;
+  return (4 * kb + t) * (n * kTileInt32 / 64) + kTileInt32 * nb + c;
+}
+
+}  // namespace swordfish

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_decode.cuh
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_decode.cuh
@@ -1,0 +1,881 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+// Swordfish decode GEMM. w4a16 mma.sync mainloop over the ABI v1
+// block-linear layout.
+//
+// One CTA (4 warps) covers M_TILES m16 tiles of one n64 block-column against
+// a single weight stream. Warps split K into contiguous pair ranges (pair =
+// 2 consecutive k16 slices = 1024 B of packed weights), which keeps each
+// warp's group scales register-resident. Weights and the tiles' activation
+// rows ride one cp.async pipeline, each lane copying exactly the bytes it
+// later consumes into its own smem slot, so bytes in flight cost no
+// registers and no warp synchronization. Each staged word is dequantized
+// once and fans out to M_TILES mmas.
+//
+// The in-tile read contract is Marlin's, proven bit-exact by the prepack
+// tests. Lane T consumes I4[T] at word 4T of each 512 B sub-tile; word j
+// dequants into the fragments of n8-tiles 2j and 2j+1, where lane T owns
+// column T/4 and rows 2*(T%4) + {0,1,8,9} of the k16xn8 fragment.
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#include <climits>
+#include <type_traits>
+
+#include "libtorch_stable/quantization/marlin/marlin.cuh"
+#include "libtorch_stable/quantization/marlin/marlin_dtypes.cuh"
+#include "libtorch_stable/quantization/marlin/dequant.h"
+#include "libtorch_stable/quantization/marlin/marlin_mma.h"
+
+#include "swordfish_abi.cuh"
+
+namespace swordfish {
+
+inline constexpr int kDecodeWarps = 4;
+inline constexpr int kDecodeThreads = kDecodeWarps * 32;
+// One k16-slice pair = two consecutive 512 B sub-tiles.
+inline constexpr int kPairInt32 = 2 * (kSubTileBytes / 4);
+// cp.async pipeline depth in pairs (stages in flight per warp).
+inline constexpr int kStages = 5;
+
+// One ldmatrix.x4 loads a full m16k16 activation fragment from smem in
+// tensor-core register order.
+template <aphrodite::ScalarTypeId type_id>
+__device__ __forceinline__ void ldsm4(
+    typename marlin::MarlinScalarType<type_id>::FragA& frag_a,
+    const void* smem_ptr) {
+  uint32_t* a = reinterpret_cast<uint32_t*>(&frag_a);
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+               : "=r"(a[0]), "=r"(a[1]), "=r"(a[2]), "=r"(a[3])
+               : "r"(smem));
+}
+
+// cp.async.cg with an evict_first L2 hint. Packed weights are read once per
+// launch and must not evict the re-read activation rows and scales.
+__device__ __forceinline__ void cp_async4_evict_first(void* smem_ptr,
+                                                      const void* glob_ptr,
+                                                      uint64_t pol) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+      "cp.async.cg.shared.global.L2::cache_hint [%0], [%1], 16, %2;\n" ::"r"(
+          smem),
+      "l"(glob_ptr), "l"(pol));
+#else
+  marlin::cp_async4(smem_ptr, glob_ptr);
+#endif
+}
+
+__device__ __forceinline__ uint64_t l2_evict_first_policy() {
+  uint64_t pol = 0;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000
+  asm volatile("createpolicy.fractional.L2::evict_first.b64 %0, 1.0;"
+               : "=l"(pol));
+#endif
+  return pol;
+}
+
+// Packed-pair global atomic add. The atomicAdd(half2*) intrinsic compiles to
+// a CAS loop on this toolchain, so emit red.global directly.
+template <typename scalar_t2>
+__device__ __forceinline__ void red_add2(scalar_t2* p, scalar_t2 v) {
+  if constexpr (sizeof(scalar_t2) == 4) {
+    if constexpr (std::is_same_v<scalar_t2, nv_bfloat162>) {
+      asm volatile("red.global.add.noftz.bf16x2 [%0], %1;" ::"l"(p),
+                   "r"(*reinterpret_cast<uint32_t*>(&v))
+                   : "memory");
+    } else {
+      asm volatile("red.global.add.noftz.f16x2 [%0], %1;" ::"l"(p),
+                   "r"(*reinterpret_cast<uint32_t*>(&v))
+                   : "memory");
+    }
+  }
+}
+
+// Grid-stride C zeroing for the atomic paths. A cudaMemsetAsync node runs
+// on the copy engine, and in a captured decode graph every compute-to-copy
+// transition costs an engine-switch gap -- at one memset per GEMM that idle
+// time measured ~90 us per decoded token on B200. A trivial kernel stays on
+// the compute engine.
+template <typename scalar_t>
+__global__ void swordfish_zero_c_kernel(int4* __restrict__ c, int64_t vecs) {
+  const int64_t i = blockIdx.x * int64_t(blockDim.x) + threadIdx.x;
+  const int4 z = {0, 0, 0, 0};
+  if (i < vecs) c[i] = z;
+}
+
+template <typename scalar_t>
+inline void launch_zero_c(void* c, int64_t m, int64_t n, cudaStream_t stream) {
+  const int64_t vecs = m * n * int64_t(sizeof(scalar_t)) / sizeof(int4);
+  const int threads = 256;
+  const int blocks = int((vecs + threads - 1) / threads);
+  swordfish_zero_c_kernel<scalar_t>
+      <<<blocks, threads, 0, stream>>>(reinterpret_cast<int4*>(c), vecs);
+}
+
+// Fused act_order prep for the decode window: writes the column-sorted
+// activation copy and zeroes the output in one launch, replacing the
+// separate permute_cols and zero nodes (each in-graph node and its
+// engine/launch gap costs about a microsecond per GEMM at bs=1). Thread i
+// of the permute range loads its perm entry coalesced and gathers one
+// activation half; the tail range zeroes C in int4 stores.
+template <typename scalar_t>
+__global__ void swordfish_prep_kernel(const scalar_t* __restrict__ a,
+                                      const int32_t* __restrict__ perm,
+                                      scalar_t* __restrict__ a_perm,
+                                      int4* __restrict__ c, int64_t m,
+                                      int64_t k, int64_t c_vecs) {
+  const int64_t idx = blockIdx.x * int64_t(blockDim.x) + threadIdx.x;
+  const int64_t perm_work = m * k;
+  if (idx < perm_work) {
+    const int64_t r = idx / k;
+    const int64_t i = idx - r * k;
+    a_perm[r * k + i] = a[r * k + perm[i]];
+  } else if (idx - perm_work < c_vecs) {
+    const int4 z = {0, 0, 0, 0};
+    c[idx - perm_work] = z;
+  }
+}
+
+template <typename scalar_t>
+inline void launch_prep(const void* a, const int32_t* perm, void* a_perm,
+                        void* c, int64_t m, int64_t k, int64_t n,
+                        cudaStream_t stream) {
+  const int64_t c_vecs = m * n * int64_t(sizeof(scalar_t)) / sizeof(int4);
+  const int64_t work = m * k + c_vecs;
+  const int threads = 256;
+  const int blocks = int((work + threads - 1) / threads);
+  swordfish_prep_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+      reinterpret_cast<const scalar_t*>(a), perm,
+      reinterpret_cast<scalar_t*>(a_perm), reinterpret_cast<int4*>(c), m, k,
+      c_vecs);
+}
+
+// ATOMIC_EPI replaces the cross-warp smem reduction with red.global adds
+// into a zeroed C, freeing 16 KB smem per CTA and both __syncthreads, and
+// making cross-CTA split-K free. Summation order is nondeterministic. The
+// launcher uses it for the decode window (M <= 47).
+template <aphrodite::ScalarTypeId type_id, bool ATOMIC_EPI, int M_TILES = 1,
+          bool HAS_ZP = false, bool W8 = false>
+__global__ void swordfish_decode_kernel(
+    const typename marlin::MarlinScalarType<type_id>::scalar_t* __restrict__ A,
+    const int32_t* __restrict__ B,
+    const typename marlin::MarlinScalarType<type_id>::scalar_t* __restrict__ S,
+    const typename marlin::MarlinScalarType<type_id>::scalar_t* __restrict__ Z,
+    typename marlin::MarlinScalarType<type_id>::scalar_t* __restrict__ C, int M,
+    int K, int N, int group_size) {
+  static_assert(M_TILES >= 1 && M_TILES <= 3, "supported m-tile fusion: 1-3");
+  static_assert(M_TILES == 1 || ATOMIC_EPI,
+                "multi-m-tile is an atomic-epilogue configuration");
+  // Pipeline depth scales inversely with M_TILES. Compute per staged pair
+  // grows with the tile count, so fewer stages hide the same copy latency,
+  // and the astage footprint stays inside the 48 KB static smem budget.
+  // 8-bit units are half the activation bytes, so the fused tiers run
+  // deeper pipelines in the same smem.
+  constexpr int kStagesT =
+      M_TILES == 1
+          ? kStages
+          : (M_TILES == 2 ? (W8 ? 5 : 4) : (M_TILES == 3 ? 3 : (W8 ? 4 : 2)));
+  // A staging unit stays 1 KB of packed weights at both widths: a k32 slice
+  // pair at 4-bit, a single k16 slice at 8-bit (deeper W8 pipelines fit the
+  // freed smem but measured flat).
+  constexpr int kUnitK = W8 ? 16 : 32;
+  static_assert(!(W8 && HAS_ZP), "8-bit weights carry no zero points");
+  using Dtype = marlin::MarlinScalarType<type_id>;
+  using scalar_t = typename Dtype::scalar_t;
+  using scalar_t2 = typename Dtype::scalar_t2;
+  using FragA = typename Dtype::FragA;
+  using FragB = typename Dtype::FragB;
+  using FragC = typename Dtype::FragC;
+
+  const int lane = threadIdx.x % 32;
+  const int warp = threadIdx.x / 32;
+  const int group_id = lane / 4;
+  const int tig = lane % 4;  // thread-in-group
+
+  const int nb = blockIdx.y;                       // n64 block-column
+  const int m_base = blockIdx.x * (16 * M_TILES);  // first m16 tile
+  const int col_base = nb * kBlockN;
+  const int num_kb = K / kBlockK;
+
+  // Output rows owned by this lane's C fragments, per m16 tile.
+  int row0[M_TILES];
+  bool r0ok[M_TILES], r1ok[M_TILES];
+#pragma unroll
+  for (int t = 0; t < M_TILES; t++) {
+    row0[t] = m_base + 16 * t + group_id;
+    r0ok[t] = row0[t] < M;
+    r1ok[t] = row0[t] + 8 < M;
+  }
+
+  // acc[t][j][b]: tile t's n8-tile at columns col_base + 16*j + 8*b + [0, 8).
+  FragC acc[M_TILES][4][2];
+#pragma unroll
+  for (int t = 0; t < M_TILES; t++)
+#pragma unroll
+    for (int j = 0; j < 4; j++)
+#pragma unroll
+      for (int b = 0; b < 2; b++)
+#pragma unroll
+        for (int i = 0; i < 4; i++) acc[t][j][b][i] = 0.0f;
+
+  const scalar_t2 zero2 = Dtype::num2num2(Dtype::float2num(0.0f));
+
+  // At split-K 1 this CTA owns its C tile exclusively and zeroes it here,
+  // sparing the launcher a flat ~2 us cudaMemsetAsync. At split > 1 tiles
+  // are shared and the launcher memsets instead.
+  if constexpr (ATOMIC_EPI) {
+    if (gridDim.z == 1) {
+      const int rows = min(16 * M_TILES, M - m_base);
+      auto* c2 = reinterpret_cast<scalar_t2*>(C);
+      for (int i = threadIdx.x; i < rows * 32; i += kDecodeThreads) {
+        c2[int64_t(m_base + (i >> 5)) * (N >> 1) + (col_base >> 1) + (i & 31)] =
+            zero2;
+      }
+      __syncthreads();  // tile zeroed before any warp's atomic epilogue
+    }
+  }
+
+  // Global just-in-time A fragment load, used only by the deterministic
+  // path. Register order per mma contract, reg0/reg1 at k0, reg2/reg3 at
+  // k0+8.
+  auto load_a_global = [&](int k0, FragA& fa) {
+    const int ca = k0 + 2 * tig;
+    const int cb = ca + 8;
+    const auto* a_row0 = reinterpret_cast<const scalar_t2*>(
+        A + int64_t(r0ok[0] ? row0[0] : 0) * K);
+    const auto* a_row1 = reinterpret_cast<const scalar_t2*>(
+        A + int64_t(r1ok[0] ? row0[0] + 8 : 0) * K);
+    fa[0] = r0ok[0] ? a_row0[ca / 2] : zero2;
+    fa[1] = r1ok[0] ? a_row1[ca / 2] : zero2;
+    fa[2] = r0ok[0] ? a_row0[cb / 2] : zero2;
+    fa[3] = r1ok[0] ? a_row1[cb / 2] : zero2;
+  };
+  // ldmatrix per-lane addressing. Lanes 0-15 cover rows 0-15 cols 0-7 and
+  // lanes 16-31 cols 8-15, yielding FragA's register order. Rows >= M hold
+  // unstaged garbage whose products only reach acc components the epilogue
+  // guards never store.
+  const int ldsm_row = lane & 15;
+  const int ldsm_col = (lane >> 4) << 3;
+  auto load_a = [&](const scalar_t(*sa)[kUnitK], int ks, FragA& fa) {
+    ldsm4<type_id>(fa, &sa[ldsm_row][ldsm_col + ks]);
+  };
+
+  // Group scales, hoisted. The contiguous k-split makes each warp see each
+  // group exactly once. One 4-byte load per lane covers the 64-wide row and
+  // shfl broadcasts the pairs. Fetch and expand are split so the next
+  // group's row prefetches a full group early, hiding its latency under
+  // compute (on-demand loads were the dominant stall on K-heavy shapes).
+  // HAS_ZP runs the same machinery over Z, whose rows hold prescaled
+  // (8 - zp) * scale, turning the dequant scaling into an fma.
+  scalar_t2 s_reg[4][2];  // [j][b] broadcast pairs for this lane's column
+  scalar_t2 z_reg[4][2];
+  auto fetch_row = [&](const scalar_t* base, int g) -> scalar_t2 {
+    return reinterpret_cast<const scalar_t2*>(base + int64_t(g) * N +
+                                              col_base)[lane];
+  };
+  auto expand_row = [&](scalar_t2 mine, scalar_t2(&dst)[4][2]) {
+    const uint32_t sel = group_id & 1;  // half index within the shfl'd pair
+#pragma unroll
+    for (int j = 0; j < 4; j++) {
+#pragma unroll
+      for (int b = 0; b < 2; b++) {
+        // half index i = 16j + 8b + group_id -> lane i/2, element i%2
+        const scalar_t2 v =
+            __shfl_sync(0xffffffffu, mine, 8 * j + 4 * b + (group_id >> 1));
+        const uint32_t bits = reinterpret_cast<const uint32_t&>(v);
+        const uint16_t h16 = sel ? uint16_t(bits >> 16) : uint16_t(bits);
+        dst[j][b] = Dtype::num2num2(reinterpret_cast<const scalar_t&>(h16));
+      }
+    }
+  };
+
+  // One k16 slice. Dequant the lane's word once, scale once, then fan the
+  // mma out across the CTA's m16 tiles.
+  auto process_slice = [&](const FragA(&fa)[M_TILES], const marlin::I4& bqa,
+                           const marlin::I4& bqb) {
+#pragma unroll
+    for (int j = 0; j < 4; j++) {
+      FragB frag_b0, frag_b1;
+      if constexpr (W8) {
+        // One int32 per n8 tile; n16 groups 2 and 3 sit in the second I4.
+        const marlin::I4& src = j < 2 ? bqa : bqb;
+        marlin::dequant<scalar_t2, aphrodite::kU8B128.id(), false>(
+            src.elems[(2 * j) & 3], reinterpret_cast<scalar_t2*>(&frag_b0));
+        marlin::dequant<scalar_t2, aphrodite::kU8B128.id(), false>(
+            src.elems[(2 * j + 1) & 3], reinterpret_cast<scalar_t2*>(&frag_b1));
+      } else {
+        const int b_quant_0 = bqa.elems[j];
+        const int b_quant_1 = b_quant_0 >> 8;
+        marlin::dequant<scalar_t2, aphrodite::kU4B8.id(), false>(
+            b_quant_0, reinterpret_cast<scalar_t2*>(&frag_b0));
+        marlin::dequant<scalar_t2, aphrodite::kU4B8.id(), false>(
+            b_quant_1, reinterpret_cast<scalar_t2*>(&frag_b1));
+      }
+
+      if constexpr (HAS_ZP) {
+        frag_b0[0] = __hfma2(frag_b0[0], s_reg[j][0], z_reg[j][0]);
+        frag_b0[1] = __hfma2(frag_b0[1], s_reg[j][0], z_reg[j][0]);
+        frag_b1[0] = __hfma2(frag_b1[0], s_reg[j][1], z_reg[j][1]);
+        frag_b1[1] = __hfma2(frag_b1[1], s_reg[j][1], z_reg[j][1]);
+      } else {
+        frag_b0[0] = __hmul2(frag_b0[0], s_reg[j][0]);
+        frag_b0[1] = __hmul2(frag_b0[1], s_reg[j][0]);
+        frag_b1[0] = __hmul2(frag_b1[0], s_reg[j][1]);
+        frag_b1[1] = __hmul2(frag_b1[1], s_reg[j][1]);
+      }
+
+#pragma unroll
+      for (int t = 0; t < M_TILES; t++) {
+        marlin::mma<type_id, /*use_fp16_accum=*/false>(fa[t], frag_b0,
+                                                       acc[t][j][0]);
+        marlin::mma<type_id, /*use_fp16_accum=*/false>(fa[t], frag_b1,
+                                                       acc[t][j][1]);
+      }
+    }
+  };
+
+  // One pair = two consecutive k16 slices from one staged buffer.
+  auto process_pair = [&](int p, const scalar_t(*sa)[16][kUnitK],
+                          const int4* buf) {
+    FragA fa0[M_TILES], fa1[M_TILES];
+    if constexpr (ATOMIC_EPI) {
+#pragma unroll
+      for (int t = 0; t < M_TILES; t++) {
+        load_a(sa[t], 0, fa0[t]);
+        if constexpr (!W8) load_a(sa[t], 16, fa1[t]);
+      }
+    } else {
+      load_a_global(kUnitK * p, fa0[0]);
+      if constexpr (!W8) load_a_global(kUnitK * p + 16, fa1[0]);
+    }
+    if constexpr (W8) {
+      const marlin::I4 bq0 =
+          *reinterpret_cast<const marlin::I4*>(&buf[2 * lane]);
+      const marlin::I4 bq1 =
+          *reinterpret_cast<const marlin::I4*>(&buf[2 * lane + 1]);
+      process_slice(fa0, bq0, bq1);
+    } else {
+      const marlin::I4 bq0 = *reinterpret_cast<const marlin::I4*>(&buf[lane]);
+      const marlin::I4 bq1 =
+          *reinterpret_cast<const marlin::I4*>(&buf[32 + lane]);
+      process_slice(fa0, bq0, bq0);
+      process_slice(fa1, bq1, bq1);
+    }
+  };
+
+  // Weight staging, one self-slot buffer per warp and stage.
+  __shared__ int4 bstage[kDecodeWarps][kStagesT][2 * 32];
+  // Activation slices for the in-flight pairs, 1 KB per tile and stage,
+  // copied in the same commit group as the weights so one wait covers both.
+  __shared__ scalar_t
+      astage[kDecodeWarps][ATOMIC_EPI ? kStagesT : 1][M_TILES][16][kUnitK];
+  const int32_t* b_col =
+      B + int64_t(nb) * num_kb * (W8 ? kBlockInt32_8 : kBlockInt32);
+  const int num_pairs = K / kUnitK;
+  // Cross-CTA split-K. blockIdx.z slices the pair space and the atomic
+  // epilogue merges slices in the zeroed C. gridDim.z > 1 only on the
+  // ATOMIC_EPI path.
+  const int slice_pairs = (num_pairs + gridDim.z - 1) / gridDim.z;
+  const int s_beg = blockIdx.z * slice_pairs;
+  const int s_end = min(s_beg + slice_pairs, num_pairs);
+  const int pairs_per_warp = (s_end - s_beg + kDecodeWarps - 1) / kDecodeWarps;
+  const int p_beg = s_beg + warp * pairs_per_warp;
+  const int p_end = min(p_beg + pairs_per_warp, s_end);
+
+  // Scale-group bookkeeping: `left` = pairs left in the current group
+  // (host guarantees group_size % 32 == 0, so pairs never straddle groups).
+  const int ppg = group_size > 0 ? group_size / kUnitK : INT_MAX;
+  int g = 0;
+  int left = INT_MAX;
+
+  // One commit group per stage. Fences are unconditional so the wait<N>
+  // accounting stays uniform through the tail (empty groups are legal).
+  const int g_last =
+      group_size > 0 && p_beg < p_end ? (kUnitK * (p_end - 1)) / group_size : 0;
+  scalar_t2 s_next = zero2;  // prefetched next-group row (lane's slice)
+  scalar_t2 z_next = zero2;
+  if (p_beg < p_end) {
+    if (group_size > 0) {
+      g = p_beg / ppg;
+      left = ppg - p_beg % ppg;
+    }
+    expand_row(fetch_row(S, g), s_reg);
+    if constexpr (HAS_ZP) expand_row(fetch_row(Z, g), z_reg);
+    if (g + 1 <= g_last) {
+      s_next = fetch_row(S, g + 1);
+      if constexpr (HAS_ZP) z_next = fetch_row(Z, g + 1);
+    }
+  }
+
+  // Incremental int32 issue cursors. A modulo-indexed ring compiles to
+  // magic-number division and per-pair int64 address math costs multiplies,
+  // both measurable in this loop. Offsets fit int32 for every shape the
+  // host validates.
+  const uint64_t bpol = l2_evict_first_policy();
+  const int32_t* ipair_ptr = b_col + p_beg * kPairInt32 + (W8 ? 8 : 4) * lane;
+  const int ia_row = lane >> 1;
+  const int ia_c0 = (kUnitK / 2) * (lane & 1);
+  // Per-tile activation cursors. Only valid rows are staged, since clamping
+  // out-of-range rows to row 0 multiplies activation traffic at small M.
+  bool ia_okt[M_TILES];
+  const scalar_t* ia_ptr[M_TILES];
+#pragma unroll
+  for (int t = 0; t < M_TILES; t++) {
+    const int r = m_base + 16 * t + ia_row;
+    ia_okt[t] = r < M;
+    ia_ptr[t] = A + (ia_okt[t] ? r : 0) * K + kUnitK * p_beg + ia_c0;
+  }
+  int ipend = p_end - p_beg;  // pairs left to issue
+
+  auto issue_pair = [&](int slot) {
+    if (ipend > 0) {
+      ipend--;
+      if constexpr (W8) {
+        cp_async4_evict_first(&bstage[warp][slot][2 * lane], ipair_ptr, bpol);
+        cp_async4_evict_first(&bstage[warp][slot][2 * lane + 1], ipair_ptr + 4,
+                              bpol);
+      } else {
+        cp_async4_evict_first(&bstage[warp][slot][lane], ipair_ptr, bpol);
+        cp_async4_evict_first(&bstage[warp][slot][32 + lane],
+                              ipair_ptr + kPairInt32 / 2, bpol);
+      }
+      ipair_ptr += kPairInt32;
+      if constexpr (ATOMIC_EPI) {
+#pragma unroll
+        for (int t = 0; t < M_TILES; t++) {
+          if (ia_okt[t]) {
+            marlin::cp_async4(&astage[warp][slot][t][ia_row][ia_c0], ia_ptr[t]);
+            if constexpr (!W8) {
+              marlin::cp_async4(&astage[warp][slot][t][ia_row][ia_c0 + 8],
+                                ia_ptr[t] + 8);
+            }
+          }
+          ia_ptr[t] += kUnitK;
+        }
+      }
+    }
+    marlin::cp_async_fence();
+  };
+
+#pragma unroll
+  for (int s = 0; s < kStagesT - 1; s++) issue_pair(s);
+
+  int slot = 0;
+  int islot = kStagesT - 1;
+  for (int p = p_beg; p < p_end; p++) {
+    issue_pair(islot);
+    if (++islot == kStagesT) islot = 0;
+    marlin::cp_async_wait<kStagesT - 2>();  // oldest stage (slot) complete
+    if (left == 0) {
+      ++g;
+      expand_row(s_next, s_reg);  // value already in flight since boundary
+      if constexpr (HAS_ZP) expand_row(z_next, z_reg);
+      if (g + 1 <= g_last) {
+        s_next = fetch_row(S, g + 1);
+        if constexpr (HAS_ZP) z_next = fetch_row(Z, g + 1);
+      }
+      left = ppg;
+    }
+    process_pair(p, astage[warp][ATOMIC_EPI ? slot : 0], bstage[warp][slot]);
+    left--;
+    if (++slot == kStagesT) slot = 0;
+  }
+
+  if constexpr (ATOMIC_EPI) {
+    // Direct atomic epilogue: every warp adds its partial fragments to C.
+#pragma unroll
+    for (int t = 0; t < M_TILES; t++) {
+#pragma unroll
+      for (int j = 0; j < 4; j++) {
+#pragma unroll
+        for (int b = 0; b < 2; b++) {
+          const int col = col_base + 8 * (2 * j + b) + 2 * tig;
+          const float4 v = *reinterpret_cast<float4*>(&acc[t][j][b]);
+          if (r0ok[t])
+            red_add2(
+                reinterpret_cast<scalar_t2*>(C + int64_t(row0[t]) * N + col),
+                Dtype::nums2num2(Dtype::float2num(v.x), Dtype::float2num(v.y)));
+          if (r1ok[t])
+            red_add2(
+                reinterpret_cast<scalar_t2*>(C + int64_t(row0[t] + 8) * N +
+                                             col),
+                Dtype::nums2num2(Dtype::float2num(v.z), Dtype::float2num(v.w)));
+        }
+      }
+    }
+    return;
+  }
+
+  // Deterministic epilogue. Partials meet in smem and warp w reduces and
+  // writes n8-tiles {2w, 2w+1}. Tile index is 2*j + b.
+  __shared__ float4 red[kDecodeWarps][8][32];
+#pragma unroll
+  for (int j = 0; j < 4; j++)
+#pragma unroll
+    for (int b = 0; b < 2; b++)
+      red[warp][2 * j + b][lane] = *reinterpret_cast<float4*>(&acc[0][j][b]);
+  __syncthreads();
+
+#pragma unroll
+  for (int i = 0; i < 2; i++) {
+    const int tile = 2 * warp + i;
+    float4 sum = red[0][tile][lane];
+#pragma unroll
+    for (int w = 1; w < kDecodeWarps; w++) {
+      const float4 v = red[w][tile][lane];
+      sum.x += v.x;
+      sum.y += v.y;
+      sum.z += v.z;
+      sum.w += v.w;
+    }
+    const int col = col_base + 8 * tile + 2 * tig;
+    if (r0ok[0]) {
+      *reinterpret_cast<scalar_t2*>(C + int64_t(row0[0]) * N + col) =
+          Dtype::nums2num2(Dtype::float2num(sum.x), Dtype::float2num(sum.y));
+    }
+    if (r1ok[0]) {
+      *reinterpret_cast<scalar_t2*>(C + int64_t(row0[0] + 8) * N + col) =
+          Dtype::nums2num2(Dtype::float2num(sum.z), Dtype::float2num(sum.w));
+    }
+  }
+}
+
+// Stream-K decode for the fused window (M 17 to 96). Persistent CTAs; one
+// unit of flat work is one k16-slice pair of one (m-group, n64-column)
+// tile, and each warp owns a contiguous range of units. The m-group index
+// varies fastest after the pair so consecutive segments in a warp's range
+// revisit the same weight column while it is L2-resident. Accumulators
+// flush through red.global at segment boundaries into a launcher-zeroed C,
+// so a tile's K slices may come from any number of warps with no locks and
+// no fixup pass. This removes split-K heuristics and wave quantization for
+// the window entirely.
+// CTA_QUAD maps claims at CTA granularity over n256 column quads: the four
+// warps take the four adjacent n64 columns of one quad over a common
+// (m-group, k-range) claim. Per-warp staging, pipeline, and epilogue are
+// untouched -- the quad buys 4x-amortized claim bookkeeping and adjacent
+// column addressing (the four B streams walk consecutive column blocks and
+// all four warps touch the same A slices while they are L2-resident).
+template <aphrodite::ScalarTypeId type_id, int M_TILES, bool HAS_ZP = false,
+          bool W8 = false, bool CTA_QUAD = false>
+__global__ void swordfish_decode_streamk_kernel(
+    const typename marlin::MarlinScalarType<type_id>::scalar_t* __restrict__ A,
+    const int32_t* __restrict__ B,
+    const typename marlin::MarlinScalarType<type_id>::scalar_t* __restrict__ S,
+    const typename marlin::MarlinScalarType<type_id>::scalar_t* __restrict__ Z,
+    typename marlin::MarlinScalarType<type_id>::scalar_t* __restrict__ C, int M,
+    int K, int N, int group_size, int m_groups) {
+  // 8-bit units are half the activation bytes, so the fused tiers run
+  // deeper pipelines in the same smem.
+  constexpr int kStagesT =
+      M_TILES == 1
+          ? kStages
+          : (M_TILES == 2 ? (W8 ? 5 : 4) : (M_TILES == 3 ? 3 : (W8 ? 4 : 2)));
+  // A staging unit stays 1 KB of packed weights at both widths: a k32 slice
+  // pair at 4-bit, a single k16 slice at 8-bit (deeper W8 pipelines fit the
+  // freed smem but measured flat).
+  constexpr int kUnitK = W8 ? 16 : 32;
+  static_assert(!(W8 && HAS_ZP), "8-bit weights carry no zero points");
+  using Dtype = marlin::MarlinScalarType<type_id>;
+  using scalar_t = typename Dtype::scalar_t;
+  using scalar_t2 = typename Dtype::scalar_t2;
+  using FragA = typename Dtype::FragA;
+  using FragB = typename Dtype::FragB;
+  using FragC = typename Dtype::FragC;
+
+  const int lane = threadIdx.x % 32;
+  const int warp = threadIdx.x / 32;
+  const int group_id = lane / 4;
+  const int tig = lane % 4;
+  const int ldsm_row = lane & 15;
+  const int ldsm_col = (lane >> 4) << 3;
+  const int ia_row = lane >> 1;
+  const int ia_c0 = (kUnitK / 2) * (lane & 1);
+
+  const int num_pairs = K / kUnitK;
+  const int nb_cnt = N / (CTA_QUAD ? kBlockN * kDecodeWarps : kBlockN);
+  const int num_kb = K / kBlockK;
+  const int ppg = group_size > 0 ? group_size / kUnitK : INT_MAX;
+  const scalar_t2 zero2 = Dtype::num2num2(Dtype::float2num(0.0f));
+  const uint64_t bpol = l2_evict_first_policy();
+
+  const int64_t total = int64_t(m_groups) * nb_cnt * num_pairs;
+  const int total_claimers = CTA_QUAD ? gridDim.x : gridDim.x * kDecodeWarps;
+  const int64_t per = (total + total_claimers - 1) / total_claimers;
+  int64_t w =
+      int64_t(CTA_QUAD ? blockIdx.x : blockIdx.x * kDecodeWarps + warp) * per;
+  const int64_t w_end = w + per < total ? w + per : total;
+
+  __shared__ int4 bstage[kDecodeWarps][kStagesT][2 * 32];
+  __shared__ scalar_t astage[kDecodeWarps][kStagesT][M_TILES][16][kUnitK];
+
+  FragC acc[M_TILES][4][2];
+  scalar_t2 s_reg[4][2];
+  scalar_t2 z_reg[4][2];
+
+  while (w < w_end) {
+    const int64_t cg = w / num_pairs;
+    const int p_beg = int(w - cg * num_pairs);
+    const int col_claim = int(cg / m_groups);
+    const int col = CTA_QUAD ? col_claim * kDecodeWarps + warp : col_claim;
+    const int g_idx = int(cg - int64_t(col_claim) * m_groups);
+    const int p_end =
+        int(int64_t(num_pairs) < p_beg + (w_end - w) ? int64_t(num_pairs)
+                                                     : p_beg + (w_end - w));
+    w += p_end - p_beg;
+
+    const int m_base = g_idx * (16 * M_TILES);
+    const int col_base = col * kBlockN;
+
+    int row0[M_TILES];
+    bool r0ok[M_TILES], r1ok[M_TILES];
+#pragma unroll
+    for (int t = 0; t < M_TILES; t++) {
+      row0[t] = m_base + 16 * t + group_id;
+      r0ok[t] = row0[t] < M;
+      r1ok[t] = row0[t] + 8 < M;
+    }
+#pragma unroll
+    for (int t = 0; t < M_TILES; t++)
+#pragma unroll
+      for (int j = 0; j < 4; j++)
+#pragma unroll
+        for (int b = 0; b < 2; b++)
+#pragma unroll
+          for (int i = 0; i < 4; i++) acc[t][j][b][i] = 0.0f;
+
+    auto fetch_row = [&](const scalar_t* base, int g) -> scalar_t2 {
+      return reinterpret_cast<const scalar_t2*>(base + int64_t(g) * N +
+                                                col_base)[lane];
+    };
+    auto expand_row = [&](scalar_t2 mine, scalar_t2(&dst)[4][2]) {
+      const uint32_t sel = group_id & 1;
+#pragma unroll
+      for (int j = 0; j < 4; j++) {
+#pragma unroll
+        for (int b = 0; b < 2; b++) {
+          const scalar_t2 v =
+              __shfl_sync(0xffffffffu, mine, 8 * j + 4 * b + (group_id >> 1));
+          const uint32_t bits = reinterpret_cast<const uint32_t&>(v);
+          const uint16_t h16 = sel ? uint16_t(bits >> 16) : uint16_t(bits);
+          dst[j][b] = Dtype::num2num2(reinterpret_cast<const scalar_t&>(h16));
+        }
+      }
+    };
+    auto load_a = [&](const scalar_t(*sa)[kUnitK], int ks, FragA& fa) {
+      ldsm4<type_id>(fa, &sa[ldsm_row][ldsm_col + ks]);
+    };
+    auto process_slice = [&](const FragA(&fa)[M_TILES], const marlin::I4& bqa,
+                             const marlin::I4& bqb) {
+#pragma unroll
+      for (int j = 0; j < 4; j++) {
+        FragB frag_b0, frag_b1;
+        if constexpr (W8) {
+          const marlin::I4& src = j < 2 ? bqa : bqb;
+          marlin::dequant<scalar_t2, aphrodite::kU8B128.id(), false>(
+              src.elems[(2 * j) & 3], reinterpret_cast<scalar_t2*>(&frag_b0));
+          marlin::dequant<scalar_t2, aphrodite::kU8B128.id(), false>(
+              src.elems[(2 * j + 1) & 3],
+              reinterpret_cast<scalar_t2*>(&frag_b1));
+        } else {
+          const int b_quant_0 = bqa.elems[j];
+          const int b_quant_1 = b_quant_0 >> 8;
+          marlin::dequant<scalar_t2, aphrodite::kU4B8.id(), false>(
+              b_quant_0, reinterpret_cast<scalar_t2*>(&frag_b0));
+          marlin::dequant<scalar_t2, aphrodite::kU4B8.id(), false>(
+              b_quant_1, reinterpret_cast<scalar_t2*>(&frag_b1));
+        }
+        if constexpr (HAS_ZP) {
+          frag_b0[0] = __hfma2(frag_b0[0], s_reg[j][0], z_reg[j][0]);
+          frag_b0[1] = __hfma2(frag_b0[1], s_reg[j][0], z_reg[j][0]);
+          frag_b1[0] = __hfma2(frag_b1[0], s_reg[j][1], z_reg[j][1]);
+          frag_b1[1] = __hfma2(frag_b1[1], s_reg[j][1], z_reg[j][1]);
+        } else {
+          frag_b0[0] = __hmul2(frag_b0[0], s_reg[j][0]);
+          frag_b0[1] = __hmul2(frag_b0[1], s_reg[j][0]);
+          frag_b1[0] = __hmul2(frag_b1[0], s_reg[j][1]);
+          frag_b1[1] = __hmul2(frag_b1[1], s_reg[j][1]);
+        }
+#pragma unroll
+        for (int t = 0; t < M_TILES; t++) {
+          marlin::mma<type_id, false>(fa[t], frag_b0, acc[t][j][0]);
+          marlin::mma<type_id, false>(fa[t], frag_b1, acc[t][j][1]);
+        }
+      }
+    };
+    auto process_pair = [&](int aslot, const int4* buf) {
+      FragA fa0[M_TILES], fa1[M_TILES];
+#pragma unroll
+      for (int t = 0; t < M_TILES; t++) {
+        load_a(astage[warp][aslot][t], 0, fa0[t]);
+        if constexpr (!W8) load_a(astage[warp][aslot][t], 16, fa1[t]);
+      }
+      if constexpr (W8) {
+        const marlin::I4 bq0 =
+            *reinterpret_cast<const marlin::I4*>(&buf[2 * lane]);
+        const marlin::I4 bq1 =
+            *reinterpret_cast<const marlin::I4*>(&buf[2 * lane + 1]);
+        process_slice(fa0, bq0, bq1);
+      } else {
+        const marlin::I4 bq0 = *reinterpret_cast<const marlin::I4*>(&buf[lane]);
+        const marlin::I4 bq1 =
+            *reinterpret_cast<const marlin::I4*>(&buf[32 + lane]);
+        process_slice(fa0, bq0, bq0);
+        process_slice(fa1, bq1, bq1);
+      }
+    };
+
+    const int32_t* ipair_ptr =
+        B + int64_t(col) * num_kb * (W8 ? kBlockInt32_8 : kBlockInt32) +
+        p_beg * kPairInt32 + (W8 ? 8 : 4) * lane;
+    bool ia_okt[M_TILES];
+    const scalar_t* ia_ptr[M_TILES];
+#pragma unroll
+    for (int t = 0; t < M_TILES; t++) {
+      const int r = m_base + 16 * t + ia_row;
+      ia_okt[t] = r < M;
+      ia_ptr[t] = A + (ia_okt[t] ? r : 0) * K + kUnitK * p_beg + ia_c0;
+    }
+    int ipend = p_end - p_beg;
+
+    auto issue_pair = [&](int slot) {
+      if (ipend > 0) {
+        ipend--;
+        if constexpr (W8) {
+          cp_async4_evict_first(&bstage[warp][slot][2 * lane], ipair_ptr, bpol);
+          cp_async4_evict_first(&bstage[warp][slot][2 * lane + 1],
+                                ipair_ptr + 4, bpol);
+        } else {
+          cp_async4_evict_first(&bstage[warp][slot][lane], ipair_ptr, bpol);
+          cp_async4_evict_first(&bstage[warp][slot][32 + lane],
+                                ipair_ptr + kPairInt32 / 2, bpol);
+        }
+        ipair_ptr += kPairInt32;
+#pragma unroll
+        for (int t = 0; t < M_TILES; t++) {
+          if (ia_okt[t]) {
+            marlin::cp_async4(&astage[warp][slot][t][ia_row][ia_c0], ia_ptr[t]);
+            if constexpr (!W8) {
+              marlin::cp_async4(&astage[warp][slot][t][ia_row][ia_c0 + 8],
+                                ia_ptr[t] + 8);
+            }
+          }
+          ia_ptr[t] += kUnitK;
+        }
+      }
+      marlin::cp_async_fence();
+    };
+
+    int g = 0;
+    int left = INT_MAX;
+    const int g_last = group_size > 0 && p_beg < p_end
+                           ? (kUnitK * (p_end - 1)) / group_size
+                           : 0;
+    scalar_t2 s_next = zero2;
+    scalar_t2 z_next = zero2;
+    if (p_beg < p_end) {
+      if (group_size > 0) {
+        g = p_beg / ppg;
+        left = ppg - p_beg % ppg;
+      }
+      expand_row(fetch_row(S, g), s_reg);
+      if constexpr (HAS_ZP) expand_row(fetch_row(Z, g), z_reg);
+      if (g + 1 <= g_last) {
+        s_next = fetch_row(S, g + 1);
+        if constexpr (HAS_ZP) z_next = fetch_row(Z, g + 1);
+      }
+    }
+
+    // The two-unit W8 step issues two copies per iteration, so its
+    // prologue holds one slot fewer or the second issue of the first
+    // iteration would overwrite the oldest unprocessed stage.
+    constexpr int kPrologue = W8 ? kStagesT - 2 : kStagesT - 1;
+#pragma unroll
+    for (int st = 0; st < kPrologue; st++) issue_pair(st);
+
+    // At two stages the historical wait<kStagesT - 2> is wait<0>, which
+    // drains the copy issued THIS iteration and serializes the pipeline;
+    // one group must stay in flight.
+    constexpr int kWaitN = kStagesT == 2 ? 1 : kStagesT - 2;
+    int slot = 0;
+    int islot = kPrologue;
+    auto step = [&](int p) {
+      if (left == 0) {
+        ++g;
+        expand_row(s_next, s_reg);
+        if constexpr (HAS_ZP) expand_row(z_next, z_reg);
+        if (g + 1 <= g_last) {
+          s_next = fetch_row(S, g + 1);
+          if constexpr (HAS_ZP) z_next = fetch_row(Z, g + 1);
+        }
+        left = ppg;
+      }
+      process_pair(slot, bstage[warp][slot]);
+      left--;
+      if (++slot == kStagesT) slot = 0;
+    };
+    if constexpr (W8) {
+      // A single k16 unit leaves one thin dequant chain exposed to the
+      // staging-buffer load latency (short-scoreboard dominates profiles);
+      // stepping two units per wait restores k32 of independent work.
+      // Both stepped slots must be complete, so the two-step wait leaves
+      // kStagesT - 2 groups in flight (zero at two stages).
+      constexpr int kWaitN2 = kStagesT - 2;
+      int p = p_beg;
+      for (; p + 1 < p_end; p += 2) {
+        issue_pair(islot);
+        if (++islot == kStagesT) islot = 0;
+        issue_pair(islot);
+        if (++islot == kStagesT) islot = 0;
+        marlin::cp_async_wait<kWaitN2>();
+        step(p);
+        step(p + 1);
+      }
+      for (; p < p_end; p++) {
+        issue_pair(islot);
+        if (++islot == kStagesT) islot = 0;
+        marlin::cp_async_wait<kWaitN>();
+        step(p);
+      }
+    } else {
+      for (int p = p_beg; p < p_end; p++) {
+        issue_pair(islot);
+        if (++islot == kStagesT) islot = 0;
+        marlin::cp_async_wait<kWaitN>();
+        step(p);
+      }
+    }
+
+    // Segment flush into the launcher-zeroed C.
+#pragma unroll
+    for (int t = 0; t < M_TILES; t++) {
+#pragma unroll
+      for (int j = 0; j < 4; j++) {
+#pragma unroll
+        for (int b = 0; b < 2; b++) {
+          const int cc = col_base + 8 * (2 * j + b) + 2 * tig;
+          const float4 v = *reinterpret_cast<float4*>(&acc[t][j][b]);
+          if (r0ok[t])
+            red_add2(
+                reinterpret_cast<scalar_t2*>(C + int64_t(row0[t]) * N + cc),
+                Dtype::nums2num2(Dtype::float2num(v.x), Dtype::float2num(v.y)));
+          if (r1ok[t])
+            red_add2(
+                reinterpret_cast<scalar_t2*>(C + int64_t(row0[t] + 8) * N + cc),
+                Dtype::nums2num2(Dtype::float2num(v.z), Dtype::float2num(v.w)));
+        }
+      }
+    }
+  }
+}
+
+}  // namespace swordfish

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_dense_tier.cu
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_dense_tier.cu
@@ -1,0 +1,317 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+// Dense-GEMM tier for very large M. Past a few thousand rows the problem is
+// compute-bound and Blackwell's dense fp16/bf16 rate through cuBLAS beats
+// any fused mixed-input mainloop, so the weight dequantizes once into a
+// transient dense buffer and cuBLAS takes the GEMM. The dequant cost is a
+// few weight-reads and amortizes to nothing at this scale.
+
+#include <cublas_v2.h>
+
+#include <optional>
+
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include "libtorch_stable/torch_utils.h"
+#include "swordfish_decode.cuh"
+
+#define SWORDFISH_CHECK_CUBLAS(cmd)                                \
+  do {                                                             \
+    cublasStatus_t e = cmd;                                        \
+    STD_TORCH_CHECK(e == CUBLAS_STATUS_SUCCESS,                    \
+                    "swordfish dense tier cuBLAS error ", int(e)); \
+  } while (0)
+
+namespace swordfish {
+
+namespace {
+
+// One warp per marlin 16x64 sub-tile, staged through smem so the dense
+// stores coalesce. The fragment contract matches the decode kernels: word j
+// of lane T covers columns {16j + T/4, 16j + 8 + T/4} at sub-tile rows
+// 2(T%4) + {0, 1, 8, 9}.
+template <aphrodite::ScalarTypeId type_id, bool W8, bool HAS_ZP,
+          bool TRANSPOSED = false>
+__global__ void swordfish_dequant_dense_kernel(
+    const int32_t* __restrict__ B,
+    const typename marlin::MarlinScalarType<type_id>::scalar_t* __restrict__ S,
+    const typename marlin::MarlinScalarType<type_id>::scalar_t* __restrict__ Z,
+    const int32_t* __restrict__ perm,
+    typename marlin::MarlinScalarType<type_id>::scalar_t* __restrict__ W, int K,
+    int N, int group_size) {
+  using Dtype = marlin::MarlinScalarType<type_id>;
+  using scalar_t = typename Dtype::scalar_t;
+  using scalar_t2 = typename Dtype::scalar_t2;
+  using FragB = typename Dtype::FragB;
+
+  const int lane = threadIdx.x % 32;
+  const int warp = threadIdx.x / 32;  // sub-tile within the block
+  const int c = lane >> 2;
+  const int t = lane & 3;
+  const int nb = blockIdx.x;
+  const int kb = blockIdx.y;
+  const int num_kb = K / kBlockK;
+  const int num_nb = N / kBlockN;
+  constexpr int64_t kBlockW = W8 ? kBlockInt32_8 : kBlockInt32;
+
+  // blockIdx.z indexes the expert for stacked MoE weights.
+  const int64_t expert = blockIdx.z;
+  B += expert * num_nb * num_kb * kBlockW;
+  const int num_groups = group_size > 0 ? K / group_size : 1;
+  S += expert * int64_t(num_groups) * N;
+  if constexpr (HAS_ZP) Z += expert * int64_t(num_groups) * N;
+  W += expert * int64_t(K) * N;
+
+  // Rows padded 64 -> 72: a 128 B row stride puts every same-column store
+  // across rows on one shared-memory bank; 144 B keeps the 16-byte
+  // alignment the vector reads need while spreading rows over the banks.
+  __shared__ scalar_t tile[4][16][72];
+
+  const int4* buf = reinterpret_cast<const int4*>(
+      B + (int64_t(nb) * num_kb + kb) * kBlockW +
+      warp * (W8 ? 2 * kPairInt32 / 2 : kPairInt32 / 2));
+
+  // One scale group covers the whole 16-row sub-tile for every supported
+  // group size.
+  const int g = group_size > 0 ? (kb * kBlockK + 16 * warp) / group_size : 0;
+  const scalar_t* srow = S + int64_t(g) * N + nb * kBlockN;
+  const scalar_t* zrow = HAS_ZP ? Z + int64_t(g) * N + nb * kBlockN : nullptr;
+
+  const marlin::I4 bq0 =
+      *reinterpret_cast<const marlin::I4*>(&buf[W8 ? 2 * lane : lane]);
+  marlin::I4 bq1;
+  if constexpr (W8) {
+    bq1 = *reinterpret_cast<const marlin::I4*>(&buf[2 * lane + 1]);
+  }
+
+  auto put = [&](int row, int col, scalar_t2 v2, bool hi) {
+    tile[warp][row][col] = reinterpret_cast<const scalar_t*>(&v2)[hi ? 1 : 0];
+  };
+
+#pragma unroll
+  for (int j = 0; j < 4; j++) {
+    FragB frag_b0, frag_b1;
+    if constexpr (W8) {
+      const marlin::I4& src = j < 2 ? bq0 : bq1;
+      marlin::dequant<scalar_t2, aphrodite::kU8B128.id(), false>(
+          src.elems[(2 * j) & 3], reinterpret_cast<scalar_t2*>(&frag_b0));
+      marlin::dequant<scalar_t2, aphrodite::kU8B128.id(), false>(
+          src.elems[(2 * j + 1) & 3], reinterpret_cast<scalar_t2*>(&frag_b1));
+    } else {
+      const int q = bq0.elems[j];
+      marlin::dequant<scalar_t2, aphrodite::kU4B8.id(), false>(
+          q, reinterpret_cast<scalar_t2*>(&frag_b0));
+      marlin::dequant<scalar_t2, aphrodite::kU4B8.id(), false>(
+          q >> 8, reinterpret_cast<scalar_t2*>(&frag_b1));
+    }
+    const int n0 = 16 * j + c;
+    const int n1 = n0 + 8;
+    const scalar_t2 s0 = Dtype::num2num2(srow[n0]);
+    const scalar_t2 s1 = Dtype::num2num2(srow[n1]);
+    if constexpr (HAS_ZP) {
+      const scalar_t2 z0 = Dtype::num2num2(zrow[n0]);
+      const scalar_t2 z1 = Dtype::num2num2(zrow[n1]);
+      frag_b0[0] = __hfma2(frag_b0[0], s0, z0);
+      frag_b0[1] = __hfma2(frag_b0[1], s0, z0);
+      frag_b1[0] = __hfma2(frag_b1[0], s1, z1);
+      frag_b1[1] = __hfma2(frag_b1[1], s1, z1);
+    } else {
+      frag_b0[0] = __hmul2(frag_b0[0], s0);
+      frag_b0[1] = __hmul2(frag_b0[1], s0);
+      frag_b1[0] = __hmul2(frag_b1[0], s1);
+      frag_b1[1] = __hmul2(frag_b1[1], s1);
+    }
+    // frag[0] holds rows {2t, 2t+1}, frag[1] rows {2t+8, 2t+9}.
+    put(2 * t, n0, frag_b0[0], false);
+    put(2 * t + 1, n0, frag_b0[0], true);
+    put(2 * t + 8, n0, frag_b0[1], false);
+    put(2 * t + 9, n0, frag_b0[1], true);
+    put(2 * t, n1, frag_b1[0], false);
+    put(2 * t + 1, n1, frag_b1[0], true);
+    put(2 * t + 8, n1, frag_b1[1], false);
+    put(2 * t + 9, n1, frag_b1[1], true);
+  }
+  __syncwarp();
+
+  const int k_base = kb * kBlockK + 16 * warp;
+  if constexpr (TRANSPOSED) {
+    // [N, K] output for consumers that want out-major weights (the triton
+    // fused-MoE kernels). 16 k-elements per n form two 16-byte runs.
+    for (int nn = lane; nn < 64; nn += 32) {
+      scalar_t run[16];
+#pragma unroll
+      for (int r = 0; r < 16; r++) run[r] = tile[warp][r][nn];
+      int4* dst =
+          reinterpret_cast<int4*>(&W[int64_t(nb * kBlockN + nn) * K + k_base]);
+      dst[0] = *reinterpret_cast<const int4*>(&run[0]);
+      dst[1] = *reinterpret_cast<const int4*>(&run[8]);
+    }
+  } else {
+    // Coalesced stores: 16-byte runs per lane over the sub-tile's rows.
+    // Under act_order the packed rows are group-sorted, so row r scatters
+    // to its original position and the activations stay unpermuted.
+    const int c0 = 8 * (lane % 8);
+#pragma unroll
+    for (int r = lane / 8; r < 16; r += 4) {
+      const int64_t k_dst = perm != nullptr ? perm[k_base + r] : k_base + r;
+      *reinterpret_cast<int4*>(&W[k_dst * N + nb * kBlockN + c0]) =
+          *reinterpret_cast<const int4*>(&tile[warp][r][c0]);
+    }
+  }
+}
+
+}  // namespace
+
+void swordfish_dense_tier_mm(const void* a, const int32_t* b, const void* s,
+                             const void* z, const int32_t* perm, void* c,
+                             void* w_dense, bool is_half, bool w8, bool has_zp,
+                             int m, int k, int n, int group_size,
+                             cudaStream_t stream) {
+  dim3 grid(n / kBlockN, k / kBlockK, 1);
+  const auto run = [&](auto tid, auto w8c, auto zpc) {
+    constexpr aphrodite::ScalarTypeId kTid = decltype(tid)::value;
+    using scalar_t = typename marlin::MarlinScalarType<kTid>::scalar_t;
+    swordfish_dequant_dense_kernel<kTid, decltype(w8c)::value,
+                                   decltype(zpc)::value>
+        <<<grid, 128, 0, stream>>>(b, reinterpret_cast<const scalar_t*>(s),
+                                   reinterpret_cast<const scalar_t*>(z), perm,
+                                   reinterpret_cast<scalar_t*>(w_dense), k, n,
+                                   group_size);
+  };
+  using kF16 =
+      std::integral_constant<aphrodite::ScalarTypeId, aphrodite::kFloat16.id()>;
+  using kBF16 = std::integral_constant<aphrodite::ScalarTypeId,
+                                       aphrodite::kBFloat16.id()>;
+  using kT = std::true_type;
+  using kF = std::false_type;
+  if (is_half) {
+    if (has_zp) {
+      run(kF16{}, kF{}, kT{});
+    } else if (w8) {
+      run(kF16{}, kT{}, kF{});
+    } else {
+      run(kF16{}, kF{}, kF{});
+    }
+  } else {
+    if (has_zp) {
+      run(kBF16{}, kF{}, kT{});
+    } else if (w8) {
+      run(kBF16{}, kT{}, kF{});
+    } else {
+      run(kBF16{}, kF{}, kF{});
+    }
+  }
+
+  // C = A W with row-major tensors through column-major cuBLAS as
+  // C^T = W^T A^T.
+  cublasHandle_t handle = get_current_cuda_blas_handle();
+  SWORDFISH_CHECK_CUBLAS(cublasSetStream(handle, stream));
+  const float alpha = 1.0f, beta = 0.0f;
+  const cudaDataType_t ct = is_half ? CUDA_R_16F : CUDA_R_16BF;
+  SWORDFISH_CHECK_CUBLAS(cublasGemmEx(
+      handle, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k, &alpha, w_dense, ct, n, a, ct,
+      k, &beta, c, ct, n, CUDA_R_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+}
+
+// Standalone dequant for consumers of dense weights, notably the MoE dense
+// tier which feeds the triton fused-MoE kernels ([E, out, in] transposed
+// layout). Accepts single [NB, KB, words] or stacked [E, NB, KB, words]
+// packed tensors.
+torch::stable::Tensor swordfish_dequant_dense(
+    torch::stable::Tensor& b_packed, torch::stable::Tensor& group_scales,
+    std::optional<torch::stable::Tensor> const& group_zps, int64_t num_bits,
+    int64_t group_size, int64_t size_k, int64_t size_n, bool transpose) {
+  STD_TORCH_CHECK(num_bits == 4 || num_bits == 8,
+                  "swordfish supports 4-bit and 8-bit weights");
+  const bool w8 = num_bits == 8;
+  const bool stacked = b_packed.dim() == 4;
+  const int64_t experts = stacked ? b_packed.size(0) : 1;
+  const auto a_st = group_scales.scalar_type();
+  STD_TORCH_CHECK(a_st == torch::headeronly::ScalarType::Half ||
+                      a_st == torch::headeronly::ScalarType::BFloat16,
+                  "group_scales must be fp16 or bf16");
+  const bool has_zp = group_zps.has_value();
+
+  const int32_t device_index = b_packed.get_device_index();
+  torch::stable::accelerator::DeviceGuard device_guard(device_index);
+  const cudaStream_t stream = get_current_cuda_stream(device_index);
+
+  torch::stable::Tensor out =
+      stacked
+          ? torch::stable::empty(
+                transpose
+                    ? std::initializer_list<int64_t>{experts, size_n, size_k}
+                    : std::initializer_list<int64_t>{experts, size_k, size_n},
+                a_st, std::nullopt, b_packed.device())
+          : torch::stable::empty(
+                transpose ? std::initializer_list<int64_t>{size_n, size_k}
+                          : std::initializer_list<int64_t>{size_k, size_n},
+                a_st, std::nullopt, b_packed.device());
+
+  dim3 grid(size_n / kBlockN, size_k / kBlockK, experts);
+  const auto* b = reinterpret_cast<const int32_t*>(b_packed.const_data_ptr());
+  const void* sp = group_scales.const_data_ptr();
+  const void* zp = has_zp ? group_zps->const_data_ptr() : nullptr;
+  void* wp = out.mutable_data_ptr();
+  const int k = int(size_k), n = int(size_n), gs = int(group_size);
+
+  const auto run = [&](auto tid, auto w8c, auto zpc, auto trc) {
+    constexpr aphrodite::ScalarTypeId kTid = decltype(tid)::value;
+    using scalar_t = typename marlin::MarlinScalarType<kTid>::scalar_t;
+    swordfish_dequant_dense_kernel<kTid, decltype(w8c)::value,
+                                   decltype(zpc)::value, decltype(trc)::value>
+        <<<grid, 128, 0, stream>>>(b, reinterpret_cast<const scalar_t*>(sp),
+                                   reinterpret_cast<const scalar_t*>(zp),
+                                   nullptr, reinterpret_cast<scalar_t*>(wp), k,
+                                   n, gs);
+  };
+  using kF16 =
+      std::integral_constant<aphrodite::ScalarTypeId, aphrodite::kFloat16.id()>;
+  using kBF16 = std::integral_constant<aphrodite::ScalarTypeId,
+                                       aphrodite::kBFloat16.id()>;
+  using kT = std::true_type;
+  using kF = std::false_type;
+  const auto dispatch = [&](auto tid) {
+    if (transpose) {
+      if (has_zp) {
+        run(tid, kF{}, kT{}, kT{});
+      } else if (w8) {
+        run(tid, kT{}, kF{}, kT{});
+      } else {
+        run(tid, kF{}, kF{}, kT{});
+      }
+    } else {
+      if (has_zp) {
+        run(tid, kF{}, kT{}, kF{});
+      } else if (w8) {
+        run(tid, kT{}, kF{}, kF{});
+      } else {
+        run(tid, kF{}, kF{}, kF{});
+      }
+    }
+  };
+  if (a_st == torch::headeronly::ScalarType::Half) {
+    dispatch(kF16{});
+  } else {
+    dispatch(kBF16{});
+  }
+  return out;
+}
+
+}  // namespace swordfish
+
+STABLE_TORCH_LIBRARY_IMPL(gptqmodel_swordfish, CUDA, m) {
+  m.impl("swordfish_dequant_dense",
+         TORCH_BOX(&swordfish::swordfish_dequant_dense));
+}

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_mm.cu
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_mm.cu
@@ -1,0 +1,473 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+// w4a16 decode GEMM over the Swordfish ABI v1 packed weight
+//. The kernel lives in swordfish_decode.cuh.
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <optional>
+
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include "libtorch_stable/ops.h"
+#include "libtorch_stable/torch_utils.h"
+#include "swordfish_decode.cuh"
+
+namespace swordfish {
+
+// Defined in swordfish_dense_tier.cu (same extension).
+void swordfish_dense_tier_mm(const void* a, const int32_t* b, const void* s,
+                             const void* z, const int32_t* perm, void* c,
+                             void* w_dense, bool is_half, bool w8, bool has_zp,
+                             int m, int k, int n, int group_size,
+                             cudaStream_t stream);
+
+// Defined in swordfish_prefill.cu (same extension).
+torch::stable::Tensor swordfish_prefill_mm(
+    torch::stable::Tensor& a, torch::stable::Tensor& b_packed,
+    torch::stable::Tensor& group_scales,
+    std::optional<torch::stable::Tensor> const& group_zps, int64_t num_bits,
+    int64_t group_size, int64_t size_k, int64_t size_n);
+
+namespace {
+
+// Decode/prefill crossover. It must live in C++ because a Python-side
+// branch is traced by torch.compile at one representative M and baked into
+// the compiled graph. Here the true runtime M decides on every call and on
+// every captured CUDA graph.
+inline bool use_prefill(int64_t m, torch::headeronly::ScalarType a_st, bool w8,
+                        int64_t group_size, int64_t k, int64_t n) {
+  if (a_st != torch::headeronly::ScalarType::BFloat16 &&
+      a_st != torch::headeronly::ScalarType::Half) {
+    return false;
+  }
+  if (w8 ? group_size != 128
+         : (group_size != 32 && group_size != 64 && group_size != 128)) {
+    return false;
+  }
+  if (k % 128 != 0 || n % 128 != 0) return false;
+  // The prefill grid launches about n/128 CTAs per M tile. When that fills
+  // the machine the tcgen05 path wins from M 48 up; when it underfills
+  // (many SMs, narrow N), the Stream-K decode window carries [17, 96).
+  static int sms = 0;
+  if (sms == 0) {
+    cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, 0);
+    if (sms <= 0) sms = 1;
+  }
+  const bool prefill_fills = n / 128 >= sms;
+  // The four-tile decode window carries [48, 56) even at wide N; the
+  // tcgen05 wave only pulls ahead of it from 56 rows up. K-heavy narrow-N
+  // shapes keep Stream-K through [96, 128) on many-SM parts, where a single
+  // underfilled tcgen05 wave loses to it.
+  if (m >= 96 && m < 128 && k >= 2 * n && n / 128 < sms / 4) return false;
+  return m >= 96 || (m >= 56 && prefill_fills);
+}
+
+// Above this M the problem is compute-bound and dequant-once + dense
+// cuBLAS outruns the fused mixed-input mainloops, so the tier takes over.
+// 8-bit crosses earlier than 4-bit because the mixed-input pipeline moves
+// twice the weight bytes through the transform. On few-SM parts the dense
+// rate only clears the 4-bit weight stream's bandwidth win at 8 bits, and
+// K-heavy shapes pay proportionally more dequant per flop, so they cross
+// later still.
+inline int dense_tier_min_m(int sms, bool w8, int64_t size_k, int64_t size_n,
+                            bool has_perm) {
+  static const int v = [] {
+    const char* e = std::getenv("APHRODITE_SWORDFISH_DENSE_M");
+    return e != nullptr && e[0] != '\0' ? std::atoi(e) : 0;
+  }();
+  if (v != 0) return v;
+  if (sms < 100) {
+    if (!w8) return INT_MAX;
+    return size_k >= 2 * size_n ? 8192 : 2048;
+  }
+  // act_order crosses much earlier outside wide N: the fused paths pay the
+  // activation sort and per-group scale gathers that the dense tier folds
+  // into its weight scatter for free (K-heavy shapes halve at M >= 512).
+  // Wide N stays fused, where the K*N dequant write dominates instead.
+  if (has_perm && size_n <= 2 * size_k) return 512;
+  return w8 ? 1024 : 4096;
+}
+
+// APHRODITE_SWORDFISH_DETERMINISTIC forces the run-stable decode paths:
+// the smem-reduction epilogue replaces every atomic-window kernel, at the
+// decode window's cost. The tcgen05 prefill is deterministic either way.
+// The fused-MoE kernels keep their atomic merge regardless.
+inline bool force_deterministic() {
+  static const bool v = [] {
+    const char* e = std::getenv("APHRODITE_SWORDFISH_DETERMINISTIC");
+    return e != nullptr && e[0] != '\0' && std::strcmp(e, "0") != 0;
+  }();
+  return v;
+}
+
+inline int cached_sm_count() {
+  static int sms = 0;
+  if (sms == 0) {
+    cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, 0);
+    if (sms <= 0) sms = 1;
+  }
+  return sms;
+}
+
+template <aphrodite::ScalarTypeId type_id, int T, bool HAS_ZP, bool W8 = false,
+          bool CTA_QUAD = false>
+void launch_decode_streamk_t(const void* a, const int32_t* b, const void* s,
+                             const void* z, void* c, int m, int k, int n,
+                             int group_size, cudaStream_t stream,
+                             bool c_zeroed = false) {
+  using scalar_t = typename marlin::MarlinScalarType<type_id>::scalar_t;
+  constexpr int kStagesT =
+      T == 1 ? kStages : (T == 2 ? (W8 ? 5 : 4) : (T == 3 ? 3 : (W8 ? 4 : 2)));
+  constexpr int kUnitK = W8 ? 16 : 32;
+  static int ctas_per_sm = 0;
+  if (ctas_per_sm == 0) {
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &ctas_per_sm,
+        swordfish_decode_streamk_kernel<type_id, T, HAS_ZP, W8, CTA_QUAD>,
+        kDecodeThreads, 0);
+    if (ctas_per_sm <= 0) ctas_per_sm = 2;
+  }
+  int sms = 0;
+  cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, 0);
+  const int m_tiles = (m + 15) / 16;
+  const int m_groups = (m_tiles + T - 1) / T;
+  const int nb = n / (CTA_QUAD ? kBlockN * kDecodeWarps : kBlockN);
+  const int num_pairs = k / kUnitK;
+  const int64_t total = int64_t(m_groups) * nb * num_pairs;
+  int ctas = ctas_per_sm * sms;
+  if (CTA_QUAD) {
+    // Quad claims are CTA-granular: keep them tens of units long so the
+    // claim, flush, and atomic costs amortize, and stop at the number of
+    // claims rather than idling CTAs.
+    const int64_t max_ctas = total / 32 > 0 ? total / 32 : 1;
+    if (ctas > max_ctas) ctas = int(max_ctas);
+  } else {
+    // Cap the grid so every warp gets at least a pipeline's worth of pairs.
+    const int64_t max_warps =
+        total / (2 * kStagesT) > 0 ? total / (2 * kStagesT) : 1;
+    if (int64_t(ctas) * kDecodeWarps > max_warps) {
+      ctas = int((max_warps + kDecodeWarps - 1) / kDecodeWarps);
+    }
+  }
+  if (ctas < 1) ctas = 1;
+  if (!c_zeroed) launch_zero_c<scalar_t>(c, m, n, stream);
+  swordfish_decode_streamk_kernel<type_id, T, HAS_ZP, W8, CTA_QUAD>
+      <<<ctas, kDecodeThreads, 0, stream>>>(
+          reinterpret_cast<const scalar_t*>(a), b,
+          reinterpret_cast<const scalar_t*>(s),
+          reinterpret_cast<const scalar_t*>(z), reinterpret_cast<scalar_t*>(c),
+          m, k, n, group_size, m_groups);
+}
+
+template <aphrodite::ScalarTypeId type_id, int T, bool HAS_ZP, bool W8 = false>
+void launch_decode_atomic_t(const void* a, const int32_t* b, const void* s,
+                            const void* z, void* c, int m, int k, int n,
+                            int group_size, cudaStream_t stream,
+                            bool c_zeroed = false) {
+  using scalar_t = typename marlin::MarlinScalarType<type_id>::scalar_t;
+  constexpr int kStagesT = T == 1 ? kStages : (T == 2 ? 4 : 3);
+  static int ctas_per_sm = 0;  // per (type, T) instantiation
+  if (ctas_per_sm == 0) {
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &ctas_per_sm, swordfish_decode_kernel<type_id, true, T, HAS_ZP, W8>,
+        kDecodeThreads, 0);
+    if (ctas_per_sm <= 0) ctas_per_sm = 4;
+  }
+  int sms = 0;
+  cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, 0);
+  const int m_ctas = (m + 16 * T - 1) / (16 * T);
+  const int nb = n / kBlockN;
+  const int num_pairs = k / (W8 ? 16 : 32);
+  const int target = ctas_per_sm * sms;
+  // Floor division. Splitting K pays only when columns fall well short of
+  // the machine, since slicing shortens the per-warp pipeline and raises
+  // atomic contention.
+  int split = target / (nb * m_ctas);
+  // On few-SM parts, columns alone reaching the machine is enough. K-slices
+  // beyond that shorten the latency-bound per-warp chains and buy the
+  // launcher memset, measured 8-15 percent slower at M=1 narrow N on 20
+  // SMs. Many-SM parts want the occupancy target: the same sweep run the
+  // other way is 2-3x slower at split 1 on 148 SMs.
+  if (sms < 100 && nb * m_ctas >= sms) split = 1;
+  // Keep at least 2*kStagesT pairs per warp so the pipeline reaches steady
+  // state within a slice.
+  const int max_split = std::max(1, num_pairs / (kDecodeWarps * 2 * kStagesT));
+  split = std::min(std::max(split, 1), max_split);
+  dim3 sgrid(m_ctas, nb, split);
+  // At split 1 each CTA zeroes its exclusive C tile in-kernel. At split > 1
+  // tiles are shared and the memset is required.
+  if (split > 1 && !c_zeroed) {
+    launch_zero_c<scalar_t>(c, m, n, stream);
+  }
+  swordfish_decode_kernel<type_id, true, T, HAS_ZP, W8>
+      <<<sgrid, kDecodeThreads, 0, stream>>>(
+          reinterpret_cast<const scalar_t*>(a), b,
+          reinterpret_cast<const scalar_t*>(s),
+          reinterpret_cast<const scalar_t*>(z), reinterpret_cast<scalar_t*>(c),
+          m, k, n, group_size);
+}
+
+template <aphrodite::ScalarTypeId type_id, bool HAS_ZP, bool W8 = false>
+void launch_decode_atomic(int T, const void* a, const int32_t* b, const void* s,
+                          const void* z, void* c, int m, int k, int n,
+                          int group_size, cudaStream_t stream,
+                          bool c_zeroed = false) {
+  if (T == 1) {
+    launch_decode_atomic_t<type_id, 1, HAS_ZP, W8>(
+        a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+  } else if (T == 2) {
+    launch_decode_atomic_t<type_id, 2, HAS_ZP, W8>(
+        a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+  } else {
+    launch_decode_atomic_t<type_id, 3, HAS_ZP, W8>(
+        a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+  }
+}
+
+template <aphrodite::ScalarTypeId type_id, bool HAS_ZP, bool W8 = false>
+void launch_decode(const void* a, const int32_t* b, const void* s,
+                   const void* z, void* c, int m, int k, int n, int group_size,
+                   cudaStream_t stream, bool c_zeroed = false) {
+  using scalar_t = typename marlin::MarlinScalarType<type_id>::scalar_t;
+  if (force_deterministic()) {
+    dim3 grid((m + 15) / 16, n / kBlockN);
+    swordfish_decode_kernel<type_id, false, 1, HAS_ZP, W8>
+        <<<grid, kDecodeThreads, 0, stream>>>(
+            reinterpret_cast<const scalar_t*>(a), b,
+            reinterpret_cast<const scalar_t*>(s),
+            reinterpret_cast<const scalar_t*>(z),
+            reinterpret_cast<scalar_t*>(c), m, k, n, group_size);
+  } else if (m <= 16) {
+    // Tuned single-tile path with in-kernel C zeroing and heuristic split-K.
+    launch_decode_atomic<type_id, HAS_ZP, W8>(1, a, b, s, z, c, m, k, n,
+                                              group_size, stream, c_zeroed);
+  } else if (m <= 127) {
+    // Window dispatch. When columns alone fill the machine the fused atomic
+    // grid (in-kernel zeroing, no memset) is already balanced; otherwise
+    // Stream-K hands each warp a contiguous flat range of (fused tile,
+    // column, pair) work and the atomic epilogue merges segments, removing
+    // split-K heuristics and wave quantization.
+    const bool wide_n = n / kBlockN >= 4 * cached_sm_count();
+    // On many-SM parts the whole [17, 48] band belongs to the fused atomic
+    // grid at any width: its CTA shares one weight stream across four
+    // warps, where Stream-K's warp-private B and A staging pays for itself
+    // only when the machine is small enough for warps to get long claims.
+    // Few-SM parts keep Stream-K outside wide N (measured 0.73-0.96 of
+    // marlin the other way around on 20 SMs).
+    const bool band_atomic = cached_sm_count() >= 100 && m <= 48;
+    if (band_atomic || (wide_n && m <= 47)) {
+      launch_decode_atomic<type_id, HAS_ZP, W8>(m <= 32 ? 2 : 3, a, b, s, z, c,
+                                                m, k, n, group_size, stream,
+                                                c_zeroed);
+    } else if (m <= 48 && n % (4 * kBlockN) == 0) {
+      // Few-SM band: CTA-granular claims over n256 column quads.
+      if (m <= 32) {
+        launch_decode_streamk_t<type_id, 2, HAS_ZP, W8, true>(
+            a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+      } else {
+        launch_decode_streamk_t<type_id, 3, HAS_ZP, W8, true>(
+            a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+      }
+    } else if (m <= 32) {
+      launch_decode_streamk_t<type_id, 2, HAS_ZP, W8>(
+          a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+    } else if (m <= 48) {
+      launch_decode_streamk_t<type_id, 3, HAS_ZP, W8>(
+          a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+    } else if (m <= 64) {
+      // Four-tile fusion amortizes the dequant across the whole band; the
+      // m-shared CTA it replaces dequantized the same weights once per warp
+      // and issued 2.7x the instructions for it.
+      launch_decode_streamk_t<type_id, 4, HAS_ZP, W8>(
+          a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+    } else {
+      launch_decode_streamk_t<type_id, 3, HAS_ZP, W8>(
+          a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+    }
+  } else {
+    dim3 grid((m + 15) / 16, n / kBlockN);
+    swordfish_decode_kernel<type_id, false, 1, HAS_ZP, W8>
+        <<<grid, kDecodeThreads, 0, stream>>>(
+            reinterpret_cast<const scalar_t*>(a), b,
+            reinterpret_cast<const scalar_t*>(s),
+            reinterpret_cast<const scalar_t*>(z),
+            reinterpret_cast<scalar_t*>(c), m, k, n, group_size);
+  }
+}
+
+}  // namespace
+
+torch::stable::Tensor swordfish_mm(
+    torch::stable::Tensor& a, torch::stable::Tensor& b_packed,
+    torch::stable::Tensor& group_scales,
+    std::optional<torch::stable::Tensor> const& group_zps, int64_t num_bits,
+    int64_t group_size, int64_t size_k, int64_t size_n) {
+  STD_TORCH_CHECK(num_bits == 4 || num_bits == 8,
+                  "swordfish supports 4-bit and 8-bit weights");
+  const bool w8 = num_bits == 8;
+  STD_TORCH_CHECK(shape_ok(size_k, size_n), "swordfish ABI v1 requires K % ",
+                  kBlockK, " == 0 and N % ", kBlockN, " == 0; got K=", size_k,
+                  " N=", size_n);
+  STD_TORCH_CHECK(a.dim() == 2 && a.size(1) == size_k,
+                  "a must be [M, K] with K=", size_k);
+  STD_TORCH_CHECK(a.stride(1) == 1 && a.stride(0) == size_k,
+                  "a must be contiguous");
+  const auto a_st = a.scalar_type();
+  STD_TORCH_CHECK(a_st == torch::headeronly::ScalarType::Half ||
+                      a_st == torch::headeronly::ScalarType::BFloat16,
+                  "a must be fp16 or bf16");
+  STD_TORCH_CHECK(group_scales.scalar_type() == a_st,
+                  "group_scales dtype must match a");
+
+  const int64_t nb = num_blocks_n(size_n);
+  const int64_t kb = num_blocks_k(size_k);
+  const int64_t words = w8 ? kBlockInt32_8 : kBlockInt32;
+  STD_TORCH_CHECK(
+      b_packed.scalar_type() == torch::headeronly::ScalarType::Int &&
+          b_packed.dim() == 3 && b_packed.size(0) == nb &&
+          b_packed.size(1) == kb && b_packed.size(2) == words,
+      "b_packed must be int32 [", nb, ", ", kb, ", ", words, "]");
+
+  int64_t num_groups = 1;
+  // Channelwise checkpoints arrive as group -1 with the single scale row
+  // replicated to group 128 by the weight loader. The grouped tiers
+  // (tcgen05 prefill, dense dequant) consume the replicated rows as g128;
+  // the decode kernels take the native -1 path, which reads row 0 once and
+  // skips the per-group fetch/expand bookkeeping the duplicate rows would
+  // otherwise re-run at every 128-row boundary.
+  int64_t tier_group = group_size;
+  if (group_size == -1) {
+    if (group_scales.size(0) == size_k / 128) {
+      num_groups = size_k / 128;
+      tier_group = 128;
+    }
+  } else {
+    // The decode mainloop consumes k16-slice PAIRS (k32) with scales hoisted
+    // per pair, so a scale group must cover whole pairs.
+    STD_TORCH_CHECK(group_size > 0 && size_k % group_size == 0 &&
+                        group_size % (2 * kMarlinTileK) == 0,
+                    "group_size must be -1 or a multiple of ", 2 * kMarlinTileK,
+                    " dividing K; got ", group_size);
+    num_groups = size_k / group_size;
+  }
+  STD_TORCH_CHECK(group_scales.dim() == 2 &&
+                      group_scales.size(0) == num_groups &&
+                      group_scales.size(1) == size_n,
+                  "group_scales must be [", num_groups, ", ", size_n, "]");
+  const bool has_zp = group_zps.has_value();
+  if (has_zp) {
+    STD_TORCH_CHECK(!w8, "zero points are a 4-bit (AWQ/HQQ) feature");
+    STD_TORCH_CHECK(
+        group_zps->scalar_type() == a_st && group_zps->dim() == 2 &&
+            group_zps->size(0) == num_groups && group_zps->size(1) == size_n,
+        "group_zps must be [", num_groups, ", ", size_n, "] with a's dtype");
+  }
+
+  const int64_t size_m = a.size(0);
+
+  // Activations are expected to be in the group-sorted order produced by
+  // swordfish_prepack_B (or explicitly permuted by the caller); the runtime
+  // GEMM no longer consumes an explicit permutation tensor.
+  const bool has_perm = false;
+
+  if (size_m >=
+          dense_tier_min_m(cached_sm_count(), w8, size_k, size_n, has_perm) &&
+      !force_deterministic()) {
+    const int32_t device_index = a.get_device_index();
+    torch::stable::accelerator::DeviceGuard device_guard(device_index);
+    const cudaStream_t stream = get_current_cuda_stream(device_index);
+    torch::stable::Tensor c =
+        torch::stable::empty({size_m, size_n}, a_st, std::nullopt, a.device());
+    torch::stable::Tensor w_dense =
+        torch::stable::empty({size_k, size_n}, a_st, std::nullopt, a.device());
+    // Act_order folds into the weight scatter here, so the activations are
+    // consumed unpermuted.
+    swordfish_dense_tier_mm(
+        a.const_data_ptr(),
+        reinterpret_cast<const int32_t*>(b_packed.const_data_ptr()),
+        group_scales.const_data_ptr(),
+        has_zp ? group_zps->const_data_ptr() : nullptr,
+        /*perm=*/nullptr,
+        c.mutable_data_ptr(), w_dense.mutable_data_ptr(),
+        a_st == torch::headeronly::ScalarType::Half, w8, has_zp, int(size_m),
+        int(size_k), int(size_n), int(tier_group), stream);
+    return c;
+  }
+
+  // The fused paths consume group-sorted K. Activations are already
+  // group-sorted by the caller, so no extra permute is needed here.
+  const bool will_prefill =
+      use_prefill(size_m, a_st, w8, tier_group, size_k, size_n);
+  const bool prep_perm = false;
+
+  if (will_prefill) {
+    return swordfish_prefill_mm(a, b_packed, group_scales, group_zps,
+                                num_bits, tier_group, size_k, size_n);
+  }
+
+  const int32_t device_index = a.get_device_index();
+  torch::stable::accelerator::DeviceGuard device_guard(device_index);
+  const cudaStream_t stream = get_current_cuda_stream(device_index);
+
+  torch::stable::Tensor c =
+      torch::stable::empty({size_m, size_n}, a_st, std::nullopt, a.device());
+  if (size_m == 0) return c;
+
+  const auto* b_ptr =
+      reinterpret_cast<const int32_t*>(b_packed.const_data_ptr());
+  const void* a_ptr = a.const_data_ptr();
+  const void* s_ptr = group_scales.const_data_ptr();
+  const void* z_ptr = has_zp ? group_zps->const_data_ptr() : nullptr;
+  void* c_ptr = c.mutable_data_ptr();
+
+  if (a_st == torch::headeronly::ScalarType::Half) {
+    if (has_zp) {
+      launch_decode<aphrodite::kFloat16.id(), true>(
+          a_ptr, b_ptr, s_ptr, z_ptr, c_ptr, size_m, size_k, size_n, group_size,
+          stream, prep_perm);
+    } else if (w8) {
+      launch_decode<aphrodite::kFloat16.id(), false, true>(
+          a_ptr, b_ptr, s_ptr, z_ptr, c_ptr, size_m, size_k, size_n, group_size,
+          stream, prep_perm);
+    } else {
+      launch_decode<aphrodite::kFloat16.id(), false>(
+          a_ptr, b_ptr, s_ptr, z_ptr, c_ptr, size_m, size_k, size_n, group_size,
+          stream, prep_perm);
+    }
+  } else {
+    if (has_zp) {
+      launch_decode<aphrodite::kBFloat16.id(), true>(
+          a_ptr, b_ptr, s_ptr, z_ptr, c_ptr, size_m, size_k, size_n, group_size,
+          stream, prep_perm);
+    } else if (w8) {
+      launch_decode<aphrodite::kBFloat16.id(), false, true>(
+          a_ptr, b_ptr, s_ptr, z_ptr, c_ptr, size_m, size_k, size_n, group_size,
+          stream, prep_perm);
+    } else {
+      launch_decode<aphrodite::kBFloat16.id(), false>(
+          a_ptr, b_ptr, s_ptr, z_ptr, c_ptr, size_m, size_k, size_n, group_size,
+          stream, prep_perm);
+    }
+  }
+
+  return c;
+}
+
+}  // namespace swordfish
+
+STABLE_TORCH_LIBRARY_IMPL(gptqmodel_swordfish, CUDA, m) {
+  m.impl("swordfish_mm", TORCH_BOX(&swordfish::swordfish_mm));
+}

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_moe.cu
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_moe.cu
@@ -1,0 +1,488 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+// Fused-MoE decode GEMM over per-expert Swordfish ABI v1 packed weights.
+// One persistent Stream-K kernel covers every (expert block, column, unit)
+// of the token-sorted problem that moe_align_block_size(block_size=16)
+// prepares: each 16-token block is one m16 tile of exactly one expert, so
+// the dense Stream-K decode mainloop applies with the activation rows and
+// output rows indirected through sorted_token_ids and the weight and scale
+// bases indexed by expert_ids. Work totals depend on the device-side padded
+// token count, so per-warp ranges derive in-kernel from
+// num_tokens_post_padded rather than on the host.
+
+#include <algorithm>
+#include <optional>
+
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include "libtorch_stable/torch_utils.h"
+#include "swordfish_decode.cuh"
+
+namespace swordfish {
+
+namespace {
+
+template <aphrodite::ScalarTypeId type_id, bool W8 = false, int M_TILES = 1>
+__global__ void swordfish_decode_moe_kernel(
+    const typename marlin::MarlinScalarType<type_id>::scalar_t* __restrict__ A,
+    const int32_t* __restrict__ B,
+    const typename marlin::MarlinScalarType<type_id>::scalar_t* __restrict__ S,
+    typename marlin::MarlinScalarType<type_id>::scalar_t* __restrict__ C,
+    const int32_t* __restrict__ sorted_token_ids,
+    const int32_t* __restrict__ expert_ids,
+    const int32_t* __restrict__ num_tokens_post_padded,
+    const float* __restrict__ topk_weights, int top_k, bool mul_topk_weights,
+    int total_tokens, int K, int N, int group_size) {
+  static_assert(M_TILES == 1 || M_TILES == 2, "moe m-tile fusion is 1 or 2");
+  constexpr int kStagesT = M_TILES == 1 ? kStages : 4;
+  constexpr int kUnitK = W8 ? 16 : 32;
+  using Dtype = marlin::MarlinScalarType<type_id>;
+  using scalar_t = typename Dtype::scalar_t;
+  using scalar_t2 = typename Dtype::scalar_t2;
+  using FragA = typename Dtype::FragA;
+  using FragB = typename Dtype::FragB;
+  using FragC = typename Dtype::FragC;
+
+  const int lane = threadIdx.x % 32;
+  const int warp = threadIdx.x / 32;
+  const int group_id = lane / 4;
+  const int tig = lane % 4;
+  const int ldsm_row = lane & 15;
+  const int ldsm_col = (lane >> 4) << 3;
+  const int ia_row = lane >> 1;
+  const int ia_c0 = (kUnitK / 2) * (lane & 1);
+
+  const int num_units = K / kUnitK;
+  const int nb_cnt = N / kBlockN;
+  const int num_kb = K / kBlockK;
+  const int ppg = group_size > 0 ? group_size / kUnitK : INT_MAX;
+  const scalar_t2 zero2 = Dtype::num2num2(Dtype::float2num(0.0f));
+  const uint64_t bpol = l2_evict_first_policy();
+  constexpr int64_t kBlockW = W8 ? kBlockInt32_8 : kBlockInt32;
+
+  const int num_blocks = *num_tokens_post_padded / (16 * M_TILES);
+  const int64_t total = int64_t(num_blocks) * nb_cnt * num_units;
+  const int total_warps = gridDim.x * kDecodeWarps;
+  const int64_t per = (total + total_warps - 1) / total_warps;
+  int64_t w = int64_t(blockIdx.x * kDecodeWarps + warp) * per;
+  const int64_t w_end = w + per < total ? w + per : total;
+
+  __shared__ int4 bstage[kDecodeWarps][kStagesT][2 * 32];
+  __shared__ scalar_t astage[kDecodeWarps][kStagesT][M_TILES][16][kUnitK];
+
+  FragC acc[M_TILES][4][2];
+  scalar_t2 s_reg[4][2];
+
+  while (w < w_end) {
+    const int64_t cg = w / num_units;
+    const int p_beg = int(w - cg * num_units);
+    const int col = int(cg / num_blocks);
+    const int blk = int(cg - int64_t(col) * num_blocks);
+    const int p_end =
+        int(int64_t(num_units) < p_beg + (w_end - w) ? int64_t(num_units)
+                                                     : p_beg + (w_end - w));
+    w += p_end - p_beg;
+
+    const int eid = expert_ids[blk];
+    if (eid < 0) continue;  // expert-parallel block owned by another rank
+
+    const int m_base = 16 * M_TILES * blk;
+    const int col_base = col * kBlockN;
+
+    // Output rows for this lane's C fragments, through the token sort.
+    int id0[M_TILES], id1[M_TILES];
+    bool r0ok[M_TILES], r1ok[M_TILES];
+#pragma unroll
+    for (int t = 0; t < M_TILES; t++) {
+      id0[t] = sorted_token_ids[m_base + 16 * t + group_id];
+      id1[t] = sorted_token_ids[m_base + 16 * t + group_id + 8];
+      r0ok[t] = id0[t] < total_tokens;
+      r1ok[t] = id1[t] < total_tokens;
+    }
+
+#pragma unroll
+    for (int t = 0; t < M_TILES; t++)
+#pragma unroll
+      for (int j = 0; j < 4; j++)
+#pragma unroll
+        for (int b = 0; b < 2; b++)
+#pragma unroll
+          for (int i = 0; i < 4; i++) acc[t][j][b][i] = 0.0f;
+
+    const scalar_t* S_e =
+        S + int64_t(eid) * (group_size > 0 ? K / group_size : 1) * N;
+    auto fetch_row = [&](int g) -> scalar_t2 {
+      return reinterpret_cast<const scalar_t2*>(S_e + int64_t(g) * N +
+                                                col_base)[lane];
+    };
+    auto expand_row = [&](scalar_t2 mine) {
+      const uint32_t sel = group_id & 1;
+#pragma unroll
+      for (int j = 0; j < 4; j++) {
+#pragma unroll
+        for (int b = 0; b < 2; b++) {
+          const scalar_t2 v =
+              __shfl_sync(0xffffffffu, mine, 8 * j + 4 * b + (group_id >> 1));
+          const uint32_t bits = reinterpret_cast<const uint32_t&>(v);
+          const uint16_t h16 = sel ? uint16_t(bits >> 16) : uint16_t(bits);
+          s_reg[j][b] = Dtype::num2num2(reinterpret_cast<const scalar_t&>(h16));
+        }
+      }
+    };
+    auto process_slice = [&](const FragA(&fa)[M_TILES], const marlin::I4& bqa,
+                             const marlin::I4& bqb) {
+#pragma unroll
+      for (int j = 0; j < 4; j++) {
+        FragB frag_b0, frag_b1;
+        if constexpr (W8) {
+          const marlin::I4& src = j < 2 ? bqa : bqb;
+          marlin::dequant<scalar_t2, aphrodite::kU8B128.id(), false>(
+              src.elems[(2 * j) & 3], reinterpret_cast<scalar_t2*>(&frag_b0));
+          marlin::dequant<scalar_t2, aphrodite::kU8B128.id(), false>(
+              src.elems[(2 * j + 1) & 3],
+              reinterpret_cast<scalar_t2*>(&frag_b1));
+        } else {
+          const int b_quant_0 = bqa.elems[j];
+          const int b_quant_1 = b_quant_0 >> 8;
+          marlin::dequant<scalar_t2, aphrodite::kU4B8.id(), false>(
+              b_quant_0, reinterpret_cast<scalar_t2*>(&frag_b0));
+          marlin::dequant<scalar_t2, aphrodite::kU4B8.id(), false>(
+              b_quant_1, reinterpret_cast<scalar_t2*>(&frag_b1));
+        }
+        frag_b0[0] = __hmul2(frag_b0[0], s_reg[j][0]);
+        frag_b0[1] = __hmul2(frag_b0[1], s_reg[j][0]);
+        frag_b1[0] = __hmul2(frag_b1[0], s_reg[j][1]);
+        frag_b1[1] = __hmul2(frag_b1[1], s_reg[j][1]);
+#pragma unroll
+        for (int t = 0; t < M_TILES; t++) {
+          marlin::mma<type_id, false>(fa[t], frag_b0, acc[t][j][0]);
+          marlin::mma<type_id, false>(fa[t], frag_b1, acc[t][j][1]);
+        }
+      }
+    };
+    auto process_pair = [&](int aslot, const int4* buf) {
+      FragA fa0[M_TILES], fa1[M_TILES];
+#pragma unroll
+      for (int t = 0; t < M_TILES; t++) {
+        ldsm4<type_id>(fa0[t], &astage[warp][aslot][t][ldsm_row][ldsm_col]);
+        if constexpr (!W8) {
+          ldsm4<type_id>(fa1[t],
+                         &astage[warp][aslot][t][ldsm_row][ldsm_col + 16]);
+        }
+      }
+      if constexpr (W8) {
+        const marlin::I4 bq0 =
+            *reinterpret_cast<const marlin::I4*>(&buf[2 * lane]);
+        const marlin::I4 bq1 =
+            *reinterpret_cast<const marlin::I4*>(&buf[2 * lane + 1]);
+        process_slice(fa0, bq0, bq1);
+      } else {
+        const marlin::I4 bq0 = *reinterpret_cast<const marlin::I4*>(&buf[lane]);
+        const marlin::I4 bq1 =
+            *reinterpret_cast<const marlin::I4*>(&buf[32 + lane]);
+        process_slice(fa0, bq0, bq0);
+        process_slice(fa1, bq1, bq1);
+      }
+    };
+
+    const int32_t* ipair_ptr =
+        B + (int64_t(eid) * nb_cnt + col) * num_kb * kBlockW +
+        p_beg * kPairInt32 + (W8 ? 8 : 4) * lane;
+    // Activation rows through the sort; padding rows stage row 0 disabled.
+    bool a_okt[M_TILES];
+    const scalar_t* ia_ptr[M_TILES];
+#pragma unroll
+    for (int t = 0; t < M_TILES; t++) {
+      const int a_id = sorted_token_ids[m_base + 16 * t + ia_row];
+      a_okt[t] = a_id < total_tokens;
+      ia_ptr[t] = A + (a_okt[t] ? int64_t(a_id / top_k) : 0) * K +
+                  kUnitK * p_beg + ia_c0;
+    }
+    int ipend = p_end - p_beg;
+
+    auto issue_pair = [&](int slot) {
+      if (ipend > 0) {
+        ipend--;
+        if constexpr (W8) {
+          cp_async4_evict_first(&bstage[warp][slot][2 * lane], ipair_ptr, bpol);
+          cp_async4_evict_first(&bstage[warp][slot][2 * lane + 1],
+                                ipair_ptr + 4, bpol);
+        } else {
+          cp_async4_evict_first(&bstage[warp][slot][lane], ipair_ptr, bpol);
+          cp_async4_evict_first(&bstage[warp][slot][32 + lane],
+                                ipair_ptr + kPairInt32 / 2, bpol);
+        }
+        ipair_ptr += kPairInt32;
+#pragma unroll
+        for (int t = 0; t < M_TILES; t++) {
+          if (a_okt[t]) {
+            marlin::cp_async4(&astage[warp][slot][t][ia_row][ia_c0], ia_ptr[t]);
+            if constexpr (!W8) {
+              marlin::cp_async4(&astage[warp][slot][t][ia_row][ia_c0 + 8],
+                                ia_ptr[t] + 8);
+            }
+          }
+          ia_ptr[t] += kUnitK;
+        }
+      }
+      marlin::cp_async_fence();
+    };
+
+    int g = 0;
+    int left = INT_MAX;
+    const int g_last = group_size > 0 && p_beg < p_end
+                           ? (kUnitK * (p_end - 1)) / group_size
+                           : 0;
+    scalar_t2 s_next = zero2;
+    if (p_beg < p_end) {
+      if (group_size > 0) {
+        g = p_beg / ppg;
+        left = ppg - p_beg % ppg;
+      }
+      expand_row(fetch_row(g));
+      if (g + 1 <= g_last) s_next = fetch_row(g + 1);
+    }
+
+#pragma unroll
+    for (int st = 0; st < kStagesT - 1; st++) issue_pair(st);
+
+    int slot = 0;
+    int islot = kStagesT - 1;
+    for (int p = p_beg; p < p_end; p++) {
+      issue_pair(islot);
+      if (++islot == kStagesT) islot = 0;
+      marlin::cp_async_wait<kStagesT - 2>();
+      if (left == 0) {
+        ++g;
+        expand_row(s_next);
+        if (g + 1 <= g_last) s_next = fetch_row(g + 1);
+        left = ppg;
+      }
+      process_pair(slot, bstage[warp][slot]);
+      left--;
+      if (++slot == kStagesT) slot = 0;
+    }
+
+    // Segment flush into the launcher-zeroed C, rows indirected through the
+    // token sort, with the router weight folded in when requested.
+#pragma unroll
+    for (int t = 0; t < M_TILES; t++) {
+      const float wt0 =
+          mul_topk_weights && r0ok[t] ? topk_weights[id0[t]] : 1.0f;
+      const float wt1 =
+          mul_topk_weights && r1ok[t] ? topk_weights[id1[t]] : 1.0f;
+#pragma unroll
+      for (int j = 0; j < 4; j++) {
+#pragma unroll
+        for (int b = 0; b < 2; b++) {
+          const int cc = col_base + 8 * (2 * j + b) + 2 * tig;
+          const float4 v = *reinterpret_cast<float4*>(&acc[t][j][b]);
+          if (r0ok[t])
+            red_add2(reinterpret_cast<scalar_t2*>(C + int64_t(id0[t]) * N + cc),
+                     Dtype::nums2num2(Dtype::float2num(v.x * wt0),
+                                      Dtype::float2num(v.y * wt0)));
+          if (r1ok[t])
+            red_add2(reinterpret_cast<scalar_t2*>(C + int64_t(id1[t]) * N + cc),
+                     Dtype::nums2num2(Dtype::float2num(v.z * wt1),
+                                      Dtype::float2num(v.w * wt1)));
+        }
+      }
+    }
+  }
+}
+
+template <aphrodite::ScalarTypeId type_id, bool W8>
+void launch_moe(const void* a, const int32_t* b, const void* s, void* c,
+                const int32_t* sorted_ids, const int32_t* expert_ids,
+                const int32_t* num_post_padded, const float* topk_w, int top_k,
+                bool mul_topk, int total_tokens, int max_blocks, int block_size,
+                int k, int n, int group_size, cudaStream_t stream) {
+  using scalar_t = typename marlin::MarlinScalarType<type_id>::scalar_t;
+  int sms = 0;
+  cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, 0);
+  constexpr int kUnitK = W8 ? 16 : 32;
+  launch_zero_c<scalar_t>(c, total_tokens, n, stream);
+  // Host-side upper bound on work keeps tiny batches from launching idle
+  // CTAs; the true total is device-side.
+  const int64_t max_total = int64_t(max_blocks) * (n / kBlockN) * (k / kUnitK);
+  const int64_t max_warps =
+      max_total / (2 * kStages) > 0 ? max_total / (2 * kStages) : 1;
+  const auto grid = [&](int ctas_per_sm) {
+    int ctas = ctas_per_sm * sms;
+    if (int64_t(ctas) * kDecodeWarps > max_warps) {
+      ctas = int((max_warps + kDecodeWarps - 1) / kDecodeWarps);
+    }
+    return ctas < 1 ? 1 : ctas;
+  };
+  if (block_size == 32) {
+    // 32-token blocks fuse two m16 tiles per weight fetch, amortizing the
+    // dequant for batched shapes.
+    static int ctas_per_sm2 = 0;
+    if (ctas_per_sm2 == 0) {
+      cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+          &ctas_per_sm2, swordfish_decode_moe_kernel<type_id, W8, 2>,
+          kDecodeThreads, 0);
+      if (ctas_per_sm2 <= 0) ctas_per_sm2 = 2;
+    }
+    swordfish_decode_moe_kernel<type_id, W8, 2>
+        <<<grid(ctas_per_sm2), kDecodeThreads, 0, stream>>>(
+            reinterpret_cast<const scalar_t*>(a), b,
+            reinterpret_cast<const scalar_t*>(s),
+            reinterpret_cast<scalar_t*>(c), sorted_ids, expert_ids,
+            num_post_padded, topk_w, top_k, mul_topk, total_tokens, k, n,
+            group_size);
+    return;
+  }
+  static int ctas_per_sm = 0;
+  if (ctas_per_sm == 0) {
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &ctas_per_sm, swordfish_decode_moe_kernel<type_id, W8>, kDecodeThreads,
+        0);
+    if (ctas_per_sm <= 0) ctas_per_sm = 2;
+  }
+  swordfish_decode_moe_kernel<type_id, W8>
+      <<<grid(ctas_per_sm), kDecodeThreads, 0, stream>>>(
+          reinterpret_cast<const scalar_t*>(a), b,
+          reinterpret_cast<const scalar_t*>(s), reinterpret_cast<scalar_t*>(c),
+          sorted_ids, expert_ids, num_post_padded, topk_w, top_k, mul_topk,
+          total_tokens, k, n, group_size);
+}
+
+}  // namespace
+
+torch::stable::Tensor swordfish_moe_mm(
+    torch::stable::Tensor& a, torch::stable::Tensor& b_packed,
+    torch::stable::Tensor& group_scales,
+    torch::stable::Tensor& sorted_token_ids, torch::stable::Tensor& expert_ids,
+    torch::stable::Tensor& num_tokens_post_padded,
+    std::optional<torch::stable::Tensor> const& topk_weights,
+    int64_t moe_block_size, int64_t top_k, bool mul_topk_weights,
+    int64_t num_bits, int64_t group_size, int64_t size_k, int64_t size_n) {
+  STD_TORCH_CHECK(moe_block_size == 16 || moe_block_size == 32,
+                  "swordfish_moe_mm supports block sizes 16 and 32");
+  STD_TORCH_CHECK(num_bits == 4 || num_bits == 8,
+                  "swordfish supports 4-bit and 8-bit weights");
+  const bool w8 = num_bits == 8;
+  STD_TORCH_CHECK(shape_ok(size_k, size_n), "swordfish ABI v1 requires K % ",
+                  kBlockK, " == 0 and N % ", kBlockN, " == 0; got K=", size_k,
+                  " N=", size_n);
+  STD_TORCH_CHECK(a.dim() == 2 && a.size(1) == size_k && a.stride(1) == 1 &&
+                      a.stride(0) == size_k,
+                  "a must be contiguous [M, K]");
+  const auto a_st = a.scalar_type();
+  STD_TORCH_CHECK(a_st == torch::headeronly::ScalarType::Half ||
+                      a_st == torch::headeronly::ScalarType::BFloat16,
+                  "a must be fp16 or bf16");
+  STD_TORCH_CHECK(group_scales.scalar_type() == a_st,
+                  "group_scales dtype must match a");
+
+  const int64_t nb = num_blocks_n(size_n);
+  const int64_t kb = num_blocks_k(size_k);
+  const int64_t words = w8 ? kBlockInt32_8 : kBlockInt32;
+  STD_TORCH_CHECK(
+      b_packed.scalar_type() == torch::headeronly::ScalarType::Int &&
+          b_packed.dim() == 4 && b_packed.size(1) == nb &&
+          b_packed.size(2) == kb && b_packed.size(3) == words,
+      "b_packed must be int32 [E, ", nb, ", ", kb, ", ", words, "]");
+  const int64_t num_experts = b_packed.size(0);
+
+  int64_t num_groups = 1;
+  if (group_size != -1) {
+    STD_TORCH_CHECK(group_size > 0 && size_k % group_size == 0 &&
+                        group_size % (2 * kMarlinTileK) == 0,
+                    "group_size must be -1 or a multiple of ", 2 * kMarlinTileK,
+                    " dividing K; got ", group_size);
+    num_groups = size_k / group_size;
+  }
+  STD_TORCH_CHECK(
+      group_scales.dim() == 3 && group_scales.size(0) == num_experts &&
+          group_scales.size(1) == num_groups && group_scales.size(2) == size_n,
+      "group_scales must be [", num_experts, ", ", num_groups, ", ", size_n,
+      "]");
+  STD_TORCH_CHECK(
+      sorted_token_ids.scalar_type() == torch::headeronly::ScalarType::Int &&
+          expert_ids.scalar_type() == torch::headeronly::ScalarType::Int &&
+          num_tokens_post_padded.scalar_type() ==
+              torch::headeronly::ScalarType::Int,
+      "alignment buffers must be int32");
+  if (mul_topk_weights) {
+    STD_TORCH_CHECK(
+        topk_weights.has_value() &&
+            topk_weights->scalar_type() == torch::headeronly::ScalarType::Float,
+        "topk_weights must be fp32 when mul_topk_weights");
+  }
+
+  const int64_t total_tokens = a.size(0) * top_k;
+
+  const int32_t device_index = a.get_device_index();
+  torch::stable::accelerator::DeviceGuard device_guard(device_index);
+  const cudaStream_t stream = get_current_cuda_stream(device_index);
+
+  torch::stable::Tensor c = torch::stable::empty({total_tokens, size_n}, a_st,
+                                                 std::nullopt, a.device());
+  if (total_tokens == 0) return c;
+
+  const auto* b_ptr =
+      reinterpret_cast<const int32_t*>(b_packed.const_data_ptr());
+  const auto* sid_ptr =
+      reinterpret_cast<const int32_t*>(sorted_token_ids.const_data_ptr());
+  const auto* eid_ptr =
+      reinterpret_cast<const int32_t*>(expert_ids.const_data_ptr());
+  const auto* npp_ptr =
+      reinterpret_cast<const int32_t*>(num_tokens_post_padded.const_data_ptr());
+  const float* tw_ptr =
+      mul_topk_weights
+          ? reinterpret_cast<const float*>(topk_weights->const_data_ptr())
+          : nullptr;
+  const int max_blocks =
+      int((sorted_token_ids.numel() + moe_block_size - 1) / moe_block_size);
+
+  if (a_st == torch::headeronly::ScalarType::Half) {
+    if (w8) {
+      launch_moe<aphrodite::kFloat16.id(), true>(
+          a.const_data_ptr(), b_ptr, group_scales.const_data_ptr(),
+          c.mutable_data_ptr(), sid_ptr, eid_ptr, npp_ptr, tw_ptr, int(top_k),
+          mul_topk_weights, int(total_tokens), max_blocks, int(moe_block_size),
+          int(size_k), int(size_n), int(group_size), stream);
+    } else {
+      launch_moe<aphrodite::kFloat16.id(), false>(
+          a.const_data_ptr(), b_ptr, group_scales.const_data_ptr(),
+          c.mutable_data_ptr(), sid_ptr, eid_ptr, npp_ptr, tw_ptr, int(top_k),
+          mul_topk_weights, int(total_tokens), max_blocks, int(moe_block_size),
+          int(size_k), int(size_n), int(group_size), stream);
+    }
+  } else {
+    if (w8) {
+      launch_moe<aphrodite::kBFloat16.id(), true>(
+          a.const_data_ptr(), b_ptr, group_scales.const_data_ptr(),
+          c.mutable_data_ptr(), sid_ptr, eid_ptr, npp_ptr, tw_ptr, int(top_k),
+          mul_topk_weights, int(total_tokens), max_blocks, int(moe_block_size),
+          int(size_k), int(size_n), int(group_size), stream);
+    } else {
+      launch_moe<aphrodite::kBFloat16.id(), false>(
+          a.const_data_ptr(), b_ptr, group_scales.const_data_ptr(),
+          c.mutable_data_ptr(), sid_ptr, eid_ptr, npp_ptr, tw_ptr, int(top_k),
+          mul_topk_weights, int(total_tokens), max_blocks, int(moe_block_size),
+          int(size_k), int(size_n), int(group_size), stream);
+    }
+  }
+
+  return c;
+}
+
+}  // namespace swordfish
+
+STABLE_TORCH_LIBRARY_IMPL(gptqmodel_swordfish, CUDA, m) {
+  m.impl("swordfish_moe_mm", TORCH_BOX(&swordfish::swordfish_moe_mm));
+}

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_prefill.cu
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_prefill.cu
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+// w4a16/w8a16 prefill GEMM over the Swordfish ABI v1 packed weight, using
+// the forked sm100 tcgen05 mixed-input collective. This TU instantiates the
+// bf16-activation configurations and hosts the op entry; the fp16 set
+// compiles in swordfish_prefill_f16.cu.
+
+#include "swordfish_prefill_impl.cuh"
+
+namespace swordfish {
+
+#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+// Defined in swordfish_prefill_f16.cu.
+namespace prefill {
+extern template void run_prefill_all<cutlass::half_t>(
+    torch::stable::Tensor&, torch::stable::Tensor&, torch::stable::Tensor&,
+    const void*, bool, bool, int, torch::stable::Tensor&, int, int, int,
+    cudaStream_t);
+}
+#endif
+
+torch::stable::Tensor swordfish_prefill_mm(
+    torch::stable::Tensor& a, torch::stable::Tensor& b_packed,
+    torch::stable::Tensor& group_scales,
+    std::optional<torch::stable::Tensor> const& group_zps, int64_t num_bits,
+    int64_t group_size, int64_t size_k, int64_t size_n) {
+#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+  STD_TORCH_CHECK(
+      shape_ok(size_k, size_n) && size_k % 128 == 0 && size_n % 128 == 0,
+      "swordfish prefill v1 requires K % 128 == 0 and "
+      "N % 128 == 0; got K=",
+      size_k, " N=", size_n);
+  STD_TORCH_CHECK(a.dim() == 2 && a.size(1) == size_k,
+                  "a must be [M, K] with K=", size_k);
+  STD_TORCH_CHECK(a.stride(1) == 1 && a.stride(0) == size_k,
+                  "a must be contiguous");
+  const auto a_st = a.scalar_type();
+  STD_TORCH_CHECK(a_st == torch::headeronly::ScalarType::BFloat16 ||
+                      a_st == torch::headeronly::ScalarType::Half,
+                  "swordfish prefill requires fp16 or bf16 activations");
+  STD_TORCH_CHECK(group_scales.scalar_type() == a_st,
+                  "group_scales dtype must match a");
+  STD_TORCH_CHECK(group_size == 32 || group_size == 64 || group_size == 128,
+                  "swordfish prefill supports group sizes 32, 64 and 128; "
+                  "got ",
+                  group_size);
+
+  STD_TORCH_CHECK(num_bits == 4 || num_bits == 8,
+                  "swordfish supports 4-bit and 8-bit weights");
+  const bool w8 = num_bits == 8;
+  const int64_t nb = num_blocks_n(size_n);
+  const int64_t kb = num_blocks_k(size_k);
+  const int64_t words = w8 ? kBlockInt32_8 : kBlockInt32;
+  STD_TORCH_CHECK(
+      b_packed.scalar_type() == torch::headeronly::ScalarType::Int &&
+          b_packed.dim() == 3 && b_packed.size(0) == nb &&
+          b_packed.size(1) == kb && b_packed.size(2) == words,
+      "b_packed must be int32 [", nb, ", ", kb, ", ", words, "]");
+
+  const int64_t num_groups = size_k / group_size;
+  STD_TORCH_CHECK(group_scales.dim() == 2 &&
+                      group_scales.size(0) == num_groups &&
+                      group_scales.size(1) == size_n,
+                  "group_scales must be [", num_groups, ", ", size_n, "]");
+  const bool has_zp = group_zps.has_value();
+  if (has_zp) {
+    STD_TORCH_CHECK(
+        group_zps->scalar_type() == a_st && group_zps->dim() == 2 &&
+            group_zps->size(0) == num_groups && group_zps->size(1) == size_n,
+        "group_zps must be [", num_groups, ", ", size_n, "] with a's dtype");
+  }
+
+  const int64_t size_m = a.size(0);
+
+  const int32_t device_index = a.get_device_index();
+  torch::stable::accelerator::DeviceGuard device_guard(device_index);
+  const cudaStream_t stream = get_current_cuda_stream(device_index);
+
+  torch::stable::Tensor c = torch::stable::empty(
+      {size_m, size_n}, a.scalar_type(), std::nullopt, a.device());
+  if (size_m == 0) return c;
+
+  const int M = int(size_m), N = int(size_n), K = int(size_k);
+
+  STD_TORCH_CHECK(!(has_zp && w8), "zero points are a 4-bit feature");
+  STD_TORCH_CHECK(!(w8 && group_size != 128),
+                  "8-bit prefill supports group_size 128 only");
+  const void* zp_ptr = has_zp ? group_zps->const_data_ptr() : nullptr;
+  if (a_st == torch::headeronly::ScalarType::Half) {
+    prefill::run_prefill_all<cutlass::half_t>(a, b_packed, group_scales, zp_ptr,
+                                              has_zp, w8, int(group_size), c, M,
+                                              N, K, stream);
+  } else {
+    prefill::run_prefill_all<cutlass::bfloat16_t>(
+        a, b_packed, group_scales, zp_ptr, has_zp, w8, int(group_size), c, M, N,
+        K, stream);
+  }
+  return c;
+#else
+  STD_TORCH_CHECK(false,
+                  "swordfish_prefill_mm requires a CUDA >= 12.8 build with "
+                  "sm100-family support");
+#endif
+}
+
+}  // namespace swordfish
+
+STABLE_TORCH_LIBRARY_IMPL(gptqmodel_swordfish, CUDA, m) {
+  m.impl("swordfish_prefill_mm", TORCH_BOX(&swordfish::swordfish_prefill_mm));
+}

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_prefill_f16.cu
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_prefill_f16.cu
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+// fp16-activation instantiations of the Swordfish prefill configurations.
+
+#include "swordfish_prefill_impl.cuh"
+
+namespace swordfish {
+#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+namespace prefill {
+template void run_prefill_all<cutlass::half_t>(torch::stable::Tensor&,
+                                               torch::stable::Tensor&,
+                                               torch::stable::Tensor&,
+                                               const void*, bool, bool, int,
+                                               torch::stable::Tensor&, int, int,
+                                               int, cudaStream_t);
+}  // namespace prefill
+#endif
+}  // namespace swordfish

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_prefill_impl.cuh
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_prefill_impl.cuh
@@ -1,0 +1,322 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+// Prefill GEMM configuration and launch for the Swordfish packed ABI, shared
+// by the per-dtype instantiation TUs (swordfish_prefill.cu for bf16 and
+// swordfish_prefill_f16.cu for fp16).
+#pragma once
+
+#include <algorithm>
+#include <optional>
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include "libtorch_stable/torch_utils.h"
+#include "swordfish_types.cuh"
+
+#include "cutlass/cutlass.h"
+#include "cute/tensor.hpp"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/epilogue/dispatch_policy.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/util/packed_stride.hpp"
+
+#include "swordfish_prefill_mainloop.cuh"
+#include "swordfish_prefill_kernel.cuh"
+
+namespace swordfish {
+
+#if defined(CUTLASS_ARCH_MMA_SM100_SUPPORTED)
+
+namespace prefill {
+
+using namespace cute;
+
+using ElementAccumulator = float;
+using ArchTag = cutlass::arch::Sm100;
+using OperatorClass = cutlass::arch::OpClassTensorOp;
+
+using ClusterShape = Shape<_2, _1, _1>;
+using EpilogueSchedule = cutlass::epilogue::TmaWarpSpecialized2Sm;
+using LayoutC = cutlass::layout::RowMajor;
+constexpr int AlignmentC = 8;  // 128b / 16b elems, fp16 and bf16 alike
+
+using StrideA =
+    cutlass::gemm::TagToStrideA_t<cutlass::layout::RowMajor>;  // packed slot
+                                                               // (unused)
+using StrideB =
+    cutlass::gemm::TagToStrideB_t<typename cutlass::layout::LayoutTranspose<
+        cutlass::layout::RowMajor>::type>;  // activations
+
+static constexpr cute::UMMA::Major UmmaMajorA = cute::UMMA::Major::K;
+static constexpr cute::UMMA::Major UmmaMajorB = cute::UMMA::Major::K;
+
+// 2-SM (cta_group::2) MMA config, parameterized on the instruction N width.
+// Tile-M (the weight N dimension) spans the two CTAs of an SM pair, 128
+// columns each. N=256 wins compute-bound shapes (per-instruction issue
+// overhead caps a 256x128 UMMA at about two thirds of the 256x256 rate);
+// N=128 wins K-heavy shapes, where the wide tile starves the K pipeline.
+template <int kTileN, bool kHasZp = false, int kWBits = 4,
+          class TAct = cutlass::bfloat16_t, int kGran = 128>
+struct PrefillCfg {
+  using MmaType = TAct;
+  using MmaTileShape = Shape<_256, Int<kTileN>, _128>;
+  // A third element in the A tuple enables the collective's zero-point row.
+  using ElementPairA =
+      cute::conditional_t<kHasZp, cute::tuple<uint8_t, MmaType, MmaType>,
+                          cute::tuple<uint8_t, MmaType>>;
+  using ScaleConfig = cutlass::detail::Sm100MixedInputBlockwiseScaleConfig<
+      /*GranN=*/1, kGran>;
+  using LayoutScale = decltype(ScaleConfig::deduce_layout_scale());
+  using StridePairA = decltype(cute::make_tuple(StrideA{}, LayoutScale{}));
+
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          ArchTag, OperatorClass, MmaTileShape, ClusterShape,
+          cutlass::epilogue::collective::EpilogueTileAuto, ElementAccumulator,
+          ElementAccumulator, MmaType,
+          typename cutlass::layout::LayoutTranspose<LayoutC>::type, AlignmentC,
+          MmaType, typename cutlass::layout::LayoutTranspose<LayoutC>::type,
+          AlignmentC, EpilogueSchedule>::CollectiveOp;
+
+  // The CUTLASS convenience builder has no branch for 2-SM atoms with
+  // smem-sourced A, so the SS atom is constructed directly. M is the full
+  // cluster tile-M spanning both CTAs.
+  using TiledMma = decltype(cute::make_tiled_mma(
+      cute::SM100_MMA_F16BF16_2x1SM_SS<MmaType, MmaType, ElementAccumulator,
+                                       256, kTileN, UmmaMajorA, UmmaMajorB>{}));
+
+  // partition_shape_A/B take CTA-local shapes for a 2-SM atom.
+  using CtaShape = decltype(shape_div(MmaTileShape{}, ClusterShape{}));
+  using MmaShapeA_MK = decltype(partition_shape_A(
+      TiledMma{},
+      make_shape(cute::size<0>(CtaShape{}), cute::size<2>(CtaShape{}))));
+  using MmaShapeB_NK = decltype(partition_shape_B(
+      TiledMma{},
+      make_shape(cute::size<1>(CtaShape{}), cute::size<2>(CtaShape{}))));
+  using BlockTileA_M = decltype(cute::size<0, 0>(MmaShapeA_MK{}) *
+                                cute::size<1>(MmaShapeA_MK{}));
+  using BlockTileA_K = decltype(cute::size<0, 1>(MmaShapeA_MK{}) *
+                                cute::size<2>(MmaShapeA_MK{}));
+  using BlockTileB_N = decltype(cute::size<0, 0>(MmaShapeB_NK{}) *
+                                cute::size<1>(MmaShapeB_NK{}));
+  using BlockTileB_K = decltype(cute::size<0, 1>(MmaShapeB_NK{}) *
+                                cute::size<2>(MmaShapeB_NK{}));
+
+  using SmemLayoutAtomACompute =
+      decltype(cutlass::gemm::collective::detail::sm100_smem_selector<
+               UmmaMajorA, MmaType, BlockTileA_M, BlockTileA_K>());
+  using SmemLayoutAtomPairA =
+      cutlass::gemm::collective::detail::CollectiveMmaEmulatedLayoutAtomType<
+          SmemLayoutAtomACompute, SmemLayoutAtomACompute>;
+  using CopyAtomPairA =
+      cutlass::gemm::collective::detail::CollectiveMmaEmulatedCopyType<
+          Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, uint8_t>,
+          Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, MmaType>>;
+
+  using SmemLayoutAtomB =
+      decltype(cutlass::gemm::collective::detail::sm100_smem_selector<
+               UmmaMajorB, MmaType, BlockTileB_N, BlockTileB_K>());
+  using SmemLayoutAtomPairB =
+      cutlass::gemm::collective::detail::CollectiveMmaEmulatedLayoutAtomType<
+          SmemLayoutAtomB, SmemLayoutAtomB>;
+  using CopyAtomPairB =
+      cutlass::gemm::collective::detail::CollectiveMmaEmulatedCopyType<
+          Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, MmaType>,
+          Copy_Atom<AutoVectorizingCopyWithAssumedAlignment<128>, MmaType>>;
+
+  // Pipeline stage counts, derived from the smem budget.
+  static constexpr int kSmemCapacity =
+      cutlass::gemm::collective::detail::sm100_smem_capacity_bytes;
+  static constexpr int kKernelCarveout = 2048;
+  static constexpr int kEpilogueBytes =
+      int(sizeof(typename CollectiveEpilogue::SharedStorage));
+  // TMEM is 512 columns and an accumulator stage needs kTileN of them.
+  static constexpr int kAccumStages = 512 / kTileN;
+  // B stage is the CTA's half of the N-split activation tile, kTileN/2 rows.
+  static constexpr int kInputStageBytes = (kWBits == 8 ? 16384 : 8192) +
+                                          kTileN * 128 + 256 + 64 +
+                                          (kHasZp ? 256 : 0);
+  static constexpr int kComputeStageBytes = 32768 + 32;
+  static constexpr int kT2MStages = 2;
+  static constexpr int kAvail = kSmemCapacity - kKernelCarveout -
+                                kEpilogueBytes - kAccumStages * 32 -
+                                kT2MStages * kComputeStageBytes;
+  static constexpr int kL2TStages =
+      kAvail / kInputStageBytes < 4 ? kAvail / kInputStageBytes : 4;
+  static_assert(kL2TStages >= 2, "not enough SMEM for two input stages");
+
+  using CollectiveMainloop =
+      cutlass::gemm::collective::SwordfishMainloopSm100MixedInput<
+          kL2TStages, kT2MStages, /*SchedulerStages=*/3, kAccumStages,
+          ClusterShape, MmaTileShape, ElementPairA, StridePairA, MmaType,
+          StrideB, TiledMma, cute::SM90_TMA_LOAD, SmemLayoutAtomPairA,
+          CopyAtomPairA, cute::identity,
+          // Activations must use the cta_group::2 TMA. The 2x1SM atom N-splits
+          // B across the CTA pair and the leader's MMA reads the peer's half,
+          // so the copy must deliver both halves with one arrival on the
+          // leader's barrier. A per-CTA TMA arrives at local barriers and
+          // races.
+          cute::SM100_TMA_2SM_LOAD, SmemLayoutAtomPairB, CopyAtomPairB,
+          cute::identity, kWBits>;
+
+  // Forked kernel layer whose warp layout derives from the collective's
+  // NumTransformationThreads.
+  using GemmKernel = cutlass::gemm::kernel::SwordfishPrefillKernel<
+      Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue, void>;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+
+template <class Cfg>
+void run(torch::stable::Tensor& a, torch::stable::Tensor& b_packed,
+         torch::stable::Tensor& group_scales, const void* zp_ptr,
+         torch::stable::Tensor& c, int M, int N, int K, cudaStream_t stream) {
+  using Gemm = typename Cfg::Gemm;
+  using GemmKernel = typename Cfg::GemmKernel;
+  using MmaType = typename Cfg::MmaType;
+  using LayoutScale = typename Cfg::LayoutScale;
+  using ScaleConfig = typename Cfg::ScaleConfig;
+
+  // L2-aware M chunking. The activation stream loses all L2 reuse once a
+  // chunk outgrows Thor's 32 MB L2, a two-thirds throughput loss, so the
+  // per-launch activation footprint is capped near 12 MB.
+  constexpr int64_t kAChunkBytes = int64_t(12) << 20;
+  int m_chunk = int(kAChunkBytes / (int64_t(K) * 2));
+  m_chunk = std::max(256, (m_chunk / 128) * 128);
+
+  LayoutScale layout_S =
+      ScaleConfig::tile_atom_to_shape_scale(cute::make_shape(N, K, 1));
+  auto* c_base = reinterpret_cast<MmaType*>(c.mutable_data_ptr());
+  const auto* a_base = reinterpret_cast<MmaType const*>(a.const_data_ptr());
+
+  torch::stable::Tensor workspace;
+  size_t ws_alloc = 0;
+
+  for (int m0 = 0; m0 < M; m0 += m_chunk) {
+    const int mc = std::min(m_chunk, M - m0);
+
+    auto stride_act =
+        cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(mc, K, 1));
+    auto stride_c = cutlass::make_cute_packed_stride(
+        typename GemmKernel::StrideC{}, cute::make_shape(N, mc, 1));
+    auto stride_d = cutlass::make_cute_packed_stride(
+        typename GemmKernel::StrideD{}, cute::make_shape(N, mc, 1));
+
+    MmaType* c_ptr = c_base + int64_t(m0) * N;
+
+    // Swapped problem shape (N, mc, K). The packed weight rides the A slot.
+    typename Gemm::Arguments arguments{
+        cutlass::gemm::GemmUniversalMode::kGemm,
+        {N, mc, K, 1},
+        {reinterpret_cast<uint8_t const*>(b_packed.const_data_ptr()), StrideA{},
+         a_base + int64_t(m0) * K, stride_act,
+         reinterpret_cast<MmaType const*>(group_scales.const_data_ptr()),
+         layout_S, reinterpret_cast<MmaType const*>(zp_ptr)},
+        {{1.0f, 0.0f}, c_ptr, stride_c, c_ptr, stride_d}};
+
+    Gemm gemm;
+    STD_TORCH_CHECK(gemm.can_implement(arguments) == cutlass::Status::kSuccess,
+                    "swordfish_prefill_mm: unsupported problem");
+
+    const size_t ws_bytes = Gemm::get_workspace_size(arguments);
+    if (ws_bytes > ws_alloc) {
+      workspace = torch::stable::empty({int64_t(ws_bytes)},
+                                       torch::headeronly::ScalarType::Byte,
+                                       std::nullopt, a.device());
+      ws_alloc = ws_bytes;
+    }
+
+    STD_TORCH_CHECK(
+        gemm.initialize(arguments,
+                        ws_alloc ? workspace.mutable_data_ptr() : nullptr,
+                        stream) == cutlass::Status::kSuccess,
+        "swordfish_prefill_mm: initialize failed");
+    STD_TORCH_CHECK(gemm.run(stream) == cutlass::Status::kSuccess,
+                    "swordfish_prefill_mm: launch failed");
+  }
+}
+
+// All prefill configurations for one activation dtype, one TU each so the
+// fp16 and bf16 sets compile in parallel.
+template <class TAct>
+void run_prefill_all(torch::stable::Tensor& a, torch::stable::Tensor& b_packed,
+                     torch::stable::Tensor& group_scales, const void* zp_ptr,
+                     bool has_zp, bool w8, int gran, torch::stable::Tensor& c,
+                     int M, int N, int K, cudaStream_t stream) {
+  // Tile-N dispatch. The 256-wide tile wins compute-bound shapes; K-heavy
+  // shapes starve its K pipeline and prefer 256x128 (measured on both
+  // Thor and B200 at K=14336). The 256-wide tile's input stages do not fit
+  // SMEM at 8 bits, and the doubled weight stream pressures the K pipeline
+  // the way K-heavy shapes do, so 8-bit always runs 256x128.
+  const bool narrow = w8 || (K >= 2 * N && K >= 8192);
+  if (w8) {
+    run<PrefillCfg<128, false, 8, TAct>>(a, b_packed, group_scales, nullptr, c,
+                                         M, N, K, stream);
+  } else if (gran == 32) {
+    if (has_zp) {
+      if (narrow) {
+        run<PrefillCfg<128, true, 4, TAct, 32>>(a, b_packed, group_scales,
+                                                zp_ptr, c, M, N, K, stream);
+      } else {
+        run<PrefillCfg<256, true, 4, TAct, 32>>(a, b_packed, group_scales,
+                                                zp_ptr, c, M, N, K, stream);
+      }
+    } else if (narrow) {
+      run<PrefillCfg<128, false, 4, TAct, 32>>(a, b_packed, group_scales,
+                                               nullptr, c, M, N, K, stream);
+    } else {
+      run<PrefillCfg<256, false, 4, TAct, 32>>(a, b_packed, group_scales,
+                                               nullptr, c, M, N, K, stream);
+    }
+  } else if (gran == 64) {
+    if (has_zp) {
+      if (narrow) {
+        run<PrefillCfg<128, true, 4, TAct, 64>>(a, b_packed, group_scales,
+                                                zp_ptr, c, M, N, K, stream);
+      } else {
+        run<PrefillCfg<256, true, 4, TAct, 64>>(a, b_packed, group_scales,
+                                                zp_ptr, c, M, N, K, stream);
+      }
+    } else if (narrow) {
+      run<PrefillCfg<128, false, 4, TAct, 64>>(a, b_packed, group_scales,
+                                               nullptr, c, M, N, K, stream);
+    } else {
+      run<PrefillCfg<256, false, 4, TAct, 64>>(a, b_packed, group_scales,
+                                               nullptr, c, M, N, K, stream);
+    }
+  } else {
+    if (has_zp) {
+      if (narrow) {
+        run<PrefillCfg<128, true, 4, TAct>>(a, b_packed, group_scales, zp_ptr,
+                                            c, M, N, K, stream);
+      } else {
+        run<PrefillCfg<256, true, 4, TAct>>(a, b_packed, group_scales, zp_ptr,
+                                            c, M, N, K, stream);
+      }
+    } else if (narrow) {
+      run<PrefillCfg<128, false, 4, TAct>>(a, b_packed, group_scales, nullptr,
+                                           c, M, N, K, stream);
+    } else {
+      run<PrefillCfg<256, false, 4, TAct>>(a, b_packed, group_scales, nullptr,
+                                           c, M, N, K, stream);
+    }
+  }
+}
+
+}  // namespace prefill
+
+#endif  // CUTLASS_ARCH_MMA_SM100_SUPPORTED
+
+}  // namespace swordfish

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_prefill_kernel.cuh
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_prefill_kernel.cuh
@@ -1,0 +1,1177 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+/***************************************************************************************************
+ * Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES. All rights
+ * reserved. SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#pragma once
+
+#include "cutlass/cutlass.h"
+#include "cutlass/kernel_hardware_info.hpp"
+#include "cutlass/detail/cluster.hpp"
+#include "cutlass/arch/grid_dependency_control.h"
+#include "cutlass/fast_math.h"
+#include "cute/arch/cluster_sm90.hpp"
+#include "cutlass/arch/arch.h"
+#include "cutlass/arch/reg_reconfig.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/gemm/kernel/sm100_tile_scheduler.hpp"
+#include "cutlass/pipeline/pipeline.hpp"
+
+#include "cute/tensor.hpp"
+#include "cute/atom/mma_atom.hpp"
+///////////////////////////////////////////////////////////////////////////////
+// SWORDFISH FORK of CUTLASS 4.4.2's
+//   include/cutlass/gemm/kernel/sm100_gemm_tma_warpspecialized_mixed_input_transform.hpp
+// (BSD-3-Clause, Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES).
+// One change: the warp-category boundaries derive from the collective's
+// NumTransformationThreads instead of hardcoding 4 transform warps, so the
+// Transform (dequant producer) stage can be widened for tuning
+// experiments.
+// Instantiated DIRECTLY (standalone class, no GemmUniversal dispatch).
+///////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass::gemm::kernel {
+
+///////////////////////////////////////////////////////////////////////////////
+
+template <class ProblemShape_, class CollectiveMainloop_,
+          class CollectiveEpilogue_, class TileScheduler_>
+class SwordfishPrefillKernel {
+ public:
+  //
+  // Type Aliases
+  //
+  using ProblemShape = ProblemShape_;
+  static_assert(rank(ProblemShape{}) == 3 or rank(ProblemShape{}) == 4,
+                "ProblemShape{} should be <M,N,K> or <M,N,K,L>");
+  static constexpr bool IsGdcEnabled = cutlass::arch::IsGdcGloballyEnabled;
+
+  // Mainloop derived types
+  using CollectiveMainloop = CollectiveMainloop_;
+  using TileShape = typename CollectiveMainloop::TileShape;
+
+  // Get Blk and Scheduling tile shapes
+  using CtaShape_MNK = typename CollectiveMainloop::CtaShape_MNK;
+  using AtomThrShapeMNK = typename CollectiveMainloop::AtomThrShapeMNK;
+
+  using TiledMma = typename CollectiveMainloop::TiledMma;
+  using ArchTag = typename CollectiveMainloop::ArchTag;
+  using ElementA = typename CollectiveMainloop::ElementA;
+  using StrideA = typename CollectiveMainloop::StrideA;
+  using ElementB = typename CollectiveMainloop::ElementB;
+  using StrideB = typename CollectiveMainloop::StrideB;
+  using DispatchPolicy = typename CollectiveMainloop::DispatchPolicy;
+  using ElementAccumulator = typename CollectiveMainloop::ElementAccumulator;
+  using ClusterShape = typename DispatchPolicy::ClusterShape;
+  using MainloopArguments = typename CollectiveMainloop::Arguments;
+  using MainloopParams = typename CollectiveMainloop::Params;
+  static constexpr bool IsComplex =
+      DispatchPolicy::InputTransformType ==
+      cutlass::gemm::detail::KernelInputTransformType::InterleavedComplexTF32;
+  static_assert(ArchTag::kMinComputeCapability >= 100);
+
+  // Epilogue derived types
+  using CollectiveEpilogue = CollectiveEpilogue_;
+  using ElementC = typename CollectiveEpilogue::ElementC;
+  using StrideC = typename CollectiveEpilogue::StrideC;
+  using ElementD = typename CollectiveEpilogue::ElementD;
+  using StrideD = typename CollectiveEpilogue::StrideD;
+  using EpilogueArguments = typename CollectiveEpilogue::Arguments;
+  using EpilogueParams = typename CollectiveEpilogue::Params;
+
+  // CLC pipeline depth
+  // determines how many waves (stages-1) a warp can race ahead
+  static constexpr uint32_t SchedulerPipelineStageCount =
+      DispatchPolicy::Schedule::SchedulerPipelineStageCount;
+  // TileID scheduler
+  using TileSchedulerTag = TileScheduler_;
+  using TileScheduler = typename detail::TileSchedulerSelector<
+      TileScheduler_, ArchTag, CtaShape_MNK, ClusterShape,
+      SchedulerPipelineStageCount>::Scheduler;
+  using TileSchedulerArguments = typename TileScheduler::Arguments;
+  using TileSchedulerParams = typename TileScheduler::Params;
+
+  static constexpr bool IsDynamicCluster = not cute::is_static_v<ClusterShape>;
+
+  // Warp specialization thread count per threadblock
+  static constexpr uint32_t NumSchedThreads = NumThreadsPerWarp;  // 1 warp
+  static constexpr uint32_t NumMMAThreads = NumThreadsPerWarp;    // 1 warp
+  static constexpr uint32_t NumMainloopLoadThreads =
+      NumThreadsPerWarp;  // 1 warp
+  static constexpr uint32_t NumEpilogueLoadThreads =
+      NumThreadsPerWarp;  // 1 warp
+  static constexpr uint32_t NumEpilogueThreads =
+      CollectiveMainloop::NumAccumThreads;  // 4 warps
+  static constexpr uint32_t NumEpilogueWarps =
+      NumEpilogueThreads / NumThreadsPerWarp;
+  static constexpr uint32_t NumTransformationThreads =
+      CollectiveMainloop::NumTransformationThreads;  // 4 warps
+  static constexpr uint32_t NumMainloopLoadBThreads =
+      NumThreadsPerWarp;  // 1 warp
+
+  static constexpr uint32_t MaxThreadsPerBlock =
+      NumSchedThreads + NumMainloopLoadThreads + NumMMAThreads +
+      NumEpilogueLoadThreads + NumEpilogueThreads + NumTransformationThreads +
+      NumMainloopLoadBThreads;
+  static constexpr uint32_t MinBlocksPerMultiprocessor = 1;
+
+  static constexpr uint32_t AccumulatorPipelineStageCount =
+      DispatchPolicy::Schedule::AccumulatorPipelineStageCount;
+  static constexpr cutlass::gemm::detail::KernelInputTransformType
+      InputTransformType = DispatchPolicy::InputTransformType;
+  static constexpr uint32_t NumFixupBarriers = 1;
+  static constexpr uint32_t CLCResponseSize =
+      sizeof(typename TileScheduler::CLCResponse);
+
+  static constexpr bool IsSchedDynamicPersistent =
+      TileScheduler::IsDynamicPersistent;
+
+  // Pipeline and pipeline state types
+  using Load2TransformPipeline =
+      typename CollectiveMainloop::Load2TransformPipeline;
+  using Load2TransformPipelineState =
+      typename CollectiveMainloop::Load2TransformPipelineState;
+
+  using Load2MmaPipeline = typename CollectiveMainloop::Load2MmaPipeline;
+  using Load2MmaPipelineState =
+      typename CollectiveMainloop::Load2MmaPipelineState;
+
+  using Transform2MmaPipeline =
+      typename CollectiveMainloop::Transform2MmaPipeline;
+  using Transform2MmaPipelineState =
+      typename CollectiveMainloop::Transform2MmaPipelineState;
+
+  using Mma2AccumPipeline = typename CollectiveMainloop::Mma2AccumPipeline;
+  using Mma2AccumPipelineState =
+      typename CollectiveMainloop::Mma2AccumPipelineState;
+
+  using EpiLoadPipeline = typename CollectiveEpilogue::LoadPipeline;
+  using EpiLoadPipelineState = typename CollectiveEpilogue::LoadPipelineState;
+
+  using EpiStorePipeline = typename CollectiveEpilogue::StorePipeline;
+  using EpiStorePipelineState = typename CollectiveEpilogue::StorePipelineState;
+
+  using LoadOrderBarrier = cutlass::OrderedSequenceBarrier<1, 2>;
+
+  using CLCPipeline =
+      cutlass::PipelineCLCFetchAsync<SchedulerPipelineStageCount, ClusterShape>;
+  using CLCPipelineState = cutlass::PipelineState<SchedulerPipelineStageCount>;
+
+  using CLCThrottlePipeline =
+      cutlass::PipelineAsync<SchedulerPipelineStageCount>;
+  using CLCThrottlePipelineState = typename CLCThrottlePipeline::PipelineState;
+
+  using TmemAllocator =
+      cute::conditional_t<cute::size(cute::shape<0>(
+                              typename TiledMma::ThrLayoutVMNK{})) == 1,
+                          cute::TMEM::Allocator1Sm, cute::TMEM::Allocator2Sm>;
+
+  // Kernel level shared memory storage
+  struct SharedStorage {
+    struct PipelineStorage : cute::aligned_struct<16, _1> {
+      using MainloopPipelineStorage =
+          typename CollectiveMainloop::PipelineStorage;
+      using EpiLoadPipelineStorage =
+          typename CollectiveEpilogue::PipelineStorage;
+      using LoadOrderBarrierStorage = typename LoadOrderBarrier::SharedStorage;
+      using CLCPipelineStorage = typename CLCPipeline::SharedStorage;
+      using CLCThrottlePipelineStorage =
+          typename CLCThrottlePipeline::SharedStorage;
+
+      alignas(16) MainloopPipelineStorage mainloop;
+      alignas(16) EpiLoadPipelineStorage epi_load;
+      alignas(16) LoadOrderBarrierStorage load_order;
+      alignas(16) CLCPipelineStorage clc;
+      alignas(16) CLCThrottlePipelineStorage clc_throttle;
+      alignas(16) arch::ClusterBarrier tmem_dealloc;
+      alignas(16) arch::ClusterBarrier epilogue_throttle;
+    } pipelines;
+
+    alignas(16) typename TileScheduler::CLCResponse
+        clc_response[SchedulerPipelineStageCount];
+    uint32_t tmem_base_ptr;
+
+    struct TensorStorage : cute::aligned_struct<128, _1> {
+      using EpilogueTensorStorage = typename CollectiveEpilogue::TensorStorage;
+      using MainloopTensorStorage = typename CollectiveMainloop::TensorStorage;
+
+      EpilogueTensorStorage epilogue;
+      MainloopTensorStorage mainloop;
+    } tensors;
+  };
+
+  static constexpr int SharedStorageSize = sizeof(SharedStorage);
+
+  // Device side arguments
+  struct Arguments {
+    GemmUniversalMode mode{};
+    ProblemShape problem_shape{};
+    MainloopArguments mainloop{};
+    EpilogueArguments epilogue{};
+    KernelHardwareInfo hw_info{};
+    TileSchedulerArguments scheduler{};
+  };
+
+  // Kernel entry point API
+  struct Params {
+    GemmUniversalMode mode{};
+    ProblemShape problem_shape{};
+    MainloopParams mainloop{};
+    EpilogueParams epilogue{};
+    TileSchedulerParams scheduler{};
+    KernelHardwareInfo hw_info{};
+  };
+
+  enum class WarpCategory : int32_t {
+    MMA = 0,
+    Sched = 1,
+    MainloopLoad = 2,
+    EpilogueLoad = 3,
+    Epilogue = 4,
+    // Transformation starts at 256 thread alignment
+    Transformation = 8,
+    // SWORDFISH: derived from the collective (stock hardcoded 12 = 4 warps)
+    MainloopLoadB = 8 + int32_t(CollectiveMainloop::NumTransformationThreads /
+                                NumThreadsPerWarp),
+  };
+
+  struct IsParticipant {
+    uint32_t mma = false;
+    uint32_t sched = false;
+    uint32_t main_load = false;
+    uint32_t main_loadA = false;
+    uint32_t main_loadB = false;
+    uint32_t epi_load = false;
+    uint32_t epilogue = false;
+    uint32_t transformation = false;
+  };
+
+  //
+  // Methods
+  //
+
+  // Convert to underlying arguments. In this case, a simple copy for the
+  // aliased type.
+  static Params to_underlying_arguments(Arguments const& args,
+                                        void* workspace) {
+    static constexpr uint32_t NumEpilogueSubTiles = 1;
+    auto problem_shape = args.problem_shape;
+    if constexpr (detail::Has_SwapAB_v<CollectiveMainloop>) {
+      // swap M/N
+      get<0>(problem_shape) = get<1>(args.problem_shape);
+      get<1>(problem_shape) = get<0>(args.problem_shape);
+    }
+    auto problem_shape_MNKL = append<4>(problem_shape, 1);
+
+    // Get SM count if needed, otherwise use user supplied SM count
+    int sm_count = args.hw_info.sm_count;
+    if (sm_count <= 0) {
+      CUTLASS_TRACE_HOST(
+          "  WARNING: Arguments do not include a valid SM count.\n"
+          "  For optimal performance, populate the arguments "
+          "KernelHardwareInfo struct with the SM count.");
+      sm_count = KernelHardwareInfo::query_device_multiprocessor_count(
+          args.hw_info.device_id);
+    }
+
+    CUTLASS_TRACE_HOST(
+        "to_underlying_arguments(): Setting persistent grid SM count to "
+        << sm_count);
+    // Calculate workspace pointers
+    uint8_t* workspace_ptr = reinterpret_cast<uint8_t*>(workspace);
+    size_t workspace_offset = 0;
+
+    // Epilogue
+    void* epilogue_workspace = workspace_ptr + workspace_offset;
+    workspace_offset += CollectiveEpilogue::get_workspace_size(
+        args.problem_shape, args.epilogue);
+    workspace_offset = round_nearest(workspace_offset, MinWorkspaceAlignment);
+
+    void* mainloop_workspace = nullptr;
+
+    // Tile scheduler
+    void* scheduler_workspace = workspace_ptr + workspace_offset;
+    workspace_offset +=
+        TileScheduler::template get_workspace_size<ProblemShape,
+                                                   ElementAccumulator>(
+            args.scheduler, args.problem_shape, args.hw_info, NumFixupBarriers,
+            NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+    workspace_offset = round_nearest(workspace_offset, MinWorkspaceAlignment);
+
+    return {
+        args.mode,
+        args.problem_shape,
+        CollectiveMainloop::to_underlying_arguments(
+            args.problem_shape, args.mainloop, mainloop_workspace,
+            args.hw_info),
+        CollectiveEpilogue::to_underlying_arguments(
+            args.problem_shape, args.epilogue, epilogue_workspace),
+        TileScheduler::to_underlying_arguments(
+            problem_shape_MNKL, TileShape{}, AtomThrShapeMNK{}, ClusterShape{},
+            args.hw_info, args.scheduler, scheduler_workspace),
+        args.hw_info};
+  }
+
+  static bool can_implement(Arguments const& args) {
+    bool implementable =
+        (args.mode == GemmUniversalMode::kGemm) or
+        (args.mode == GemmUniversalMode::kBatched && rank(ProblemShape{}) == 4);
+    if (!implementable) {
+      CUTLASS_TRACE_HOST(
+          "  CAN IMPLEMENT: Arguments or Problem Shape don't meet the "
+          "requirements.\n");
+      return implementable;
+    }
+    implementable &=
+        CollectiveMainloop::can_implement(args.problem_shape, args.mainloop);
+    implementable &=
+        CollectiveEpilogue::can_implement(args.problem_shape, args.epilogue);
+    implementable &= TileScheduler::can_implement(args.scheduler);
+
+    if constexpr (IsDynamicCluster) {
+      static constexpr int MaxClusterSize = 16;
+      implementable &= size(args.hw_info.cluster_shape) <= MaxClusterSize;
+      implementable &=
+          size(args.hw_info.cluster_shape_fallback) <= MaxClusterSize;
+      implementable &=
+          cutlass::detail::preferred_cluster_can_implement<AtomThrShapeMNK>(
+              args.hw_info.cluster_shape, args.hw_info.cluster_shape_fallback);
+    }
+
+    return implementable;
+  }
+
+  static size_t get_workspace_size(Arguments const& args) {
+    static constexpr uint32_t NumEpilogueSubTiles = 1;
+    size_t workspace_size = 0;
+
+    // Epilogue
+    workspace_size += CollectiveEpilogue::get_workspace_size(args.problem_shape,
+                                                             args.epilogue);
+    workspace_size = round_nearest(workspace_size, MinWorkspaceAlignment);
+
+    // Tile scheduler
+    workspace_size +=
+        TileScheduler::template get_workspace_size<ProblemShape,
+                                                   ElementAccumulator>(
+            args.scheduler, args.problem_shape, args.hw_info, NumFixupBarriers,
+            NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+    workspace_size = round_nearest(workspace_size, MinWorkspaceAlignment);
+
+    return workspace_size;
+  }
+
+  static cutlass::Status initialize_workspace(
+      Arguments const& args, void* workspace = nullptr,
+      cudaStream_t stream = nullptr, CudaHostAdapter* cuda_adapter = nullptr) {
+    Status status = Status::kSuccess;
+    uint8_t* workspace_ptr = reinterpret_cast<uint8_t*>(workspace);
+    size_t workspace_offset = 0;
+    static constexpr uint32_t NumEpilogueSubTiles = 1;
+
+    // Epilogue
+    status = CollectiveEpilogue::initialize_workspace(
+        args.problem_shape, args.epilogue, workspace_ptr + workspace_offset,
+        stream, cuda_adapter);
+    workspace_offset += CollectiveEpilogue::get_workspace_size(
+        args.problem_shape, args.epilogue);
+    workspace_offset = round_nearest(workspace_offset, MinWorkspaceAlignment);
+    if (status != Status::kSuccess) {
+      return status;
+    }
+
+    // Tile scheduler
+    status = TileScheduler::template initialize_workspace<ProblemShape,
+                                                          ElementAccumulator>(
+        args.scheduler, workspace_ptr + workspace_offset, stream,
+        args.problem_shape, args.hw_info, NumFixupBarriers, NumEpilogueSubTiles,
+        CollectiveEpilogue::NumAccumulatorMtxs, cuda_adapter);
+    workspace_offset +=
+        TileScheduler::template get_workspace_size<ProblemShape,
+                                                   ElementAccumulator>(
+            args.scheduler, args.problem_shape, args.hw_info, NumFixupBarriers,
+            NumEpilogueSubTiles, CollectiveEpilogue::NumAccumulatorMtxs);
+    workspace_offset = round_nearest(workspace_offset, MinWorkspaceAlignment);
+    if (status != Status::kSuccess) {
+      return status;
+    }
+
+    return status;
+  }
+
+  // Computes the kernel launch grid shape based on runtime parameters
+  static dim3 get_grid_shape(Params const& params) {
+    auto cluster_shape = cutlass::detail::select_cluster_shape(
+        ClusterShape{}, params.hw_info.cluster_shape);
+    auto blk_shape = CtaShape_MNK{};
+    auto problem_shape_MNKL = append<4>(params.problem_shape, Int<1>{});
+    return TileScheduler::get_grid_shape(params.scheduler, problem_shape_MNKL,
+                                         TileShape{}, AtomThrShapeMNK{},
+                                         cluster_shape, params.hw_info);
+  }
+
+  static dim3 get_block_shape() { return dim3(MaxThreadsPerBlock, 1, 1); }
+
+  CUTLASS_DEVICE
+  void operator()(Params const& params, char* smem_buf) {
+    using namespace cute;
+    using X = Underscore;
+
+    static_assert(SharedStorageSize <= cutlass::arch::sm100_smem_capacity_bytes,
+                  "SMEM usage exceeded capacity.");
+    // Separate out problem shape for convenience
+    // Optionally append 1s until problem shape is rank-4 in case its is only
+    // rank-3 (MNK)
+    auto problem_shape_MNKL = append<4>(params.problem_shape, Int<1>{});
+    auto M = get<0>(problem_shape_MNKL);
+    auto N = get<1>(problem_shape_MNKL);
+    auto K = get<2>(problem_shape_MNKL);
+    auto L = get<3>(problem_shape_MNKL);
+
+    // Account for multiple epilogue and transformation warps
+    int warp_idx = canonical_warp_idx_sync();
+    WarpCategory warp_category =
+        warp_idx < static_cast<int>(WarpCategory::Epilogue)
+            ? WarpCategory(warp_idx)
+        : warp_idx < static_cast<int>(WarpCategory::Transformation)
+            ? WarpCategory::Epilogue
+        : warp_idx < static_cast<int>(WarpCategory::MainloopLoadB)
+            ? WarpCategory::Transformation
+            : WarpCategory::MainloopLoadB;
+
+    int thread_idx = int(threadIdx.x);
+    int thread_idx_in_warp = thread_idx % 32;
+    uint32_t lane_predicate = cute::elect_one_sync();
+    int cta_rank_in_cluster = cute::block_rank_in_cluster();
+    auto cluster_shape = cutlass::detail::select_cluster_shape(
+        ClusterShape{}, cute::cluster_shape());
+    int cluster_size = size(cluster_shape);
+    bool is_first_cta_in_cluster = (cta_rank_in_cluster == 0);
+    bool is_mma_leader_cta = (cta_rank_in_cluster % size<0>(TiledMma{}) == 0);
+    // Even if this variable is unused, shape_div still performs useful
+    // compile-time checks.
+    [[maybe_unused]] auto mma_leader_ctas =
+        size(shape_div(cluster_shape, AtomThrShapeMNK{}));
+    constexpr bool has_mma_peer_cta = size(AtomThrShapeMNK{}) == 2;
+    uint32_t mma_peer_cta_rank =
+        has_mma_peer_cta ? cta_rank_in_cluster ^ 1 : cta_rank_in_cluster;
+
+    // Issue Tma Descriptor Prefetch from a single thread
+    if ((warp_category == WarpCategory::Sched) && lane_predicate) {
+      CollectiveMainloop::prefetch_tma_descriptors(params.mainloop);
+    }
+    if ((warp_category == WarpCategory::EpilogueLoad) && lane_predicate) {
+      CollectiveEpilogue::prefetch_tma_descriptors(params.epilogue);
+    }
+
+    // Kernel level shared memory storage
+    SharedStorage& shared_storage = *reinterpret_cast<SharedStorage*>(smem_buf);
+
+    CollectiveMainloop collective_mainloop(params.mainloop, cluster_shape,
+                                           cta_rank_in_cluster);
+    CollectiveEpilogue collective_epilogue{params.epilogue,
+                                           shared_storage.tensors.epilogue};
+
+    bool is_epi_load_needed = collective_epilogue.is_producer_load_needed();
+    IsParticipant is_participant = {
+        (warp_category == WarpCategory::MMA),  // mma
+        (warp_category == WarpCategory::Sched) &&
+            (is_first_cta_in_cluster),  // sched
+        (warp_category == WarpCategory::MainloopLoad ||
+         warp_category == WarpCategory::MainloopLoadB),  // main_load
+        (warp_category == WarpCategory::MainloopLoad),   // main_loadA
+        (warp_category == WarpCategory::MainloopLoadB),  // main_loadB
+        (warp_category == WarpCategory::EpilogueLoad) &&
+            is_epi_load_needed,                          // epi_load
+        (warp_category == WarpCategory::Epilogue),       // epilogue
+        (warp_category == WarpCategory::Transformation)  // transformation
+    };
+
+    // MainloopLoad <--> Transformation Pipeline
+    typename Load2TransformPipeline::Params load2transform_pipeline_params;
+    if (warp_category == WarpCategory::MainloopLoad) {
+      load2transform_pipeline_params.role =
+          Load2TransformPipeline::ThreadCategory::Producer;
+    } else if (warp_category == WarpCategory::Transformation) {
+      load2transform_pipeline_params.role =
+          Load2TransformPipeline::ThreadCategory::Consumer;
+    }
+    load2transform_pipeline_params.is_leader = (thread_idx_in_warp == 0);
+    load2transform_pipeline_params.num_consumers = NumTransformationThreads;
+    load2transform_pipeline_params.transaction_bytes =
+        CollectiveMainloop::TmaTransactionBytes_A;
+    load2transform_pipeline_params.initializing_warp = 0;
+    Load2TransformPipeline load2transform_pipeline(
+        shared_storage.pipelines.mainloop.load2transform_pipeline,
+        load2transform_pipeline_params, cluster_shape, McastDirection::kRow,
+        cute::true_type{},  // Perform barrier init
+        cute::false_type{}  // Delay mask calculation
+    );
+
+    Load2TransformPipelineState load2transform_pipeline_consumer_state;
+    Load2TransformPipelineState load2transform_pipeline_producer_state =
+        cutlass::make_producer_start_state<Load2TransformPipeline>();
+
+    // MainloopLoad <--> MMA Pipeline
+    typename Load2MmaPipeline::Params load2mma_pipeline_params;
+    if (warp_category == WarpCategory::MainloopLoadB) {
+      load2mma_pipeline_params.role =
+          Load2MmaPipeline::ThreadCategory::Producer;
+    } else if (warp_category == WarpCategory::MMA) {
+      load2mma_pipeline_params.role =
+          Load2MmaPipeline::ThreadCategory::Consumer;
+    }
+    load2mma_pipeline_params.is_leader =
+        lane_predicate && is_mma_leader_cta && is_participant.main_loadB;
+    load2mma_pipeline_params.num_consumers = NumMMAThreads;
+    load2mma_pipeline_params.transaction_bytes =
+        CollectiveMainloop::TmaTransactionBytes_B;
+    load2mma_pipeline_params.initializing_warp = 8;
+    Load2MmaPipeline load2mma_pipeline(
+        shared_storage.pipelines.mainloop.load2mma_pipeline,
+        load2mma_pipeline_params, cluster_shape, McastDirection::kCol,
+        cute::true_type{},  // Perform barrier init
+        cute::false_type{}  // Delay mask calculation
+    );
+
+    Load2MmaPipelineState load2mma_pipeline_consumer_state;
+    Load2MmaPipelineState load2mma_pipeline_producer_state =
+        cutlass::make_producer_start_state<Load2MmaPipeline>();
+
+    // Transformation <--> MMA pipeline
+    typename Transform2MmaPipeline::Params transform2mma_pipeline_params;
+    if (warp_category == WarpCategory::Transformation) {
+      transform2mma_pipeline_params.role =
+          Transform2MmaPipeline::ThreadCategory::Producer;
+    } else if (warp_category == WarpCategory::MMA) {
+      transform2mma_pipeline_params.role =
+          Transform2MmaPipeline::ThreadCategory::Consumer;
+    }
+    transform2mma_pipeline_params.consumer_arv_count = 1;
+    transform2mma_pipeline_params.producer_arv_count =
+        size(AtomThrShapeMNK{}) * NumTransformationThreads;
+    transform2mma_pipeline_params.initializing_warp = 2;
+    Transform2MmaPipeline transform2mma_pipeline(
+        shared_storage.pipelines.mainloop.transform2mma_pipeline,
+        transform2mma_pipeline_params, cluster_shape,
+        cute::true_type{},  // Perform barrier init
+        cute::false_type{}  // Delay mask calculation
+    );
+
+    Transform2MmaPipelineState transform2mma_pipeline_consumer_state;
+    Transform2MmaPipelineState transform2mma_pipeline_producer_state =
+        cutlass::make_producer_start_state<Transform2MmaPipeline>();
+
+    // MMA <--> Accumulator pipeline
+    typename Mma2AccumPipeline::Params mma2accum_pipeline_params;
+    if (warp_category == WarpCategory::MMA) {
+      mma2accum_pipeline_params.role =
+          Mma2AccumPipeline::ThreadCategory::Producer;
+    } else if (warp_category == WarpCategory::Epilogue) {
+      mma2accum_pipeline_params.role =
+          Mma2AccumPipeline::ThreadCategory::Consumer;
+    }
+    mma2accum_pipeline_params.producer_arv_count = 1;
+    mma2accum_pipeline_params.consumer_arv_count =
+        size(AtomThrShapeMNK{}) * NumEpilogueThreads;
+    mma2accum_pipeline_params.initializing_warp = 6;
+    Mma2AccumPipeline mma2accum_pipeline(
+        shared_storage.pipelines.mainloop.mma2accum_pipeline,
+        mma2accum_pipeline_params, cluster_shape,
+        cute::true_type{},  // Perform barrier init
+        cute::false_type{}  // Delay mask calculation
+    );
+
+    Mma2AccumPipelineState mma2accum_pipeline_consumer_state;
+    Mma2AccumPipelineState mma2accum_pipeline_producer_state =
+        cutlass::make_producer_start_state<Mma2AccumPipeline>();
+
+    // Epilogue Load pipeline
+    typename EpiLoadPipeline::Params epi_load_pipeline_params;
+    if (WarpCategory::EpilogueLoad == warp_category) {
+      epi_load_pipeline_params.role = EpiLoadPipeline::ThreadCategory::Producer;
+    }
+    if (WarpCategory::Epilogue == warp_category) {
+      epi_load_pipeline_params.role = EpiLoadPipeline::ThreadCategory::Consumer;
+    }
+    epi_load_pipeline_params.dst_blockid = cta_rank_in_cluster;
+    epi_load_pipeline_params.producer_arv_count = NumEpilogueLoadThreads;
+    epi_load_pipeline_params.consumer_arv_count = NumEpilogueThreads;
+    epi_load_pipeline_params.transaction_bytes =
+        CollectiveEpilogue::TmaTransactionBytes;
+    epi_load_pipeline_params.initializing_warp = 4;
+    EpiLoadPipeline epi_load_pipeline(shared_storage.pipelines.epi_load,
+                                      epi_load_pipeline_params);
+
+    // Epilogue Store pipeline
+    typename EpiStorePipeline::Params epi_store_pipeline_params;
+    epi_store_pipeline_params.always_wait = true;
+    EpiStorePipeline epi_store_pipeline(epi_store_pipeline_params);
+
+    // Load order barrier
+    typename LoadOrderBarrier::Params load_order_barrier_params;
+    load_order_barrier_params.group_id =
+        (warp_category == WarpCategory::MainloopLoad) ? 0 : 1;
+    load_order_barrier_params.group_size = 1;
+    load_order_barrier_params.initializing_warp = 5;
+    LoadOrderBarrier load_order_barrier(shared_storage.pipelines.load_order,
+                                        load_order_barrier_params);
+
+    EpiLoadPipelineState epi_load_pipe_consumer_state;
+    EpiLoadPipelineState epi_load_pipe_producer_state =
+        cutlass::make_producer_start_state<EpiLoadPipeline>();
+
+    // epilogue store pipe is producer-only (consumer is TMA unit, waits via
+    // scoreboarding)
+    EpiStorePipelineState epi_store_pipe_producer_state =
+        cutlass::make_producer_start_state<EpiStorePipeline>();
+
+    // CLC pipeline
+    // Operates Scheduling Warp <--> All Warps
+    typename CLCPipeline::Params clc_pipeline_params;
+    if (WarpCategory::Sched == warp_category) {
+      clc_pipeline_params.role = CLCPipeline::ThreadCategory::ProducerConsumer;
+    } else {
+      clc_pipeline_params.role = CLCPipeline::ThreadCategory::Consumer;
+    }
+    clc_pipeline_params.producer_blockid = 0;
+    clc_pipeline_params.producer_arv_count = 1;
+    clc_pipeline_params.consumer_arv_count =
+        NumSchedThreads +
+        cluster_size *
+            (NumMainloopLoadThreads + NumMainloopLoadBThreads +
+             NumEpilogueThreads + NumMMAThreads + NumTransformationThreads);
+    if (is_epi_load_needed) {
+      clc_pipeline_params.consumer_arv_count +=
+          cluster_size * NumEpilogueLoadThreads;
+    }
+    clc_pipeline_params.transaction_bytes = CLCResponseSize;
+    clc_pipeline_params.initializing_warp = 1;
+    CLCPipeline clc_pipeline(shared_storage.pipelines.clc, clc_pipeline_params,
+                             cluster_shape);
+
+    CLCPipelineState clc_pipeline_consumer_state;
+    CLCPipelineState clc_pipeline_producer_state =
+        cutlass::make_producer_start_state<CLCPipeline>();
+
+    // CLC throttle pipeline
+    typename CLCThrottlePipeline::Params clc_throttle_pipeline_params;
+    if (WarpCategory::MainloopLoad == warp_category) {
+      clc_throttle_pipeline_params.role =
+          CLCThrottlePipeline::ThreadCategory::Producer;
+    }
+    if (WarpCategory::Sched == warp_category) {
+      clc_throttle_pipeline_params.role =
+          CLCThrottlePipeline::ThreadCategory::Consumer;
+    }
+    clc_throttle_pipeline_params.producer_arv_count = NumMainloopLoadThreads;
+    clc_throttle_pipeline_params.consumer_arv_count = NumSchedThreads;
+    clc_throttle_pipeline_params.dst_blockid = 0;
+    clc_throttle_pipeline_params.initializing_warp = 3;
+    CLCThrottlePipeline clc_throttle_pipeline(
+        shared_storage.pipelines.clc_throttle, clc_throttle_pipeline_params);
+    CLCThrottlePipelineState clc_pipe_throttle_consumer_state;
+    CLCThrottlePipelineState clc_pipe_throttle_producer_state =
+        cutlass::make_producer_start_state<CLCThrottlePipeline>();
+
+    // Tmem allocator
+    TmemAllocator tmem_allocator{};
+
+    // Sync allocation status between transform, MMA, and epilogue warps within
+    // CTA
+    arch::NamedBarrier tmem_allocation_result_barrier(
+        NumTransformationThreads + NumMMAThreads + NumEpilogueThreads,
+        cutlass::arch::ReservedNamedBarriers::TmemAllocBarrier);
+    // Sync deallocation status between MMA warps of peer CTAs
+    arch::ClusterBarrier& tmem_deallocation_result_barrier =
+        shared_storage.pipelines.tmem_dealloc;
+    [[maybe_unused]] uint32_t dealloc_barrier_phase = 0;
+    if (WarpCategory::MMA == warp_category && has_mma_peer_cta &&
+        lane_predicate) {
+      tmem_deallocation_result_barrier.init(NumMMAThreads);
+    }
+
+    // Initialize smem barrier for prologue throttling. Epilogue warps are
+    // stalled until the prologue finishes.
+    arch::ClusterBarrier& epilogue_throttle_barrier =
+        shared_storage.pipelines.epilogue_throttle;
+    if (WarpCategory::MMA == warp_category && lane_predicate) {
+      epilogue_throttle_barrier.init(
+          NumMMAThreads + (is_first_cta_in_cluster ? NumSchedThreads : 0) +
+          NumMainloopLoadThreads + NumMainloopLoadBThreads +
+          (is_epi_load_needed ? NumEpilogueLoadThreads : 0) +
+          NumTransformationThreads);
+    }
+
+    // We need this to guarantee that the Pipeline init is visible
+    // To all producers and consumer threadblocks in the cluster
+    pipeline_init_arrive_relaxed(cluster_size);
+
+    dim3 block_id_in_cluster = cute::block_id_in_cluster();
+
+    // Calculate mask after cluster barrier arrival
+    load2transform_pipeline.init_masks(cluster_shape, block_id_in_cluster,
+                                       cutlass::McastDirection::kRow);
+    load2mma_pipeline.init_masks(cluster_shape, cutlass::McastDirection::kCol);
+    transform2mma_pipeline.init_masks(cluster_shape);
+    mma2accum_pipeline.init_masks(cluster_shape);
+
+    // TileID scheduler
+    TileScheduler scheduler(&shared_storage.clc_response[0], params.scheduler,
+                            block_id_in_cluster);
+    typename TileScheduler::WorkTileInfo work_tile_info =
+        scheduler.initial_work_tile_info(cluster_shape);
+
+    auto cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+
+    // Allocate accumulators
+    auto acc_shape = collective_mainloop.partition_accumulator_shape();
+    auto bulk_tmem = TiledMma::make_fragment_C(
+        append(acc_shape, Int<AccumulatorPipelineStageCount>{}));
+
+    // Tile transform inputs now to get the k tile count
+    auto transform_inputs = collective_mainloop.transform_init(
+        params.mainloop, problem_shape_MNKL, bulk_tmem,
+        shared_storage.tensors.mainloop);
+    Tensor gA_mkl = get<0>(transform_inputs);
+
+    // Synchronization call. Blocks wait until barriers are initialized in
+    // shared memory.
+    pipeline_init_wait(cluster_size);
+
+    if (is_participant.main_load) {
+      // Ensure that the prefetched kernel does not touch
+      // unflushed global memory prior to this instruction
+      cutlass::arch::wait_on_dependent_grids();
+
+      bool do_load_order_arrive = is_epi_load_needed;
+      auto load_inputs = collective_mainloop.load_init(
+          problem_shape_MNKL, params.mainloop, shared_storage.tensors.mainloop);
+
+      // Signal the epilogue warps to proceed once the prologue is complete
+      epilogue_throttle_barrier.arrive();
+      bool requires_clc_query = true;
+
+      do {
+        cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+        auto k_tile_iter =
+            scheduler.get_k_tile_iterator(work_tile_info, problem_shape_MNKL,
+                                          CtaShape_MNK{}, shape<3>(gA_mkl));
+        auto k_tile_count = TileScheduler::get_work_k_tile_count(
+            work_tile_info, problem_shape_MNKL, CtaShape_MNK{});
+        auto k_tile_prologue =
+            min(Load2TransformPipeline::Stages, k_tile_count);
+
+        if (is_participant.main_loadA) {
+          if constexpr (IsSchedDynamicPersistent) {
+            if (is_first_cta_in_cluster && requires_clc_query) {
+              clc_throttle_pipeline.producer_acquire(
+                  clc_pipe_throttle_producer_state);
+              clc_throttle_pipeline.producer_commit(
+                  clc_pipe_throttle_producer_state);
+              ++clc_pipe_throttle_producer_state;
+            }
+          }
+        }
+
+        if (lane_predicate) {
+          if (is_participant.main_loadA) {
+            auto [load2transform_pipeline_producer_state_next,
+                  k_tile_iter_next] =
+                collective_mainloop.load_A(
+                    params.mainloop, load2transform_pipeline,
+                    load2transform_pipeline_producer_state, load_inputs,
+                    cta_coord_mnkl, k_tile_iter, k_tile_prologue);
+            load2transform_pipeline_producer_state =
+                load2transform_pipeline_producer_state_next;
+
+            if (do_load_order_arrive) {
+              load_order_barrier.arrive();
+              do_load_order_arrive = false;
+            }
+
+            auto [load2transform_pipeline_producer_state_next_, unused_] =
+                collective_mainloop.load_A(
+                    params.mainloop, load2transform_pipeline,
+                    load2transform_pipeline_producer_state, load_inputs,
+                    cta_coord_mnkl, k_tile_iter_next,
+                    k_tile_count - k_tile_prologue);
+            load2transform_pipeline_producer_state =
+                load2transform_pipeline_producer_state_next_;
+          }
+
+          if (is_participant.main_loadB) {
+            auto [load2mma_pipeline_producer_state_next, k_tile_iter_next] =
+                collective_mainloop.load_B(params.mainloop, load2mma_pipeline,
+                                           load2mma_pipeline_producer_state,
+                                           load_inputs, cta_coord_mnkl,
+                                           k_tile_iter, k_tile_prologue);
+            load2mma_pipeline_producer_state =
+                load2mma_pipeline_producer_state_next;
+
+            auto [load2mma_pipeline_producer_state_next_, unused_] =
+                collective_mainloop.load_B(params.mainloop, load2mma_pipeline,
+                                           load2mma_pipeline_producer_state,
+                                           load_inputs, cta_coord_mnkl,
+                                           k_tile_iter_next,
+                                           k_tile_count - k_tile_prologue);
+            load2mma_pipeline_producer_state =
+                load2mma_pipeline_producer_state_next_;
+          }
+        }
+
+        // Sync warp to prevent non-participating threads entering next wave
+        // early
+        __syncwarp();
+
+        // Fetch next work tile
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+            work_tile_info, clc_pipeline, clc_pipeline_consumer_state);
+
+        requires_clc_query = increment_pipe;
+        if (increment_pipe) {
+          ++clc_pipeline_consumer_state;
+        }
+        work_tile_info = next_work_tile_info;
+      } while (work_tile_info.is_valid());
+
+      if (is_participant.main_loadA) {
+        if (lane_predicate) {
+          load2transform_pipeline.producer_tail(
+              load2transform_pipeline_producer_state);
+        }
+      }
+      if (is_participant.main_loadB) {
+        if (lane_predicate) {
+          load2mma_pipeline.producer_tail(load2mma_pipeline_producer_state);
+        }
+      }
+
+    }
+
+    else if (is_participant.sched) {
+      // Signal the epilogue warps to proceed once the prologue is complete
+      epilogue_throttle_barrier.arrive();
+
+      if constexpr (IsSchedDynamicPersistent) {
+        // Whether a new CLC query must be performed.
+        // See comment below where this variable is updated for a description of
+        // why this variable is needed.
+        bool requires_clc_query = true;
+
+        cutlass::arch::wait_on_dependent_grids();
+
+        do {
+          if (requires_clc_query) {
+            // Throttle CLC query to mitigate workload imbalance caused by skews
+            // among persistent workers.
+            clc_throttle_pipeline.consumer_wait(
+                clc_pipe_throttle_consumer_state);
+            clc_throttle_pipeline.consumer_release(
+                clc_pipe_throttle_consumer_state);
+            ++clc_pipe_throttle_consumer_state;
+
+            // Query next clcID and update producer state
+            clc_pipeline_producer_state = scheduler.advance_to_next_work(
+                clc_pipeline, clc_pipeline_producer_state);
+          }
+
+          // Fetch next work tile
+          auto [next_work_tile_info, increment_pipe] =
+              scheduler.fetch_next_work(work_tile_info, clc_pipeline,
+                                        clc_pipeline_consumer_state);
+
+          // Only perform a new CLC query if we consumed a new CLC query result
+          // in `fetch_next_work`. An example of a case in which CLC
+          // `fetch_next_work` does not consume a new CLC query response is when
+          // processing stream-K units. The current stream-K scheduler uses
+          // single WorkTileInfo to track multiple (potentially-partial) tiles
+          // to be computed via stream-K. In this case, `fetch_next_work` simply
+          // performs in-place updates on the existing WorkTileInfo, rather than
+          // consuming a CLC query response.
+          requires_clc_query = increment_pipe;
+          if (increment_pipe) {
+            ++clc_pipeline_consumer_state;
+          }
+
+          work_tile_info = next_work_tile_info;
+        } while (work_tile_info.is_valid());
+        clc_pipeline.producer_tail(clc_pipeline_producer_state);
+      }
+    }
+
+    else if (is_participant.transformation) {
+      // Signal the epilogue warps to proceed once the prologue is complete
+      epilogue_throttle_barrier.arrive();
+
+      // Wait for tmem allocation
+      tmem_allocation_result_barrier.arrive_and_wait_unaligned();
+
+      do {
+        auto k_tile_count = TileScheduler::get_work_k_tile_count(
+            work_tile_info, problem_shape_MNKL, CtaShape_MNK{});
+        auto k_tile_start =
+            TileScheduler::get_work_k_tile_start(work_tile_info);
+        auto k_tile_iter = cute::make_coord_iterator(
+            idx2crd(k_tile_start, shape<3>(gA_mkl)), shape<3>(gA_mkl));
+        auto [load2transform_pipeline_consumer_state_next,
+              transform2mma_pipeline_producer_state_next] =
+            collective_mainloop.transform(
+                load2transform_pipeline, load2transform_pipeline_consumer_state,
+                transform2mma_pipeline, transform2mma_pipeline_producer_state,
+                bulk_tmem, transform_inputs, k_tile_iter, k_tile_count);
+        transform2mma_pipeline_producer_state =
+            transform2mma_pipeline_producer_state_next;
+        load2transform_pipeline_consumer_state =
+            load2transform_pipeline_consumer_state_next;
+
+        // Fetch next work tile
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+            work_tile_info, clc_pipeline, clc_pipeline_consumer_state);
+        work_tile_info = next_work_tile_info;
+
+        if (increment_pipe) {
+          ++clc_pipeline_consumer_state;
+        }
+      } while (work_tile_info.is_valid());
+
+      transform2mma_pipeline.producer_tail(
+          transform2mma_pipeline_producer_state);
+    }
+
+    else if (is_participant.mma) {
+      // Tmem allocation sequence
+      tmem_allocator.allocate(TmemAllocator::Sm100TmemCapacityColumns,
+                              &shared_storage.tmem_base_ptr);
+      __syncwarp();
+      tmem_allocation_result_barrier.arrive();
+      uint32_t tmem_base_ptr = shared_storage.tmem_base_ptr;
+
+      auto mma_input_operands = collective_mainloop.mma_init(
+          bulk_tmem, shared_storage.tensors.mainloop);
+
+      // Signal the epilogue warps to proceed once the prologue is complete
+      epilogue_throttle_barrier.arrive();
+
+      do {
+        auto k_tile_count = TileScheduler::get_work_k_tile_count(
+            work_tile_info, problem_shape_MNKL, CtaShape_MNK{});
+        // Fetch next work tile
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+            work_tile_info, clc_pipeline, clc_pipeline_consumer_state);
+        work_tile_info = next_work_tile_info;
+
+        if (increment_pipe) {
+          ++clc_pipeline_consumer_state;
+        }
+
+        if (is_mma_leader_cta) {
+          auto [load2mma_pipeline_consumer_state_next,
+                transform2mma_pipeline_consumer_state_next,
+                mma2accum_pipeline_producer_state_next] =
+              collective_mainloop.mma(
+                  load2mma_pipeline, load2mma_pipeline_consumer_state,
+                  transform2mma_pipeline, transform2mma_pipeline_consumer_state,
+                  mma2accum_pipeline, mma2accum_pipeline_producer_state,
+                  bulk_tmem, mma_input_operands, k_tile_count);
+          // Advance the mm2accum pipe
+          load2mma_pipeline_consumer_state =
+              load2mma_pipeline_consumer_state_next;
+          transform2mma_pipeline_consumer_state =
+              transform2mma_pipeline_consumer_state_next;
+          mma2accum_pipeline_producer_state =
+              mma2accum_pipeline_producer_state_next;
+        }
+      } while (work_tile_info.is_valid());
+
+      // leader MMA waits for leader + peer epilogues to release accumulator
+      // stage
+      if (is_mma_leader_cta) {
+        mma2accum_pipeline.producer_tail(mma2accum_pipeline_producer_state);
+      }
+
+      // Hint on an early release of global memory resources.
+      // The timing of calling this function only influences performance,
+      // not functional correctness.
+      cutlass::arch::launch_dependent_grids();
+
+      // Signal to peer MMA that entire tmem allocation can be deallocated
+      if constexpr (has_mma_peer_cta) {
+        // Leader does wait + arrive, follower does arrive + wait
+        tmem_deallocation_result_barrier.arrive(mma_peer_cta_rank,
+                                                not is_mma_leader_cta);
+        tmem_deallocation_result_barrier.wait(dealloc_barrier_phase);
+        tmem_deallocation_result_barrier.arrive(mma_peer_cta_rank,
+                                                is_mma_leader_cta);
+      }
+
+      // Free entire tmem allocation
+      tmem_allocator.free(tmem_base_ptr,
+                          TmemAllocator::Sm100TmemCapacityColumns);
+    }
+
+    else if (is_participant.epi_load) {
+      // Ensure that the prefetched kernel does not touch
+      // unflushed global memory prior to this instruction
+      cutlass::arch::wait_on_dependent_grids();
+
+      bool do_load_order_wait = true;
+      bool do_tail_load = false;
+
+      // Signal the epilogue warps to proceed once the prologue is complete
+      epilogue_throttle_barrier.arrive();
+
+      do {
+        bool compute_epilogue =
+            TileScheduler::compute_epilogue(work_tile_info, params.scheduler);
+        // Get current work tile and fetch next work tile
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+            work_tile_info, clc_pipeline, clc_pipeline_consumer_state);
+        work_tile_info = next_work_tile_info;
+
+        if (increment_pipe) {
+          ++clc_pipeline_consumer_state;
+        }
+
+        if (compute_epilogue) {
+          if (do_load_order_wait) {
+            load_order_barrier.wait();
+            do_load_order_wait = false;
+          }
+
+          epi_load_pipe_producer_state = collective_epilogue.load(
+              epi_load_pipeline, epi_load_pipe_producer_state,
+              problem_shape_MNKL, CtaShape_MNK{}, cta_coord_mnkl, TileShape{},
+              TiledMma{}, shared_storage.tensors.epilogue);
+
+          do_tail_load = true;
+        }
+
+        // Calculate the cta coordinates of the next work tile
+        cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+      } while (work_tile_info.is_valid());
+
+      // Only perform a tail load if one of the work units processed performed
+      // an epilogue load. An example of a case in which a tail load should not
+      // be performed is in split-K if a cluster is only assigned non-final
+      // splits (for which the cluster does not compute the epilogue).
+      if (do_tail_load) {
+        collective_epilogue.load_tail(
+            epi_load_pipeline, epi_load_pipe_producer_state, epi_store_pipeline,
+            epi_store_pipe_producer_state);
+      }
+    }
+
+    else if (is_participant.epilogue) {
+      // Throttle the epilogue warps to improve prologue performance
+      static constexpr int epilogue_throttle_phase_bit = 0;
+      epilogue_throttle_barrier.wait(epilogue_throttle_phase_bit);
+
+      // Wait for tmem allocation
+      tmem_allocation_result_barrier.arrive_and_wait_unaligned();
+
+      auto accum_inputs = collective_mainloop.accum_init(
+          bulk_tmem, typename CollectiveEpilogue::CopyOpT2R{},
+          typename CollectiveEpilogue::EpilogueTile{});
+      bool do_tail_store = false;
+      do {
+        // Fetch next work tile
+        auto [next_work_tile_info, increment_pipe] = scheduler.fetch_next_work(
+            work_tile_info, clc_pipeline, clc_pipeline_consumer_state);
+
+        if (increment_pipe) {
+          ++clc_pipeline_consumer_state;
+        }
+
+        auto k_tile_count = TileScheduler::get_work_k_tile_count(
+            work_tile_info, problem_shape_MNKL, CtaShape_MNK{});
+        mma2accum_pipeline.consumer_wait(mma2accum_pipeline_consumer_state);
+
+        // Accumulators
+        Tensor accumulators =
+            bulk_tmem(_, _, _,
+                      mma2accum_pipeline_consumer_state
+                          .index());  // ((MMA_TILE_M,MMA_TILE_N),MMA_M,MMA_N)
+
+        mma2accum_pipeline_consumer_state = scheduler.template fixup<IsComplex>(
+            TiledMma{}, work_tile_info, accumulators, mma2accum_pipeline,
+            mma2accum_pipeline_consumer_state,
+            typename CollectiveEpilogue::CopyOpT2R{});
+
+        //
+        // Epilogue and write to gD
+        //
+        if (scheduler.compute_epilogue(work_tile_info)) {
+          auto [load_state_next, store_state_next,
+                mma2accum_pipeline_state_next] =
+              collective_epilogue.store(
+                  epi_load_pipeline, epi_load_pipe_consumer_state,
+                  epi_store_pipeline, epi_store_pipe_producer_state,
+                  mma2accum_pipeline, mma2accum_pipeline_consumer_state,
+                  problem_shape_MNKL, CtaShape_MNK{}, cta_coord_mnkl,
+                  TileShape{}, TiledMma{}, accumulators,
+                  shared_storage.tensors.epilogue);
+          epi_load_pipe_consumer_state = load_state_next;
+          epi_store_pipe_producer_state = store_state_next;
+          do_tail_store = true;
+
+          // Advance the mma2accum pipe
+          mma2accum_pipeline_consumer_state = mma2accum_pipeline_state_next;
+        }
+
+        work_tile_info = next_work_tile_info;
+        cta_coord_mnkl = scheduler.work_tile_to_cta_coord(work_tile_info);
+      } while (work_tile_info.is_valid());
+
+      // Only perform a tail load if one of the work units processed performed
+      // an epilogue load. An example of a case in which a tail load should not
+      // be performed is in split-K if a cluster is only assigned non-final
+      // splits (for which the cluster does not compute the epilogue).
+      if (do_tail_store) {
+        collective_epilogue.store_tail(
+            epi_load_pipeline, epi_load_pipe_consumer_state, epi_store_pipeline,
+            epi_store_pipe_producer_state, CtaShape_MNK{});
+      }
+    } else {
+    }
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+}  // namespace cutlass::gemm::kernel

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_prefill_mainloop.cuh
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_prefill_mainloop.cuh
@@ -1,0 +1,1291 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+// Swordfish prefill mainloop, an sm100 tcgen05 mixed-input collective reading
+// the Swordfish packed-weight ABI v1 directly.
+//
+// This is a fork of CUTLASS 4.4.2's
+//   include/cutlass/gemm/collective/sm100_mma_warpspecialized_mixed_input.hpp
+// (BSD-3-Clause, Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES),
+// following the Machete precedent of forking a stock collective. Line
+// references below are against that file. The pipeline structure
+// (Load2Transform / Load2Mma / Transform2Mma / Mma2Accum), the B (activation)
+// path, the scale TMA path, and the MMA stage are stock. Two things change.
+//
+// 1. B-operand TMA over the packed ABI (stock lines 310-313, 460-467,
+//    529-535, 735-814, 883-973). The quantized operand (riding the swapped
+//    A slot) is
+//    presented to TMA as a dense byte tensor (256, 8, KB, NB); each (nb, kb)
+//    ABI block is a linear 2048 B run (invariant I3), and the Marlin in-tile
+//    permutation is invisible to a byte copy (I4). The input smem staging is a
+//    plain byte buffer; the canonical-layout input atom machinery is deleted.
+//
+// 2. The Transform stage (stock lines 975-1144). Instead of
+//    MixedInputUtils::dequantize_A_kblock_for_transform over canonical int4,
+//    each transform thread consumes packed words in Marlin tile order (lane T
+//    <-> word 4T of each 512 B sub-tile, the contract proven by the decode
+//    path, swordfish_decode.cuh) and dequantizes with the marlin u4b8 LOP3
+//    idiom, applies group scales, and writes K-major bf16 into the
+//    tcgen05-descriptor-legal compute smem buffer (invariant I5, four 32-bit
+//    lane-local stores per packed word). Because the stores are free-form smem
+//    writes, this fork uses the SS (A-from-SMEM) UMMA atom, i.e. the TiledMma
+//    of KernelTmaWarpSpecialized1SmMixedInputSmemSm100. (The stock Smem
+//    schedule does not compile in CUTLASS 4.4.2, since its transform_init calls
+//    make_tmem_copy on an SS descriptor fragment; this fork replaces that code
+//    entirely.)
+//
+// Scope: 1-SM or 2-SM (cta_group::2) MMA, u4b8 weights, bf16
+// activations/scales, ConvertAndScale without zero points, group_size 64 or
+// 128, L = 1, N and K multiples of 128 (the ABI tail policy rejects rests).
+#pragma once
+
+#include <cuda_bf16.h>
+
+#include "cutlass/cutlass.h"
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/dispatch_policy.hpp"
+#include "cutlass/pipeline/pipeline.hpp"
+#include "cutlass/numeric_conversion.h"
+#include "cutlass/detail/sm100_tmem_helper.hpp"
+#include "cutlass/detail/cluster.hpp"
+#include "cutlass/detail/collective/mixed_input_utils.hpp"
+#include "cutlass/detail/sm100_mixed_dtype_blockwise_layout.hpp"
+#include "cutlass/detail/blockwise_scale_layout.hpp"
+
+#include "cute/algorithm/functional.hpp"
+#include "cute/arch/cluster_sm90.hpp"
+#include "cute/atom/mma_atom.hpp"
+#include "cute/atom/copy_atom.hpp"
+#include "cute/algorithm/gemm.hpp"
+#include "cute/arch/mma_sm100.hpp"
+#include "cutlass/trace.h"
+#include "cutlass/kernel_hardware_info.hpp"
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass::gemm::collective {
+using namespace cute;
+
+namespace swordfish_detail {
+
+// u4b8 -> bf16x2 pair dequant, the marlin LOP3 idiom
+// (csrc/libtorch_stable/quantization/marlin/dequant.h,
+// dequant<nv_bfloat162, kU4B8>; re-stated here so this header only depends on
+// CUTLASS/CUDA). Consumes nibbles {0,4} into frag[0] and {1,5} into frag[1];
+// feed `q >> 8` for nibbles {2,6}/{3,7}. Under the Marlin pack_idx interleave
+// {0,2,4,6,1,3,5,7} this yields, for a word held by lane T (column c = T/4,
+// k-quad t = T%4):
+//   dequant(q):      frag[0] = (k=2t, 2t+1),  frag[1] = (k=2t+8, 2t+9)   @ col
+//   c dequant(q >> 8): same k positions                                    @
+//   col c+8
+__device__ __forceinline__ void dequant_u4b8_bf16x2(uint32_t q,
+                                                    __nv_bfloat162 frag[2]) {
+  static constexpr uint32_t kMask = 0x000f000f;
+  static constexpr uint32_t kEx = 0x43004300;
+  static constexpr uint32_t kSub =
+      0x43084308;  // {136, 136}: (v | 0x4300) - 136 = v - 8
+  static constexpr uint32_t kImmLut = (0xf0 & 0xcc) | 0xaa;
+  uint32_t lo, hi;
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(lo)
+               : "r"(q), "n"(kMask), "n"(kEx), "n"(kImmLut));
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(hi)
+               : "r"(q >> 4), "n"(kMask), "n"(kEx), "n"(kImmLut));
+  frag[0] = __hsub2(reinterpret_cast<__nv_bfloat162 const&>(lo),
+                    reinterpret_cast<__nv_bfloat162 const&>(kSub));
+  frag[1] = __hsub2(reinterpret_cast<__nv_bfloat162 const&>(hi),
+                    reinterpret_cast<__nv_bfloat162 const&>(kSub));
+}
+
+// u4b8 -> f16x2 pair dequant (marlin dequant<half2, kU4B8>). Same fragment
+// semantics as the bf16 helper; the high nibble plane rides an embedded
+// x16 exponent folded out by the fma.
+__device__ __forceinline__ void dequant_u4b8_f16x2(uint32_t q,
+                                                   __half2 frag[2]) {
+  static constexpr uint32_t kLo = 0x000f000f;
+  static constexpr uint32_t kHi = 0x00f000f0;
+  static constexpr uint32_t kEx = 0x64006400;
+  static constexpr uint32_t kSub = 0x64086408;
+  static constexpr uint32_t kMul = 0x2c002c00;
+  static constexpr uint32_t kAdd = 0xd480d480;
+  static constexpr uint32_t kImmLut = (0xf0 & 0xcc) | 0xaa;
+  uint32_t lo, hi;
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(lo)
+               : "r"(q), "n"(kLo), "n"(kEx), "n"(kImmLut));
+  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+               : "=r"(hi)
+               : "r"(q), "n"(kHi), "n"(kEx), "n"(kImmLut));
+  frag[0] = __hsub2(reinterpret_cast<__half2 const&>(lo),
+                    reinterpret_cast<__half2 const&>(kSub));
+  frag[1] = __hfma2(reinterpret_cast<__half2 const&>(hi),
+                    reinterpret_cast<__half2 const&>(kMul),
+                    reinterpret_cast<__half2 const&>(kAdd));
+}
+
+// u8b128 -> f16x2 pair dequant (marlin dequant<half2, kU8B128>).
+__device__ __forceinline__ void dequant_u8b128_f16x2(uint32_t q,
+                                                     __half2 frag[2]) {
+  static constexpr uint32_t kMask01 = 0x5250;
+  static constexpr uint32_t kMask23 = 0x5351;
+  static constexpr uint32_t kBase = 0x64646464;
+  static constexpr uint32_t kSub = 0x64806480;
+  const uint32_t lo = __byte_perm(q, kBase, kMask01);
+  const uint32_t hi = __byte_perm(q, kBase, kMask23);
+  frag[0] = __hsub2(reinterpret_cast<__half2 const&>(lo),
+                    reinterpret_cast<__half2 const&>(kSub));
+  frag[1] = __hsub2(reinterpret_cast<__half2 const&>(hi),
+                    reinterpret_cast<__half2 const&>(kSub));
+}
+
+// u8b128 -> bf16x2 pair dequant (marlin dequant<nv_bfloat162, kU8B128>, the
+// FasterTransformer fp32-bias idiom). Under the 8-bit pack interleave
+// {0,2,1,3} one word yields the same fragment pair as the 4-bit dequant of
+// one nibble plane: frag[0] = perm values (0,1), frag[1] = values (2,3).
+__device__ __forceinline__ void dequant_u8b128_bf16x2(uint32_t q,
+                                                      __nv_bfloat162 frag[2]) {
+  float f[4];
+  uint32_t* fc = reinterpret_cast<uint32_t*>(f);
+  static constexpr uint32_t kBase = 0x4B000000;
+  fc[0] = __byte_perm(q, kBase, 0x7650);
+  fc[1] = __byte_perm(q, kBase, 0x7652);
+  fc[2] = __byte_perm(q, kBase, 0x7651);
+  fc[3] = __byte_perm(q, kBase, 0x7653);
+  f[0] -= 8388736.f;
+  f[1] -= 8388736.f;
+  f[2] -= 8388736.f;
+  f[3] -= 8388736.f;
+  uint32_t* out = reinterpret_cast<uint32_t*>(frag);
+  out[0] = __byte_perm(fc[0], fc[1], 0x7632);
+  out[1] = __byte_perm(fc[2], fc[3], 0x7632);
+}
+
+}  // namespace swordfish_detail
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Same template signature as the stock CollectiveMma specialization (stock
+// lines 62-103) so the instantiation site can mirror the stock builder; a
+// standalone struct (the kernel layer dispatches on DispatchPolicy::Schedule
+// only).
+template <int Load2TransformPipelineStageCount_,
+          int Transform2MmaPipelineStageCount_,
+          int SchedulerPipelineStageCount_, int AccumulatorPipelineStageCount_,
+          class ClusterShape, class TileShape_, class ElementAOptionalTuple_,
+          class StridePairA_, class ElementBOptionalTuple_, class StrideB_,
+          class TiledMma_, class GmemTiledCopyA_, class SmemLayoutAtomsA_,
+          class CopyAtomsA_, class TransformA_, class GmemTiledCopyB_,
+          class SmemLayoutAtomsB_, class CopyAtomsB_, class TransformB_,
+          int WBits = 4>
+struct SwordfishMainloopSm100MixedInput {
+ public:
+  //
+  // Type Aliases (stock lines 105-263, SwapAB plumbing removed: the quantized
+  // operand is ALWAYS the A slot here)
+  //
+  using ConversionMode = cutlass::detail::ConversionMode;
+  using AtomThrShapeMNK =
+      Shape<decltype(shape<0>(typename TiledMma_::ThrLayoutVMNK{})), _1, _1>;
+  using DispatchPolicy = MainloopSm100TmaUmmaWarpSpecializedMixedInput<
+      Load2TransformPipelineStageCount_, Transform2MmaPipelineStageCount_,
+      SchedulerPipelineStageCount_, AccumulatorPipelineStageCount_,
+      ClusterShape>;
+  using TileShape = TileShape_;
+  using TiledMma = TiledMma_;
+  using KernelSchedule = typename DispatchPolicy::Schedule;
+  static constexpr bool IsDynamicCluster = not cute::is_static_v<ClusterShape>;
+  static_assert(!IsDynamicCluster,
+                "swordfish prefill v1 requires a static cluster");
+  static_assert(cute::is_same_v<ClusterShape, Shape<_1, _1, _1>> ||
+                    cute::is_same_v<ClusterShape, Shape<_2, _1, _1>>,
+                "swordfish prefill supports 1-SM (cluster 1x1x1) or 2-SM "
+                "(cluster 2x1x1) only");
+  using CtaShape_MNK = decltype(shape_div(TileShape{}, AtomThrShapeMNK{}));
+  // Number of CTAs the 2-SM MMA atom spans in the tile-M (weight-N) axis:
+  // 1 for the 1-SM atom, 2 for the 2-SM atom. Drives the per-CTA A split.
+  static constexpr int kAtomCtasM = size<0>(AtomThrShapeMNK{});
+
+  using ElementAOptionalTuple = ElementAOptionalTuple_;
+  using ElementBOptionalTuple = ElementBOptionalTuple_;
+  static_assert(cute::is_tuple<ElementAOptionalTuple>::value &&
+                    !cute::is_tuple<ElementBOptionalTuple>::value,
+                "swordfish prefill: quantized operand must ride the A slot "
+                "(pass {ElementA, ElementScale} for A)");
+
+  using ElementA = detail::deduce_mixed_width_dtype_t<0, ElementAOptionalTuple>;
+  using ElementB = detail::deduce_mixed_width_dtype_t<0, ElementBOptionalTuple>;
+  static constexpr bool IsATransformed = true;
+  using ElementScale =
+      detail::deduce_mixed_width_dtype_t<1, ElementAOptionalTuple>;
+  using ElementZero =
+      detail::deduce_mixed_width_dtype_t<2, ElementAOptionalTuple>;
+  using NonVoidElementScale =
+      cute::conditional_t<cute::is_void_v<ElementScale>, float, ElementScale>;
+  using NonVoidElementZero =
+      cute::conditional_t<cute::is_void_v<ElementZero>, float, ElementZero>;
+
+  // The packed operand is staged as raw bytes.
+  static_assert(cute::is_same_v<ElementA, uint8_t>,
+                "swordfish prefill: pass uint8_t as the (packed) A element");
+  // Zero-point checkpoints (AWQ/HQQ) pass a third element in the A tuple.
+  // The zero tensor holds prescaled (8 - zp) * scale rows, scale-shaped and
+  // scale-typed, so it rides the scale TMA machinery verbatim and the
+  // transform's scaling multiply becomes an fma.
+  static constexpr bool HasZp = !cute::is_void_v<ElementZero>;
+  static_assert(!HasZp || cute::is_same_v<ElementZero, ElementScale>,
+                "swordfish prefill zero points are scale-typed (8 - zp) * s");
+
+  using StrideA = cute::remove_cvref_t<decltype(get<0>(StridePairA_{}))>;
+  using LayoutScale = cute::remove_cvref_t<decltype(get<1>(StridePairA_{}))>;
+  using InternalStrideA = cute::remove_pointer_t<StrideA>;
+  using StrideB = StrideB_;
+  using InternalStrideB = cute::remove_pointer_t<StrideB>;
+
+  using CtaShapeA_MK = decltype(partition_shape_A(
+      TiledMma{}, make_shape(size<0>(TileShape{}), size<2>(TileShape{}))));
+  using CtaShapeB_NK = decltype(partition_shape_B(
+      TiledMma{}, make_shape(size<1>(TileShape{}), size<2>(TileShape{}))));
+
+  using ElementAMma = typename TiledMma::ValTypeA;
+  using ElementBMma = typename TiledMma::ValTypeB;
+  static constexpr bool kActF16 = cute::is_same_v<ElementAMma, cutlass::half_t>;
+  static_assert(kActF16 || cute::is_same_v<ElementAMma, cutlass::bfloat16_t>,
+                "swordfish prefill dequantizes to fp16 or bf16");
+  static_assert(cute::is_same_v<NonVoidElementScale, ElementAMma>,
+                "swordfish prefill group scales match the activation dtype");
+  // Register pair type matching ElementAMma for the transform.
+  using Elem2 = cute::conditional_t<kActF16, __half2, __nv_bfloat162>;
+
+  using ElementAccumulator = typename TiledMma::ValTypeC;
+
+  using GmemTiledCopyA = GmemTiledCopyA_;
+  using GmemTiledCopyB = GmemTiledCopyB_;
+  using GmemTiledCopyScale = GmemTiledCopyA_;
+
+  using SmemLayoutAtomsA = SmemLayoutAtomsA_;
+  using SmemLayoutAtomsB = SmemLayoutAtomsB_;
+  using CopyAtomsA = CopyAtomsA_;
+  using CopyAtomsB = CopyAtomsB_;
+
+  using SmemLayoutAtomACompute = typename SmemLayoutAtomsA::ComputeLayoutAtom;
+  using SmemLayoutAtomB = typename SmemLayoutAtomsB::InputLayoutAtom;
+
+  using TmaElementA = uint8_t;
+
+  using ArchTag = typename DispatchPolicy::ArchTag;
+
+  using Load2TransformPipeline = cutlass::PipelineTmaTransformAsync<
+      DispatchPolicy::Load2TransformPipelineStageCount, AtomThrShapeMNK>;
+  using Load2TransformPipelineState =
+      typename Load2TransformPipeline::PipelineState;
+
+  using Load2MmaPipeline = cutlass::PipelineTmaUmmaAsync<
+      DispatchPolicy::Load2TransformPipelineStageCount, ClusterShape,
+      AtomThrShapeMNK>;
+  using Load2MmaPipelineState = typename Load2MmaPipeline::PipelineState;
+
+  using Transform2MmaPipeline = cutlass::PipelineUmmaConsumerAsync<
+      DispatchPolicy::Transform2MmaPipelineStageCount, AtomThrShapeMNK>;
+  using Transform2MmaPipelineState =
+      typename Transform2MmaPipeline::PipelineState;
+
+  using Mma2AccumPipeline = cutlass::PipelineUmmaAsync<
+      DispatchPolicy::Schedule::AccumulatorPipelineStageCount, AtomThrShapeMNK>;
+  using Mma2AccumPipelineState = typename Mma2AccumPipeline::PipelineState;
+
+  // ---- scale layout machinery (stock lines 265-278, unchanged) --------------
+  static constexpr int ScaleGranularityMN = size<0, 0>(LayoutScale{});
+  static constexpr int ScaleGranularityK = size<1, 0>(LayoutScale{});
+  static_assert(ScaleGranularityMN == 1, "swordfish scales are per-column");
+  static_assert(ScaleGranularityK == 32 || ScaleGranularityK == 64 ||
+                    ScaleGranularityK == 128,
+                "swordfish prefill supports group sizes 32, 64 and 128");
+  // At granularity 32 a k64 sub-block spans two scale groups, so the
+  // transform keeps one register set per 32-row group of its share.
+  static constexpr int kScaleGroupsPerWarp = ScaleGranularityK == 32 ? 2 : 1;
+  using ScaleConfig =
+      cutlass::detail::Sm100MixedInputBlockwiseScaleConfig<ScaleGranularityMN,
+                                                           ScaleGranularityK>;
+
+  using ScaleTileShape =
+      decltype(make_shape(size<0>(TileShape{}), size<2>(TileShape{})));
+  using SmemLayoutAtomScaleFull =
+      decltype(ScaleConfig::smem_atom_layout_scale(ScaleTileShape{}));
+  using SmemLayoutAtomScale =
+      decltype(slice(make_coord(make_coord(_, 0), make_coord(_, 0)),
+                     SmemLayoutAtomScaleFull{}));
+
+  static_assert(cute::rank(SmemLayoutAtomB{}) == 2,
+                "SmemLayoutAtom must be rank 2 (M/N, K)");
+  static_assert((size<1>(TileShape{}) % size<0>(SmemLayoutAtomB{})) == 0,
+                "SmemLayoutAtom must evenly divide tile shape.");
+  static_assert((size<2>(TileShape{}) % size<1>(SmemLayoutAtomB{})) == 0,
+                "SmemLayoutAtom must evenly divide tile shape.");
+
+  // Thread counts (stock lines 292-294)
+  // Parametric transform width. The forked kernel layer derives its warp
+  // layout from this. 128 means one warp per packed block; 256 (one per half
+  // block) measured slightly worse on B200, so the transform is not the
+  // bottleneck there.
+  static constexpr uint32_t NumTransformationThreads = 128;
+  static constexpr uint32_t NumAccumThreads = 128;
+
+  constexpr static int AccumulatorPipelineStageCount =
+      DispatchPolicy::Schedule::AccumulatorPipelineStageCount;
+  constexpr static int StagesPerTile = size<2>(CtaShapeA_MK{});
+
+  // ---- Swordfish geometry
+  // ---------------------------------------------------- ABI v1 constants
+  // (swordfish_types.cuh; restated to keep this header dependent only on
+  // CUTLASS/CUDA).
+  static constexpr int kBlockN = 64;  // columns per packed block
+  static constexpr int kBlockK = 64;  // K rows per packed block
+  static_assert(WBits == 4 || WBits == 8, "swordfish weights are 4 or 8 bit");
+  static constexpr int kSubTileBytes = WBits == 8 ? 1024 : 512;  // 16x64 tile
+  static constexpr int kBlockBytes = 4 * kSubTileBytes;
+  static constexpr int kBlockRows = kBlockBytes / 256;  // TMA inner rows
+
+  // Full MMA-tile weight-N drives the packed-A gmem tiler so the tile
+  // coordinate matches the scheduler. Per-CTA weight-N drives the smem
+  // buffers, since each CTA of a 2-SM pair stages only its own half.
+  static constexpr int TileN_Weights_Full = size<0>(TileShape{});
+  static constexpr int CtaTileN_Weights = size<0>(CtaShape_MNK{});  // per-CTA
+  static constexpr int CtaTileK = size<2>(CtaShape_MNK{});
+  static_assert(
+      CtaTileN_Weights == 128 && CtaTileK == 128,
+      "swordfish prefill is tuned/asserted for a 128x128x128 CTA tile");
+  static constexpr int kBlocksPerTileN =
+      CtaTileN_Weights / kBlockN;                             // 2 (per CTA)
+  static constexpr int kBlocksPerTileK = CtaTileK / kBlockK;  // 2
+  static constexpr int kStageBytes =
+      kBlocksPerTileN * kBlocksPerTileK * kBlockBytes;  // 8192
+
+  // CHANGE (1): input staging is the packed byte stream, laid out
+  // (byte-lo, byte-hi, kb, nb, PIPE). Modes 0-1 pre-split the 2048 B block run
+  // so every TMA box extent is <= 256. Sized/tiled PER-CTA (128 weight-cols);
+  // in 2-SM the load loop maps the cluster's weight-N tile coord to this CTA's
+  // 128-col half via kAtomCtasM*coord + atom_half.
+  using SmemLayoutA = Layout<
+      Shape<_256, Int<kBlockRows>, Int<kBlocksPerTileK>, Int<kBlocksPerTileN>,
+            Int<DispatchPolicy::Load2TransformPipelineStageCount>>,
+      Stride<_1, _256, Int<kBlockBytes>, Int<kBlocksPerTileK * kBlockBytes>,
+             Int<kStageBytes>>>;
+  using SwordfishTilerA =
+      Shape<_256, Int<kBlockRows>, Int<kBlocksPerTileK>, Int<kBlocksPerTileN>>;
+
+  // B (activations) staging: stock (lines 320-323).
+  using SmemLayoutB = decltype(UMMA::tile_to_mma_shape(
+      SmemLayoutAtomB{},
+      append(CtaShapeB_NK{},
+             Int<DispatchPolicy::Load2TransformPipelineStageCount>{}),
+      (cute::conditional_t<cutlass::gemm::detail::is_mn_major<StrideB>(),
+                           Step<_2, _1, _3>, Step<_1, _2, _3>>{})));
+
+  // CHANGE (2): the compute buffer keeps the stock tcgen05-descriptor-legal
+  // core-matrix layout, but is built flat-first so the transform can address
+  // it by logical (n, k, stage) with a memory function IDENTICAL (by
+  // construction) to the MMA-facing grouped view.
+  // Per-CTA shape. Each CTA dequants only its own weight-N half.
+  using SmemLayoutAComputeMK = decltype(tile_to_shape(
+      SmemLayoutAtomACompute{},
+      make_shape(size<0>(CtaShape_MNK{}), size<2>(CtaShape_MNK{}),
+                 Int<DispatchPolicy::Transform2MmaPipelineStageCount>{}),
+      Step<_1, _2, _3>{}));
+  // Same regroup tile_to_mma_shape applies
+  // (cute/atom/mma_traits_sm100.hpp:116).
+  using SmemLayoutACompute = decltype(tiled_divide(
+      SmemLayoutAComputeMK{}, product_each(shape<0>(CtaShapeA_MK{}))));
+
+  // Closed-form of the compute buffer's memory function (element offset for
+  // logical (n, k, stage)), used by the transform's store path so each 32-bit
+  // store is one ADD instead of a hierarchical cute crd2idx evaluation. For
+  // the Sw<3,4,3> (8, 64):(64, 1) 16-bit-flagged atom tiled M-first
+  // (Step<_1,_2,_3>):
+  //   pre = (n%8)*64 + (k%64) + (n/8)*512 + (k/64)*8192 + stage*16384
+  //   off = pre XOR ((n%8) << 3)
+  // The swizzle of the smem_ptr_flag_bits<16> atom acts in the BYTE domain
+  // (element bits [3..6) ^= element bits [6..9) = n%8), matching the UMMA
+  // SWIZZLE_128B descriptor; evaluating the flagged ComposedLayout directly
+  // applies the swizzle in the wrong unit, so the static_asserts below pin
+  // the formula against the position-independent view (what the numerics
+  // verified end-to-end).
+  CUTLASS_HOST_DEVICE
+  static constexpr int compute_elem_offset(int n, int k, int stage) {
+    int const pre = (n & 7) * 64 + (k & 63) + (n >> 3) * 512 + (k >> 6) * 8192 +
+                    stage * 16384;
+    return pre ^ ((n & 7) << 3);
+  }
+  using SmemLayoutAComputePosInd =
+      decltype(as_position_independent_swizzle_tensor(
+                   make_tensor(
+                       make_smem_ptr(static_cast<ElementAMma*>(nullptr)),
+                       SmemLayoutAComputeMK{}))
+                   .layout());
+  static_assert(SmemLayoutAComputePosInd{}(0, 0, 0) ==
+                compute_elem_offset(0, 0, 0));
+  static_assert(SmemLayoutAComputePosInd{}(1, 0, 0) ==
+                compute_elem_offset(1, 0, 0));
+  static_assert(SmemLayoutAComputePosInd{}(9, 8, 0) ==
+                compute_elem_offset(9, 8, 0));
+  static_assert(SmemLayoutAComputePosInd{}(3, 17, 1) ==
+                compute_elem_offset(3, 17, 1));
+  static_assert(SmemLayoutAComputePosInd{}(77, 101, 1) ==
+                compute_elem_offset(77, 101, 1));
+  static_assert(SmemLayoutAComputePosInd{}(127, 127, 0) ==
+                compute_elem_offset(127, 127, 0));
+  static_assert(SmemLayoutAComputePosInd{}(64, 64, 0) ==
+                compute_elem_offset(64, 64, 0));
+  static_assert(SmemLayoutAComputePosInd{}(15, 40, 0) ==
+                compute_elem_offset(15, 40, 0));
+
+  // Scale staging: stock (lines 325-328).
+  using SmemLayoutScale = decltype(UMMA::tile_to_mma_shape(
+      SmemLayoutAtomScale{},
+      append(CtaShapeA_MK{},
+             Int<DispatchPolicy::Load2TransformPipelineStageCount>{}),
+      Step<_1, _2, _3>{}));
+  static constexpr int kScalesPerStage = cosize(take<0, 3>(SmemLayoutScale{}));
+  static constexpr int kScaleKGroupsPerStage = CtaTileK / ScaleGranularityK;
+  static_assert(kScalesPerStage == CtaTileN_Weights * kScaleKGroupsPerStage,
+                "unexpected scale smem layout");
+
+  static_assert(DispatchPolicy::Load2TransformPipelineStageCount >= 2 &&
+                    DispatchPolicy::Transform2MmaPipelineStageCount >= 2,
+                "Specialization requires Stages set to value 2 or more.");
+  // SS MMA only: A operand consumed from SMEM through a descriptor.
+  static_assert(
+      cute::is_base_of<cute::UMMA::DescriptorIterator,
+                       typename TiledMma::FrgTypeA>::value &&
+          cute::is_base_of<cute::UMMA::DescriptorIterator,
+                           typename TiledMma::FrgTypeB>::value,
+      "swordfish prefill requires an SS UMMA atom (A and B from SMEM)");
+  static_assert(cute::is_same_v<GmemTiledCopyA, SM90_TMA_LOAD>,
+                "swordfish prefill v1 uses plain (non-multicast) TMA for the "
+                "packed operand");
+
+  static constexpr ConversionMode KernelConversionMode =
+      ConversionMode::ConvertAndScale;
+  static constexpr bool ModeHasScales = true;
+
+  static constexpr size_t SmemAlignmentA = 1024;
+  static constexpr size_t SmemAlignmentB =
+      cutlass::detail::alignment_for_swizzle(SmemLayoutB{});
+
+  struct PipelineStorage {
+    using Load2TransformPipelineStorage =
+        typename Load2TransformPipeline::SharedStorage;
+    alignas(16) Load2TransformPipelineStorage load2transform_pipeline;
+    using Load2MmaPipelineStorage = typename Load2MmaPipeline::SharedStorage;
+    alignas(16) Load2MmaPipelineStorage load2mma_pipeline;
+    using Transform2MmaPipelineStorage =
+        typename Transform2MmaPipeline::SharedStorage;
+    alignas(16) Transform2MmaPipelineStorage transform2mma_pipeline;
+    using Mma2AccumPipelineStorage = typename Mma2AccumPipeline::SharedStorage;
+    alignas(16) Mma2AccumPipelineStorage mma2accum_pipeline;
+  };
+
+  struct SharedStorage {
+    struct TensorStorage : cute::aligned_struct<128, _0> {
+      struct TensorStorageUntransformed {
+        alignas(1024)
+            cute::ArrayEngine<uint8_t, cute::cosize_v<SmemLayoutA>> smem_A;
+        alignas(1024)
+            cute::ArrayEngine<ElementB, cute::cosize_v<SmemLayoutB>> smem_B;
+        cute::ArrayEngine<NonVoidElementScale, cute::cosize_v<SmemLayoutScale>>
+            smem_scale;
+        cute::ArrayEngine<NonVoidElementScale,
+                          HasZp ? cute::cosize_v<SmemLayoutScale> : 1>
+            smem_zero;
+      };
+      struct TensorStorageTransformed {
+        alignas(1024) cute::ArrayEngine<
+            ElementAMma, cute::cosize_v<SmemLayoutACompute>> smem_ACompute;
+      };
+      TensorStorageUntransformed input;
+      TensorStorageTransformed compute;
+    } tensors;
+    PipelineStorage pipeline;
+  };
+  using TensorStorage = typename SharedStorage::TensorStorage;
+
+  // Per-stage mbarrier transaction bytes: packed bytes + scales. Only TMA
+  // bytes count here (the transform's smem stores arrive through the
+  // transform2mma pipeline and not this barrier, per the stock collective's
+  // mbarrier caution).
+  static constexpr uint32_t kScaleTxBytes = cutlass::bits_to_bytes(
+      kScalesPerStage * cute::sizeof_bits_v<NonVoidElementScale>);
+  static constexpr uint32_t TmaTransactionBytes_A =
+      kStageBytes + kScaleTxBytes * (HasZp ? 2 : 1);
+  // AtomThrShape-scaled as in stock. The cta_group::2 TMA loads both CTAs'
+  // B halves with one instruction and its arrival, covering both halves'
+  // bytes, lands on the MMA leader's barrier. In 1-SM this reduces to one
+  // tile.
+  static constexpr uint32_t TmaTransactionBytes_B = cutlass::bits_to_bytes(
+      size(AtomThrShapeMNK{}) * cosize(take<0, 3>(SmemLayoutB{})) *
+      cute::sizeof_bits_v<ElementB>);
+  static constexpr uint32_t TmaTransactionBytes =
+      TmaTransactionBytes_A + TmaTransactionBytes_B;
+
+  // Host side kernel arguments (stock lines 424-432; ptr_A is the packed ABI
+  // tensor base; dA is carried for interface parity but the packed layout is
+  // derived from the problem shape).
+  struct Arguments {
+    ElementA const* ptr_A{nullptr};
+    StrideA dA{};
+    ElementB const* ptr_B{nullptr};
+    StrideB dB{};
+    ElementScale const* ptr_S{nullptr};
+    LayoutScale layout_S{};
+    ElementZero const* ptr_Z{nullptr};  // scale-shaped (8 - zp) * scale rows
+  };
+
+  // Device side kernel params
+  struct Params {
+    using ClusterLayout_VMNK =
+        decltype(tiled_divide(make_layout(ClusterShape{}),
+                              make_tile(typename TiledMma::AtomThrID{})));
+
+    // CHANGE (1): TMA over the packed byte tensor (256, 8, KB, NB).
+    using GmemLayoutAPacked =
+        Layout<Shape<_256, Int<kBlockRows>, int32_t, int32_t>,
+               Stride<_1, _256, Int<kBlockBytes>, int64_t>>;
+    using TMA_A = decltype(make_tma_copy(
+        GmemTiledCopyA{},
+        make_tensor(make_gmem_ptr(static_cast<uint8_t const*>(nullptr)),
+                    GmemLayoutAPacked{}),
+        SmemLayoutA{}(_, _, _, _, cute::Int<0>{})));
+
+    using TMA_B = decltype(make_tma_atom_B_sm100<ElementB>(
+        GmemTiledCopyB{},
+        make_tensor(static_cast<ElementB const*>(nullptr),
+                    repeat_like(StrideB{}, int32_t(0)), StrideB{}),
+        SmemLayoutB{}(_, _, _, cute::Int<0>{}), TileShape{}, TiledMma{},
+        ClusterLayout_VMNK{}));
+
+    using TMA_Scale = decltype(make_tma_atom_A_sm100(
+        GmemTiledCopyScale{},
+        make_tensor(static_cast<NonVoidElementScale const*>(nullptr),
+                    LayoutScale{}),
+        SmemLayoutScale{}(_, _, _, cute::Int<0>{}), TileShape{}, TiledMma{},
+        ClusterLayout_VMNK{}));
+
+    TMA_A tma_load_a;
+    TMA_B tma_load_b;
+    TMA_Scale tma_load_scale;
+    TMA_Scale tma_load_zero;  // constructed over ptr_Z (layout shared with S)
+    uint32_t tma_transaction_bytes{TmaTransactionBytes};
+    int32_t blocks_k{0};  // KB = K / 64
+    int32_t blocks_n{0};  // NB = N_weights / 64
+  };
+
+  CUTLASS_DEVICE
+  SwordfishMainloopSm100MixedInput(Params const& params, ClusterShape,
+                                   uint32_t block_rank_in_cluster)
+      : observed_tma_load_a_(&params.tma_load_a),
+        observed_tma_load_b_(&params.tma_load_b),
+        block_rank_in_cluster_(block_rank_in_cluster) {}
+
+  template <class ProblemShape>
+  static constexpr Params to_underlying_arguments(
+      ProblemShape const& problem_shape, Arguments const& args, void* workspace,
+      cutlass::KernelHardwareInfo const& hw_info =
+          cutlass::KernelHardwareInfo{}) {
+    (void)workspace;
+    (void)hw_info;
+
+    auto problem_shape_MNKL = append<4>(problem_shape, 1);
+    auto [M, N, K, L] = problem_shape_MNKL;  // M = weight N (swapped operands)
+
+    int32_t const blocks_k = int32_t(K / kBlockK);
+    int32_t const blocks_n = int32_t(M / kBlockN);
+
+    // Packed operand as a dense byte tensor (ABI invariant I3).
+    auto gA_layout =
+        make_layout(make_shape(_256{}, Int<kBlockRows>{}, blocks_k, blocks_n),
+                    make_stride(_1{}, _256{}, Int<kBlockBytes>{},
+                                int64_t(kBlockBytes) * blocks_k));
+    Tensor tensor_a = make_tensor(
+        make_gmem_ptr(reinterpret_cast<uint8_t const*>(args.ptr_A)), gA_layout);
+    typename Params::TMA_A tma_load_a = make_tma_copy(
+        GmemTiledCopyA{}, tensor_a, SmemLayoutA{}(_, _, _, _, cute::Int<0>{}));
+
+    Tensor tensor_b =
+        make_tensor(args.ptr_B, make_layout(make_shape(N, K, L), args.dB));
+    auto cluster_layout_vmnk = tiled_divide(
+        make_layout(ClusterShape{}), make_tile(typename TiledMma::AtomThrID{}));
+
+    typename Params::TMA_B tma_load_b = make_tma_atom_B_sm100<ElementB>(
+        GmemTiledCopyB{}, tensor_b, SmemLayoutB{}(_, _, _, cute::Int<0>{}),
+        TileShape{}, TiledMma{}, cluster_layout_vmnk);
+
+    Tensor tensor_scale =
+        make_tensor(detail::get_logical_ptr(args.ptr_S), args.layout_S);
+    typename Params::TMA_Scale tma_load_scale =
+        make_tma_atom_A_sm100(GmemTiledCopyScale{}, tensor_scale,
+                              SmemLayoutScale{}(_, _, _, cute::Int<0>{}),
+                              TileShape{}, TiledMma{}, cluster_layout_vmnk);
+
+    Tensor tensor_zero = make_tensor(
+        detail::get_logical_ptr(
+            reinterpret_cast<NonVoidElementScale const*>(args.ptr_Z)),
+        args.layout_S);
+    typename Params::TMA_Scale tma_load_zero =
+        make_tma_atom_A_sm100(GmemTiledCopyScale{}, tensor_zero,
+                              SmemLayoutScale{}(_, _, _, cute::Int<0>{}),
+                              TileShape{}, TiledMma{}, cluster_layout_vmnk);
+
+    return {tma_load_a,          tma_load_b, tma_load_scale, tma_load_zero,
+            TmaTransactionBytes, blocks_k,   blocks_n};
+  }
+
+  template <class ProblemShape>
+  static bool can_implement(ProblemShape const& problem_shape,
+                            Arguments const& args) {
+    auto problem_shape_MNKL = append<4>(problem_shape, 1);
+    auto [M, N, K, L] = problem_shape_MNKL;
+
+    bool implementable = true;
+    // ABI v1 tail policy: reject non-multiples (M here = weight N).
+    implementable &= (M % CtaTileN_Weights == 0);
+    implementable &= (K % CtaTileK == 0);
+    implementable &= (L == 1);
+    implementable &= (args.ptr_S != nullptr);
+    implementable &= ((args.ptr_Z != nullptr) == HasZp);
+
+    constexpr int tma_alignment_bits_B =
+        cutlass::detail::get_input_alignment_bits<ElementB>();
+    constexpr int min_tma_aligned_elements_B =
+        tma_alignment_bits_B / cutlass::sizeof_bits<ElementB>::value;
+    implementable &=
+        cutlass::detail::check_alignment<min_tma_aligned_elements_B>(
+            cute::make_shape(N, K, L), StrideB{});
+
+    if (!implementable) {
+      CUTLASS_TRACE_HOST(
+          "  CAN IMPLEMENT: swordfish prefill shape/argument requirements not "
+          "met.\n");
+    }
+    return implementable;
+  }
+
+  /// Issue Tma Descriptor Prefetch -- ideally from a single thread for best
+  /// performance
+  CUTLASS_DEVICE static void prefetch_tma_descriptors(Params const& params) {
+    cute::prefetch_tma_descriptor(params.tma_load_a.get_tma_descriptor());
+    cute::prefetch_tma_descriptor(params.tma_load_b.get_tma_descriptor());
+    cute::prefetch_tma_descriptor(params.tma_load_scale.get_tma_descriptor());
+    if constexpr (HasZp) {
+      cute::prefetch_tma_descriptor(params.tma_load_zero.get_tma_descriptor());
+    }
+  }
+
+  /// Construct A Single Stage's Accumulator Shape
+  CUTLASS_DEVICE auto partition_accumulator_shape() {
+    return partition_shape_C(TiledMma{}, take<0, 2>(TileShape{}));
+  }
+
+  /// Produce the inputs to the transform threads by loading inputs from gmem ->
+  /// smem. (stock lines 735-814; the A copy now walks the packed block tensor)
+  template <class GTensorA, class GTensorB, class GTensorPartitionedA,
+            class GTensorPartitionedB, class STensorA, class STensorB,
+            class TileCoordMNKL, class KTileIterator, class... Ts>
+  CUTLASS_DEVICE auto load_A(
+      Params const& params, Load2TransformPipeline load2xform_pipeline,
+      Load2TransformPipelineState load2xform_pipeline_state,
+      cute::tuple<GTensorA, GTensorB, GTensorPartitionedA, GTensorPartitionedB,
+                  STensorA, STensorB, uint16_t, uint16_t,
+                  cute::tuple<Ts...>> const& load_inputs,
+      TileCoordMNKL const& cta_coord_mnkl, KTileIterator k_tile_iter,
+      int k_tile_count) {
+    auto [unused_gA, unused_gB, tAgA_nk, tBgB_nkl, tAsA, tBsB, mcast_mask_a,
+          mcast_mask_b, extra_input_partitions] = load_inputs;
+
+    // tAgA_nk : ((TMA), 1, 1, K_TILES, N_TILES) over the packed byte tensor,
+    // tiled PER-CTA (128 weight-cols). Unlike the scales (multicast, routed
+    // through cta_mma.partition_A which applies the atom split), the packed A
+    // is DISJOINT across the 2-SM pair: each CTA loads its own 128-col half.
+    // So index the CTA's own 128-tile: AtomThrID*(base MMA tile) + atom half.
+    // Reduces to get<0>(cta_coord_mnkl) in the 1-SM case (AtomThrID size 1).
+    constexpr int kAtom = size(typename TiledMma::AtomThrID{});
+    const int a_ntile =
+        kAtom * (get<0>(cta_coord_mnkl) / kAtom) + int(block_rank_in_cluster_);
+    Tensor tAgA = tAgA_nk(_, _0{}, _0{}, _, a_ntile);
+
+    uint32_t skip_wait = (k_tile_count <= 0);
+    auto load2xform_pipeline_flag = load2xform_pipeline.producer_try_acquire(
+        load2xform_pipeline_state, skip_wait);
+
+    using BarrierType = typename Load2TransformPipeline::ProducerBarrierType;
+
+    CUTLASS_PRAGMA_NO_UNROLL
+    for (; k_tile_count > 0; --k_tile_count) {
+      load2xform_pipeline.producer_acquire(load2xform_pipeline_state,
+                                           load2xform_pipeline_flag);
+
+      int tile_A_write_stage = load2xform_pipeline_state.index();
+      BarrierType* load2xform_tma_barrier =
+          load2xform_pipeline.producer_get_barrier(load2xform_pipeline_state);
+
+      ++load2xform_pipeline_state;
+      skip_wait = (k_tile_count <= 1);
+      load2xform_pipeline_flag = load2xform_pipeline.producer_try_acquire(
+          load2xform_pipeline_state, skip_wait);
+
+      // TMA load: 4 packed blocks (2 nb x 2 kb) = one k tile of this CTA's
+      // weight stripe, plus the k tile's group scales.
+      copy(observed_tma_load_a_->with(*load2xform_tma_barrier, mcast_mask_a),
+           tAgA(_, *k_tile_iter), tAsA(_, tile_A_write_stage));
+
+      auto tSgS_mkl = get<0>(extra_input_partitions);
+      auto tSgS = tSgS_mkl(
+          _, get<0>(cta_coord_mnkl) / size(typename TiledMma::AtomThrID{}), _,
+          get<3>(cta_coord_mnkl));
+      auto tSsS = get<1>(extra_input_partitions);
+      copy(params.tma_load_scale.with(*load2xform_tma_barrier, mcast_mask_a),
+           tSgS(_, *k_tile_iter), tSsS(_, tile_A_write_stage));
+
+      if constexpr (HasZp) {
+        auto tZgZ_mkl = get<2>(extra_input_partitions);
+        auto tZgZ = tZgZ_mkl(
+            _, get<0>(cta_coord_mnkl) / size(typename TiledMma::AtomThrID{}), _,
+            get<3>(cta_coord_mnkl));
+        auto tZsZ = get<3>(extra_input_partitions);
+        copy(params.tma_load_zero.with(*load2xform_tma_barrier, mcast_mask_a),
+             tZgZ(_, *k_tile_iter), tZsZ(_, tile_A_write_stage));
+      }
+
+      ++k_tile_iter;
+    }
+
+    return cute::make_tuple(load2xform_pipeline_state, k_tile_iter);
+  }
+
+  /// (stock lines 816-876, unchanged: activations)
+  template <class GTensorA, class GTensorB, class GTensorPartitionedA,
+            class GTensorPartitionedB, class STensorA, class STensorB,
+            class TileCoordMNKL, class KTileIterator, class... Ts>
+  CUTLASS_DEVICE auto load_B(
+      Params const& params, Load2MmaPipeline load2mma_pipeline,
+      Load2MmaPipelineState load2mma_pipeline_state,
+      cute::tuple<GTensorA, GTensorB, GTensorPartitionedA, GTensorPartitionedB,
+                  STensorA, STensorB, uint16_t, uint16_t,
+                  cute::tuple<Ts...>> const& load_inputs,
+      TileCoordMNKL const& cta_coord_mnkl, KTileIterator k_tile_iter,
+      int k_tile_count) {
+    auto [unused_gA, unused_gB, tAgA_nk, tBgB_nkl, tAsA, tBsB, mcast_mask_a,
+          mcast_mask_b, extra_input_partitions] = load_inputs;
+
+    Tensor tBgB =
+        tBgB_nkl(_, get<1>(cta_coord_mnkl), _, get<3>(cta_coord_mnkl));
+
+    uint32_t skip_wait = (k_tile_count <= 0);
+    auto load2mma_pipeline_flag = load2mma_pipeline.producer_try_acquire(
+        load2mma_pipeline_state, skip_wait);
+
+    using BarrierType = typename Load2TransformPipeline::ProducerBarrierType;
+
+    CUTLASS_PRAGMA_NO_UNROLL
+    for (; k_tile_count > 0; --k_tile_count) {
+      load2mma_pipeline.producer_acquire(load2mma_pipeline_state,
+                                         load2mma_pipeline_flag);
+
+      int tile_B_write_stage = load2mma_pipeline_state.index();
+      BarrierType* load2mma_tma_barrier =
+          load2mma_pipeline.producer_get_barrier(load2mma_pipeline_state);
+
+      ++load2mma_pipeline_state;
+      skip_wait = (k_tile_count <= 1);
+      load2mma_pipeline_flag = load2mma_pipeline.producer_try_acquire(
+          load2mma_pipeline_state, skip_wait);
+
+      copy(observed_tma_load_b_->with(*load2mma_tma_barrier, mcast_mask_b),
+           tBgB(_, *k_tile_iter), tBsB(_, tile_B_write_stage));
+
+      ++k_tile_iter;
+    }
+
+    return cute::make_tuple(load2mma_pipeline_state, k_tile_iter);
+  }
+
+  /// Set up the data needed by this collective for load.
+  /// (stock lines 883-973; A partitioning swapped for the packed byte tensor)
+  template <class ProblemShape_MNKL>
+  CUTLASS_DEVICE auto load_init(ProblemShape_MNKL const& problem_shape_MNKL,
+                                Params const& params,
+                                TensorStorage& shared_storage) const {
+    auto [M, N, K, L] = problem_shape_MNKL;
+
+    auto [gA_mkl, gB_nkl] = tile_input_tensors(params, problem_shape_MNKL);
+
+    ThrMMA cta_mma =
+        TiledMma{}.get_slice(blockIdx.x % size(typename TiledMma::AtomThrID{}));
+
+    // ---- A: packed byte tensor, tiled by (256, 8, kb-per-tile, nb-per-tile).
+    Tensor mA_packed = observed_tma_load_a_->get_tma_tensor(
+        make_shape(_256{}, _8{}, params.blocks_k, params.blocks_n));
+    Tensor gA_packed = flat_divide(mA_packed, SwordfishTilerA{});
+    // (256, 8, KBt, NBt, 1, 1, K_TILES, N_TILES)
+
+    Tensor sA = make_tensor(make_smem_ptr(shared_storage.input.smem_A.begin()),
+                            SmemLayoutA{});
+    Tensor sB = make_tensor(make_smem_ptr(shared_storage.input.smem_B.begin()),
+                            SmemLayoutB{});
+
+    Layout cta_layout_mnk = make_layout(ClusterShape{});
+    Layout cta_layout_vmnk =
+        tiled_divide(cta_layout_mnk, make_tile(typename TiledMma::AtomThrID{}));
+    auto cta_coord_vmnk =
+        cta_layout_vmnk.get_flat_coord(block_rank_in_cluster_);
+
+    auto [tAgA_nk, tAsA] =
+        tma_partition(*observed_tma_load_a_, Int<0>{}, Layout<_1>{},
+                      group_modes<0, 4>(sA), group_modes<0, 4>(gA_packed));
+
+    Tensor tCgB_nkl = cta_mma.partition_B(gB_nkl);
+    auto [tBgB_nkl, tBsB] =
+        tma_partition(*observed_tma_load_b_, get<1>(cta_coord_vmnk),
+                      make_layout(size<1>(cta_layout_vmnk)),
+                      group_modes<0, 3>(sB), group_modes<0, 3>(tCgB_nkl));
+
+    uint16_t mcast_mask_a = 0;
+    uint16_t mcast_mask_b =
+        create_tma_multicast_mask<1>(cta_layout_vmnk, cta_coord_vmnk);
+
+    // ---- scales: stock path (lines 925-947).
+    Tensor mS_mkl = params.tma_load_scale.get_tma_tensor(shape(LayoutScale{}));
+    Tensor gS_mkl = local_tile(mS_mkl, TileShape{}, make_coord(_, _, _),
+                               Step<_1, cute::Underscore, _1>{});
+    Tensor sS =
+        make_tensor(make_smem_ptr(shared_storage.input.smem_scale.begin()),
+                    SmemLayoutScale{});
+    Tensor tCgS_mkl = cta_mma.partition_A(gS_mkl);
+
+    auto [tSgS_mkl, tSsS] =
+        tma_partition(params.tma_load_scale, get<2>(cta_coord_vmnk),
+                      make_layout(size<2>(cta_layout_vmnk)),
+                      group_modes<0, 3>(sS), group_modes<0, 3>(tCgS_mkl));
+
+    // Zero rows share the scale layout; the partitions are layout-only and
+    // never copied from when HasZp is false.
+    Tensor mZ_mkl = params.tma_load_zero.get_tma_tensor(shape(LayoutScale{}));
+    Tensor gZ_mkl = local_tile(mZ_mkl, TileShape{}, make_coord(_, _, _),
+                               Step<_1, cute::Underscore, _1>{});
+    Tensor sZ =
+        make_tensor(make_smem_ptr(shared_storage.input.smem_zero.begin()),
+                    SmemLayoutScale{});
+    Tensor tCgZ_mkl = cta_mma.partition_A(gZ_mkl);
+
+    auto [tZgZ_mkl, tZsZ] =
+        tma_partition(params.tma_load_zero, get<2>(cta_coord_vmnk),
+                      make_layout(size<2>(cta_layout_vmnk)),
+                      group_modes<0, 3>(sZ), group_modes<0, 3>(tCgZ_mkl));
+
+    return cute::make_tuple(gA_mkl, gB_nkl,  // for scheduler (shapes only)
+                            tAgA_nk, tBgB_nkl, tAsA,
+                            tBsB,  // for input tensor values
+                            mcast_mask_a, mcast_mask_b,  // multicast masks
+                            cute::make_tuple(tSgS_mkl, tSsS, tZgZ_mkl, tZsZ));
+  }
+
+  /// CHANGE (2): the Transform stage (stock lines 975-1059). Consumes the
+  /// packed bytes in Marlin tile order, dequantizes via the marlin u4b8 LOP3
+  /// sequences, applies group scales, and writes K-major bf16 into the
+  /// tcgen05 compute buffer.
+  ///
+  /// Thread assignment (128 threads, 4 warps; ABI read contract):
+  ///   warp w      <-> packed block (nb = w>>1, kb = w&1) of the k tile
+  ///   lane T      <-> words [4T, 4T+4) of each of the block's 4 sub-tiles
+  ///                   (one 16 B vector load per sub-tile)
+  ///   word 4T+j   ->  dequants to columns {16j+c, 16j+8+c} (c = T/4) at
+  ///                   k rows 16s + 2t + {0,1,8,9} (t = T%4) of the sub-tile.
+  template <class KTileIterator, class Accumulator, class GTensorA,
+            class SrcTensorA, class DstTensorA, class ScaleTensor,
+            class ZeroTensor>
+  CUTLASS_DEVICE auto transform(
+      Load2TransformPipeline load2transform_pipeline,
+      Load2TransformPipelineState load2transform_pipeline_consumer_state,
+      Transform2MmaPipeline transform2mma_pipeline,
+      Transform2MmaPipelineState transform2mma_pipeline_producer_state,
+      Accumulator accumulators,
+      cute::tuple<GTensorA, SrcTensorA, DstTensorA, ScaleTensor, ZeroTensor>
+          input_operands,
+      KTileIterator k_tile_iter, int k_tile_count) {
+    cutlass::arch::NamedBarrier transform_bar(
+        NumTransformationThreads,
+        cutlass::arch::ReservedNamedBarriers::TransformBarrier);
+
+    auto [unused_gA, sA, sACompute, sS, sZ] = input_operands;
+    uint8_t const* smem_a_base =
+        reinterpret_cast<uint8_t const*>(raw_pointer_cast(sA.data()));
+    NonVoidElementScale const* smem_s_base = raw_pointer_cast(sS.data());
+    NonVoidElementScale const* smem_z_base = raw_pointer_cast(sZ.data());
+    ElementAMma* smem_c_base = raw_pointer_cast(sACompute.data());
+
+    const int tid = threadIdx.x % NumTransformationThreads;
+    const int lane = tid % 32;
+    const int warp = tid / 32;
+    // Parametric width: kWarpsPerBlock warps share a packed block, each
+    // covering kSubTilesPerWarp of its 4 sub-tiles (4 warps -> whole block,
+    // 8 warps -> half each).
+    constexpr int kWarpsPerBlock = int(NumTransformationThreads) / 128;
+    constexpr int kSubTilesPerWarp = 4 / kWarpsPerBlock;
+    const int blk_id = warp / kWarpsPerBlock;
+    const int nbi = blk_id >> 1;  // n64 block within the 128-col stripe
+    const int kbi = blk_id & 1;   // k64 block within the k tile
+    const int sh = (warp % kWarpsPerBlock) * kSubTilesPerWarp;
+    const int c = lane >> 2;  // column octet within each n16 group
+    const int t = lane & 3;   // k-quad
+
+    // This warp's k rows fall in [kbi*64, kbi*64+64), one scale k-group for
+    // group sizes 64 and 128 and two consecutive groups at 32.
+    const int scale_kg = (kbi * kBlockK) / ScaleGranularityK;
+
+    // Per-thread compute-buffer addressing (see compute_elem_offset). The
+    // word (s, j) covers columns n = nbi*64 + 16j + 8b + c and rows
+    // k = kbi*64 + 16s + 2t + 8p, and n%8 == c for all of them, so the
+    // swizzle XOR mask (c << 3) is a per-thread constant confined to the
+    // (k%64) bits:
+    //   off = A(j,b) + (((16s + 8p) ^ (c<<3)) + 2t)
+    //   A   = c*64 + (nbi*8 + 2j + b)*512 + kbi*8192 + stage*16384
+    // Everything except the stage term is loop-invariant.
+    int klow[4][2];
+    CUTLASS_PRAGMA_UNROLL
+    for (int s = 0; s < 4; s++) {
+      klow[s][0] = ((16 * s) ^ (c << 3)) + 2 * t;
+      klow[s][1] = ((16 * s + 8) ^ (c << 3)) + 2 * t;
+    }
+    ElementAMma* const thread_c_base = smem_c_base + c * 64 + kbi * 8192;
+
+    uint32_t skip_wait = (k_tile_count <= 0);
+    auto load2transform_flag = load2transform_pipeline.consumer_try_wait(
+        load2transform_pipeline_consumer_state, skip_wait);
+    auto transform2mma_flag = transform2mma_pipeline.producer_try_acquire(
+        transform2mma_pipeline_producer_state, skip_wait);
+
+    CUTLASS_PRAGMA_NO_UNROLL
+    for (; k_tile_count > 0; --k_tile_count) {
+      load2transform_pipeline.consumer_wait(
+          load2transform_pipeline_consumer_state, load2transform_flag);
+      transform2mma_pipeline.producer_acquire(
+          transform2mma_pipeline_producer_state, transform2mma_flag);
+
+      int load2transform_consumer_index =
+          load2transform_pipeline_consumer_state.index();
+      int transform2mma_producer_index =
+          transform2mma_pipeline_producer_state.index();
+
+      auto curr_load2transform_pipeline_consumer_state =
+          load2transform_pipeline_consumer_state;
+      auto curr_transform2mma_pipeline_producer_state =
+          transform2mma_pipeline_producer_state;
+
+      // ---- pull this thread's packed words and scales into registers
+      // (this warp's share of the block: sub-tiles [sh, sh+kSubTilesPerWarp))
+      uint32_t w[kSubTilesPerWarp][WBits == 8 ? 8 : 4];
+      uint8_t const* blk = smem_a_base +
+                           load2transform_consumer_index * kStageBytes +
+                           (nbi * kBlocksPerTileK + kbi) * kBlockBytes +
+                           lane * (WBits == 8 ? 32 : 16);
+      CUTLASS_PRAGMA_UNROLL
+      for (int si = 0; si < kSubTilesPerWarp; si++) {
+        uint4 v =
+            *reinterpret_cast<uint4 const*>(blk + (sh + si) * kSubTileBytes);
+        w[si][0] = v.x;
+        w[si][1] = v.y;
+        w[si][2] = v.z;
+        w[si][3] = v.w;
+        if constexpr (WBits == 8) {
+          uint4 v1 = *reinterpret_cast<uint4 const*>(
+              blk + (sh + si) * kSubTileBytes + 16);
+          w[si][4] = v1.x;
+          w[si][5] = v1.y;
+          w[si][6] = v1.z;
+          w[si][7] = v1.w;
+        }
+      }
+
+      auto bcast2 = [](NonVoidElementScale v) {
+        if constexpr (kActF16) {
+          return __half2half2(reinterpret_cast<__half const&>(v));
+        } else {
+          return __bfloat162bfloat162(
+              reinterpret_cast<__nv_bfloat16 const&>(v));
+        }
+      };
+      // [group of the warp's share][j][column octet 0/1] broadcast pairs
+      Elem2 sreg[kScaleGroupsPerWarp][4][2];
+      Elem2 zreg[kScaleGroupsPerWarp][4][2];
+      CUTLASS_PRAGMA_UNROLL
+      for (int kg = 0; kg < kScaleGroupsPerWarp; kg++) {
+        NonVoidElementScale const* srow =
+            smem_s_base + load2transform_consumer_index * kScalesPerStage +
+            (scale_kg + kg) * CtaTileN_Weights + nbi * kBlockN;
+        CUTLASS_PRAGMA_UNROLL
+        for (int j = 0; j < 4; j++) {
+          sreg[kg][j][0] = bcast2(srow[16 * j + c]);
+          sreg[kg][j][1] = bcast2(srow[16 * j + 8 + c]);
+        }
+        if constexpr (HasZp) {
+          NonVoidElementScale const* zrow =
+              smem_z_base + load2transform_consumer_index * kScalesPerStage +
+              (scale_kg + kg) * CtaTileN_Weights + nbi * kBlockN;
+          CUTLASS_PRAGMA_UNROLL
+          for (int j = 0; j < 4; j++) {
+            zreg[kg][j][0] = bcast2(zrow[16 * j + c]);
+            zreg[kg][j][1] = bcast2(zrow[16 * j + 8 + c]);
+          }
+        }
+      }
+
+      // Loads from SMEM are done. Signal the mainloop load as early as possible
+      transform_bar.sync();
+      load2transform_pipeline.consumer_release(
+          curr_load2transform_pipeline_consumer_state);
+
+      // ---- dequant + scale + I5 stores (4x 32-bit per packed word)
+      ElementAMma* const stage_base =
+          thread_c_base + transform2mma_producer_index * 16384;
+      CUTLASS_PRAGMA_UNROLL
+      for (int si = 0; si < kSubTilesPerWarp; si++) {
+        const int s = sh + si;
+        // Sub-tile s covers k rows [16s, 16s+16); group index within the
+        // warp's register set (always 0 at granularity 64 and 128).
+        const int kg = kScaleGroupsPerWarp == 1 ? 0 : (s / 2) % 2;
+        CUTLASS_PRAGMA_UNROLL
+        for (int j = 0; j < 4; j++) {
+          ElementAMma* const row0 = stage_base + (nbi * 8 + 2 * j) * 512;
+          ElementAMma* const row1 = row0 + 512;
+          Elem2 f0[2], f1[2];
+          if constexpr (WBits == 8 && kActF16) {
+            swordfish_detail::dequant_u8b128_f16x2(w[si][2 * j], f0);
+            swordfish_detail::dequant_u8b128_f16x2(w[si][2 * j + 1], f1);
+          } else if constexpr (WBits == 8) {
+            swordfish_detail::dequant_u8b128_bf16x2(w[si][2 * j], f0);
+            swordfish_detail::dequant_u8b128_bf16x2(w[si][2 * j + 1], f1);
+          } else if constexpr (kActF16) {
+            swordfish_detail::dequant_u4b8_f16x2(w[si][j], f0);
+            swordfish_detail::dequant_u4b8_f16x2(w[si][j] >> 8, f1);
+          } else {
+            swordfish_detail::dequant_u4b8_bf16x2(w[si][j], f0);
+            swordfish_detail::dequant_u4b8_bf16x2(w[si][j] >> 8, f1);
+          }
+          if constexpr (HasZp) {
+            f0[0] = __hfma2(f0[0], sreg[kg][j][0], zreg[kg][j][0]);
+            f0[1] = __hfma2(f0[1], sreg[kg][j][0], zreg[kg][j][0]);
+            f1[0] = __hfma2(f1[0], sreg[kg][j][1], zreg[kg][j][1]);
+            f1[1] = __hfma2(f1[1], sreg[kg][j][1], zreg[kg][j][1]);
+          } else {
+            f0[0] = __hmul2(f0[0], sreg[kg][j][0]);
+            f0[1] = __hmul2(f0[1], sreg[kg][j][0]);
+            f1[0] = __hmul2(f1[0], sreg[kg][j][1]);
+            f1[1] = __hmul2(f1[1], sreg[kg][j][1]);
+          }
+          *reinterpret_cast<uint32_t*>(row0 + klow[s][0]) =
+              reinterpret_cast<uint32_t const&>(f0[0]);
+          *reinterpret_cast<uint32_t*>(row0 + klow[s][1]) =
+              reinterpret_cast<uint32_t const&>(f0[1]);
+          *reinterpret_cast<uint32_t*>(row1 + klow[s][0]) =
+              reinterpret_cast<uint32_t const&>(f1[0]);
+          *reinterpret_cast<uint32_t*>(row1 + klow[s][1]) =
+              reinterpret_cast<uint32_t const&>(f1[1]);
+        }
+      }
+
+      // Publish the generic STS to the async proxy the tcgen05 MMA reads
+      // through, then let the MMA know this stage is transformed.
+      cutlass::arch::fence_view_async_shared();
+      transform2mma_pipeline.producer_commit(
+          curr_transform2mma_pipeline_producer_state);
+
+      ++load2transform_pipeline_consumer_state;
+      ++transform2mma_pipeline_producer_state;
+
+      skip_wait = (k_tile_count <= 1);
+      load2transform_flag = load2transform_pipeline.consumer_try_wait(
+          load2transform_pipeline_consumer_state, skip_wait);
+      transform2mma_flag = transform2mma_pipeline.producer_try_acquire(
+          transform2mma_pipeline_producer_state, skip_wait);
+    }
+    return cute::make_tuple(load2transform_pipeline_consumer_state,
+                            transform2mma_pipeline_producer_state);
+  }
+
+  /// (stock lines 1061-1144, replaced. No tiled-copy plumbing, the transform
+  /// addresses the byte staging and the compute buffer directly)
+  template <class ProblemShape_MNKL, class Accumulator>
+  CUTLASS_DEVICE auto transform_init(
+      Params const& params, ProblemShape_MNKL const& problem_shape_MNKL,
+      Accumulator accumulators, TensorStorage& shared_storage) {
+    auto [gA_mkl, gB_nkl] = tile_input_tensors(params, problem_shape_MNKL);
+
+    Tensor sA = make_tensor(make_smem_ptr(shared_storage.input.smem_A.begin()),
+                            SmemLayoutA{});
+    Tensor sACompute = as_position_independent_swizzle_tensor(
+        make_tensor(make_smem_ptr(shared_storage.compute.smem_ACompute.begin()),
+                    SmemLayoutAComputeMK{}));
+    Tensor sS =
+        make_tensor(make_smem_ptr(shared_storage.input.smem_scale.begin()),
+                    SmemLayoutScale{});
+    Tensor sZ =
+        make_tensor(make_smem_ptr(shared_storage.input.smem_zero.begin()),
+                    SmemLayoutScale{});
+
+    return cute::make_tuple(gA_mkl, sA, sACompute, sS, sZ);
+  }
+
+  /// Perform a collective-scoped matrix multiply-accumulate: stock (lines
+  /// 1146-1232), SS descriptor path.
+  template <class FrgEngine, class FrgLayout, class TensorA, class TensorB>
+  CUTLASS_DEVICE auto mma(
+      Load2MmaPipeline load2mma_pipeline,
+      Load2MmaPipelineState load2mma_pipeline_consumer_state,
+      Transform2MmaPipeline transform2mma_pipeline,
+      Transform2MmaPipelineState transform2mma_pipeline_consumer_state,
+      Mma2AccumPipeline mma2accum_pipeline,
+      Mma2AccumPipelineState mma2accum_pipeline_producer_state,
+      cute::Tensor<FrgEngine, FrgLayout> const& accumulators,
+      cute::tuple<TensorA, TensorB> const& input_operands, int k_tile_count) {
+    TiledMma tiled_mma;
+
+    auto curr_load2mma_pipeline_consumer_state =
+        load2mma_pipeline_consumer_state;
+    auto next_load2mma_pipeline_consumer_state =
+        load2mma_pipeline_consumer_state;
+
+    auto curr_transform2mma_pipeline_consumer_state =
+        transform2mma_pipeline_consumer_state;
+    auto next_transform2mma_pipeline_consumer_state =
+        transform2mma_pipeline_consumer_state;
+
+    uint32_t skip_wait = (k_tile_count <= 0);
+    auto transform2mma_flag = transform2mma_pipeline.consumer_try_wait(
+        next_transform2mma_pipeline_consumer_state, skip_wait);
+    auto load2mma_flag = load2mma_pipeline.consumer_try_wait(
+        next_load2mma_pipeline_consumer_state, skip_wait);
+    ++next_transform2mma_pipeline_consumer_state;
+    ++next_load2mma_pipeline_consumer_state;
+
+    auto const [tCrA, tCrB] = input_operands;
+
+    mma2accum_pipeline.producer_acquire(mma2accum_pipeline_producer_state);
+
+    int mma2accum_pipeline_producer_state_index =
+        mma2accum_pipeline_producer_state.index();
+    auto tCtC = accumulators(_, _, _, mma2accum_pipeline_producer_state_index);
+    auto curr_mma2accum_pipeline_producer_state =
+        mma2accum_pipeline_producer_state;
+    ++mma2accum_pipeline_producer_state;
+
+    tiled_mma.accumulate_ = UMMA::ScaleOut::Zero;
+
+    CUTLASS_PRAGMA_NO_UNROLL
+    for (; k_tile_count > 0; --k_tile_count) {
+      load2mma_pipeline.consumer_wait(curr_load2mma_pipeline_consumer_state,
+                                      load2mma_flag);
+      transform2mma_pipeline.consumer_wait(
+          curr_transform2mma_pipeline_consumer_state, transform2mma_flag);
+
+      int load2mma_pipeline_consumer_state_index =
+          curr_load2mma_pipeline_consumer_state.index();
+      int transform2mma_pipeline_consumer_state_index =
+          curr_transform2mma_pipeline_consumer_state.index();
+
+      auto tCrA0 = tCrA(_, _, _, transform2mma_pipeline_consumer_state_index);
+      auto tCrB0 = tCrB(_, _, _, load2mma_pipeline_consumer_state_index);
+
+      CUTLASS_PRAGMA_UNROLL
+      for (int k_block = 0; k_block < size<2>(tCrA); k_block++) {
+        cute::gemm(tiled_mma, tCrA0(_, _, k_block), tCrB0(_, _, k_block), tCtC);
+        tiled_mma.accumulate_ = UMMA::ScaleOut::One;
+      }
+
+      load2mma_pipeline.consumer_release(curr_load2mma_pipeline_consumer_state);
+      transform2mma_pipeline.consumer_release(
+          curr_transform2mma_pipeline_consumer_state);
+
+      skip_wait = (k_tile_count <= 1);
+      load2mma_flag = load2mma_pipeline.consumer_try_wait(
+          next_load2mma_pipeline_consumer_state, skip_wait);
+      transform2mma_flag = transform2mma_pipeline.consumer_try_wait(
+          next_transform2mma_pipeline_consumer_state, skip_wait);
+
+      curr_load2mma_pipeline_consumer_state =
+          next_load2mma_pipeline_consumer_state;
+      curr_transform2mma_pipeline_consumer_state =
+          next_transform2mma_pipeline_consumer_state;
+
+      ++next_load2mma_pipeline_consumer_state;
+      ++next_transform2mma_pipeline_consumer_state;
+    }
+
+    mma2accum_pipeline.producer_commit(curr_mma2accum_pipeline_producer_state);
+
+    return cute::make_tuple(curr_load2mma_pipeline_consumer_state,
+                            curr_transform2mma_pipeline_consumer_state,
+                            mma2accum_pipeline_producer_state);
+  }
+
+  /// (stock lines 1234-1255; SS branch only)
+  template <class FrgEngine, class FrgLayout>
+  CUTLASS_DEVICE auto mma_init(
+      cute::Tensor<FrgEngine, FrgLayout> const& accumulators,
+      TensorStorage& shared_storage) const {
+    TiledMma tiled_mma;
+
+    Tensor sACompute =
+        make_tensor(make_smem_ptr(shared_storage.compute.smem_ACompute.begin()),
+                    SmemLayoutACompute{});
+    Tensor tCrA = tiled_mma.make_fragment_A(sACompute);
+
+    Tensor sB = make_tensor(make_smem_ptr(shared_storage.input.smem_B.begin()),
+                            SmemLayoutB{});
+    Tensor tCrB = tiled_mma.make_fragment_B(sB);
+    return cute::make_tuple(tCrA, tCrB);
+  }
+
+  template <class FrgEngine, class FrgLayout, class TmemCopyAtom,
+            class EpilogueTile>
+  CUTLASS_DEVICE auto accum_init(
+      cute::Tensor<FrgEngine, FrgLayout> const& accumulators,
+      TmemCopyAtom tmem_cp_atom, EpilogueTile epilogue_tile) {
+    return accumulators;
+  }
+
+ private:
+  /// gA_mkl slot 0 is only consumed for its SHAPE (the kernel derives the
+  /// k-tile count from shape<3>); return an identity tensor with the stock
+  /// tiled shape. gB_nkl is the stock activation tiling.
+  template <class ProblemShape_MNKL>
+  CUTLASS_DEVICE constexpr auto tile_input_tensors(
+      Params const& params, ProblemShape_MNKL const& problem_shape_MNKL) const {
+    using X = cute::Underscore;
+    auto [M, N, K, L] = problem_shape_MNKL;
+
+    auto gA_mkl = make_identity_tensor(
+        make_shape(size<0>(TileShape{}), size<2>(TileShape{}),
+                   ceil_div(M, size<0>(TileShape{})),
+                   ceil_div(K, size<2>(TileShape{})), L));
+
+    Tensor mB_nkl = observed_tma_load_b_->get_tma_tensor(make_shape(N, K, L));
+    Tensor gB_nkl =
+        local_tile(mB_nkl, TileShape{}, make_coord(_, _, _), Step<X, _1, _1>{});
+
+    return cute::make_tuple(gA_mkl, gB_nkl);
+  }
+
+  typename Params::TMA_A const* observed_tma_load_a_ = nullptr;
+  typename Params::TMA_B const* observed_tma_load_b_ = nullptr;
+  uint32_t block_rank_in_cluster_ = 0;
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace cutlass::gemm::collective
+
+/////////////////////////////////////////////////////////////////////////////////////////////////

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_prepack.cu
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_prepack.cu
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+// Packs a GPTQ int4 weight into the Swordfish ABI v1 block-linear layout
+//. Reuses the Marlin repack kernel for the in-tile
+// permutation, which ABI v1 adopts verbatim, then re-tiles its flat
+// [K/16, N*2] int32 layout into (NB, KB, 512) int32 blocks. Runs once at
+// weight load.
+
+#include <optional>
+
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/headeronly/util/Exception.h>
+
+#include "libtorch_stable/torch_utils.h"
+#include "swordfish_abi.cuh"
+
+// Defined in quantization/marlin/gptq_marlin_repack.cu (same extension).
+torch::stable::Tensor gptq_marlin_repack(torch::stable::Tensor& b_q_weight,
+                                         torch::stable::Tensor& perm,
+                                         int64_t size_k, int64_t size_n,
+                                         int64_t num_bits, bool is_a_8bit);
+
+namespace swordfish {
+
+namespace {
+
+// One CTA per output block: 512 threads gather the block's int32 words from
+// the flat Marlin layout (two words each at 8-bit). Writes are perfectly
+// coalesced; reads are tile-sized runs from 4 Marlin rows.
+template <int kTileInt32>
+__global__ void retile_marlin_to_blocks(const int32_t* __restrict__ marlin,
+                                        int32_t* __restrict__ out,
+                                        int64_t num_kb, int64_t size_n) {
+  constexpr int kWords = 4 * kTileInt32;
+  const int64_t nb = blockIdx.x;
+  const int64_t kb = blockIdx.y;
+  for (int w = threadIdx.x; w < kWords; w += kBlockInt32) {
+    const int64_t dst = (nb * num_kb + kb) * kWords + w;
+    out[dst] = marlin[marlin_word_index<kTileInt32>(nb, kb, w, size_n)];
+  }
+}
+
+}  // namespace
+
+torch::stable::Tensor swordfish_prepack_B(
+    torch::stable::Tensor& b_q_weight,
+    std::optional<torch::stable::Tensor> const& perm, int64_t size_k,
+    int64_t size_n, int64_t num_bits) {
+  STD_TORCH_CHECK(shape_ok(size_k, size_n), "swordfish ABI v1 requires K % ",
+                  kBlockK, " == 0 and N % ", kBlockN, " == 0; got K=", size_k,
+                  " N=", size_n, " (v1 tail policy: reject)");
+  STD_TORCH_CHECK(num_bits == 4 || num_bits == 8,
+                  "swordfish supports 4-bit and 8-bit weights");
+
+  const int32_t device_index = b_q_weight.get_device_index();
+  torch::stable::accelerator::DeviceGuard device_guard(device_index);
+  const cudaStream_t stream = get_current_cuda_stream(device_index);
+
+  // Stage 1: Marlin in-tile permutation. A non-empty perm applies the
+  // act_order row sort (g_idx argsort) during the repack.
+  torch::stable::Tensor perm_t =
+      perm.has_value()
+          ? *perm
+          : torch::stable::empty({0}, torch::headeronly::ScalarType::Int,
+                                 std::nullopt, b_q_weight.device());
+  torch::stable::Tensor marlin_flat =
+      gptq_marlin_repack(b_q_weight, perm_t, size_k, size_n, num_bits,
+                         /*is_a_8bit=*/false);
+
+  // Stage 2: re-tile to (NB, KB, 512|1024) int32 blocks.
+  const int64_t nb = num_blocks_n(size_n);
+  const int64_t kb = num_blocks_k(size_k);
+  const int64_t words = num_bits == 8 ? kBlockInt32_8 : kBlockInt32;
+  torch::stable::Tensor out =
+      torch::stable::empty({nb, kb, words}, torch::headeronly::ScalarType::Int,
+                           std::nullopt, b_q_weight.device());
+
+  dim3 grid(nb, kb);
+  if (num_bits == 8) {
+    retile_marlin_to_blocks<256><<<grid, kBlockInt32, 0, stream>>>(
+        reinterpret_cast<const int32_t*>(marlin_flat.const_data_ptr()),
+        reinterpret_cast<int32_t*>(out.mutable_data_ptr()), kb, size_n);
+  } else {
+    retile_marlin_to_blocks<128><<<grid, kBlockInt32, 0, stream>>>(
+        reinterpret_cast<const int32_t*>(marlin_flat.const_data_ptr()),
+        reinterpret_cast<int32_t*>(out.mutable_data_ptr()), kb, size_n);
+  }
+
+  return out;
+}
+
+}  // namespace swordfish
+
+STABLE_TORCH_LIBRARY_IMPL(gptqmodel_swordfish, CUDA, m) {
+  m.impl("swordfish_prepack_B", TORCH_BOX(&swordfish::swordfish_prepack_B));
+}

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_types.cuh
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_types.cuh
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+// Swordfish packed-weight ABI v1 constants and metadata. The ABI encodes
+// layout, quant metadata, alignment, and versioning only, never launch
+// geometry.
+#pragma once
+
+#include <cstdint>
+
+namespace swordfish {
+
+// ---- ABI v1 layout constants ------------------------------------------------
+inline constexpr int kAbiVersion = 1;
+inline constexpr int kTileLayoutId =
+    1;  // marlin16x64 / pack_idx{0,2,4,6,1,3,5,7}
+        // in (NB, KB, 2048B) block-linear order
+
+inline constexpr int kBlockN = 64;  // columns per packed block
+inline constexpr int kBlockK = 64;  // K rows per packed block
+inline constexpr int kMarlinTileK = 16;
+inline constexpr int kMarlinTileN = 64;
+inline constexpr int kSubTileBytes = 512;  // one marlin 16x64 int4 tile
+inline constexpr int kTilesPerBlock = kBlockK / kMarlinTileK;       // 4
+inline constexpr int kBlockBytes = kTilesPerBlock * kSubTileBytes;  // 2048
+inline constexpr int kBlockInt32 = kBlockBytes / 4;                 // 512
+
+// 8-bit blocks double every byte figure; the tile permutation is the same.
+inline constexpr int kSubTileBytes8 = 2 * kSubTileBytes;
+inline constexpr int kBlockBytes8 = 2 * kBlockBytes;
+inline constexpr int kBlockInt32_8 = 2 * kBlockInt32;
+
+// ---- schemes (metadata enums; v1 supports exactly one of each) --------------
+enum class WeightScheme : uint8_t { kU4B8 = 1, kU8B128 = 2 };
+enum class ScaleScheme : uint8_t {
+  kGroupContiguous = 1
+};  // [groups][N] fp16/bf16
+enum class ZpScheme : uint8_t { kNone = 0 };
+
+// feature_bits (all zero in v1)
+inline constexpr uint32_t kFeatHasZp = 1u << 0;
+inline constexpr uint32_t kFeatActOrder = 1u << 1;
+inline constexpr uint32_t kFeatPaddedTail = 1u << 2;
+
+// ---- shape rules (the v1 tail policy rejects non-multiples)
+// ------------------
+__host__ __device__ inline constexpr bool shape_ok(int64_t k, int64_t n) {
+  return k > 0 && n > 0 && (k % kBlockK) == 0 && (n % kBlockN) == 0;
+}
+__host__ __device__ inline constexpr int64_t num_blocks_n(int64_t n) {
+  return n / kBlockN;
+}
+__host__ __device__ inline constexpr int64_t num_blocks_k(int64_t k) {
+  return k / kBlockK;
+}
+
+}  // namespace swordfish

--- a/gptqmodel_ext/swordfish/libtorch_stable/torch_utils.h
+++ b/gptqmodel_ext/swordfish/libtorch_stable/torch_utils.h
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+#pragma once
+
+#ifndef USE_CUDA
+#define USE_CUDA
+#endif
+
+#include <torch/csrc/stable/c/shim.h>
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/ops.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/headeronly/util/shim_utils.h>
+
+#include <cuda_runtime.h>
+#include <cublas_v2.h>
+
+#include <deque>
+#include <mutex>
+#include <string>
+#include <vector>
+
+// Stable ABI equivalent of TORCH_CHECK_NOT_IMPLEMENTED.
+#define STD_TORCH_CHECK_NOT_IMPLEMENTED(cond, ...) \
+  STD_TORCH_CHECK(cond, "NotImplementedError: ", __VA_ARGS__)
+
+// Device properties cache for stable ABI compatibility.
+// Uses raw CUDA/HIP APIs instead of ATen functions.
+// Using inline ensures a single instance across all translation units.
+inline std::deque<std::once_flag> device_flags;
+inline std::vector<cudaDeviceProp> device_properties;
+inline std::once_flag vectors_init_flag;
+
+inline void do_init_device_vectors() {
+  int device_count;
+  cudaError_t err = cudaGetDeviceCount(&device_count);
+  if (err != cudaSuccess) {
+    STD_TORCH_CHECK(false, "cudaGetDeviceCount failed: " +
+                               std::string(cudaGetErrorString(err)));
+  }
+  device_flags.resize(device_count);
+  device_properties.resize(device_count);
+}
+
+inline void initDeviceVectors() {
+  std::call_once(vectors_init_flag, do_init_device_vectors);
+}
+
+inline void initDeviceProperty(int device_index) {
+  cudaDeviceProp device_prop{};
+  cudaError_t err = cudaGetDeviceProperties(&device_prop, device_index);
+  if (err != cudaSuccess) {
+    STD_TORCH_CHECK(false, "cudaGetDeviceProperties failed: " +
+                               std::string(cudaGetErrorString(err)));
+  }
+  device_properties[device_index] = device_prop;
+}
+
+// Get device properties using raw CUDA/HIP APIs (stable ABI compatible).
+// Caches results per device so cudaGetDeviceProperties is called at most once
+// per device.
+inline cudaDeviceProp* get_device_prop() {
+  initDeviceVectors();
+  int device_index;
+  cudaError_t err = cudaGetDevice(&device_index);
+  if (err != cudaSuccess) {
+    STD_TORCH_CHECK(
+        false, "cudaGetDevice failed: " + std::string(cudaGetErrorString(err)));
+  }
+  STD_TORCH_CHECK(device_index >= 0 && static_cast<size_t>(device_index) <
+                                           device_properties.size(),
+                  "CUDA device index " + std::to_string(device_index) +
+                      " out of range [0, " +
+                      std::to_string(device_properties.size()) + ")");
+
+  std::call_once(device_flags[device_index], initDeviceProperty, device_index);
+  return &device_properties[device_index];
+}
+
+// Utility to get the current CUDA stream for a given device using stable APIs.
+// Returns a cudaStream_t for use in kernel launches.
+inline cudaStream_t get_current_cuda_stream(int32_t device_index = -1) {
+  void* stream_ptr = nullptr;
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_get_current_cuda_stream(device_index, &stream_ptr));
+  return reinterpret_cast<cudaStream_t>(stream_ptr);
+}
+
+// Utility to get the current cuBLAS handle using stable APIs.
+inline cublasHandle_t get_current_cuda_blas_handle() {
+  void* blas_handle_ptr = nullptr;
+  TORCH_ERROR_CODE_CHECK(torch_get_current_cuda_blas_handle(&blas_handle_ptr));
+  return reinterpret_cast<cublasHandle_t>(blas_handle_ptr);
+}

--- a/gptqmodel_ext/swordfish/licenses/LICENSE
+++ b/gptqmodel_ext/swordfish/licenses/LICENSE
@@ -1,0 +1,662 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+
+    Copyright (C) {{ year }}  {{ organization }}
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.

--- a/gptqmodel_ext/swordfish/swordfish_arch_macros.cuh
+++ b/gptqmodel_ext/swordfish/swordfish_arch_macros.cuh
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+// Compatibility shim for CUTLASS 4.4 architecture-family macros.
+// CUTLASS 4.4 gates Blackwell TMA/tcgen05 features behind architecture-family
+// macros that are not always enabled for the sm_100/sm_103 targets we build.
+// This header is force-included by the Swordfish JIT build and enables the
+// family macros only in the device-code pass (__CUDA_ARCH__ is not defined
+// during the host pass, so host-side paths keep their stubs).
+
+#ifndef SWORDFISH_ARCH_MACROS_CUH
+#define SWORDFISH_ARCH_MACROS_CUH
+
+#if defined(__CUDA_ARCH__)
+#  if (__CUDA_ARCH__ == 1000)
+#    define CUTLASS_ARCH_MMA_SM100A_ENABLED 1
+#    define CUTLASS_ARCH_MMA_SM100F_ENABLED 1
+#    define CUTE_ARCH_TMA_SM100_ENABLED 1
+#  elif (__CUDA_ARCH__ == 1030)
+#    define CUTLASS_ARCH_MMA_SM103A_ENABLED 1
+#    define CUTLASS_ARCH_MMA_SM103F_ENABLED 1
+#    define CUTE_ARCH_TMA_SM100_ENABLED 1
+#  elif (__CUDA_ARCH__ == 1100)
+#    define CUTLASS_ARCH_MMA_SM110A_ENABLED 1
+#    define CUTLASS_ARCH_MMA_SM110F_ENABLED 1
+#    define CUTE_ARCH_TMA_SM100_ENABLED 1
+#  endif
+#endif
+
+#endif  // SWORDFISH_ARCH_MACROS_CUH

--- a/gptqmodel_ext/swordfish/swordfish_bindings.cpp
+++ b/gptqmodel_ext/swordfish/swordfish_bindings.cpp
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Vendored from https://github.com/dphnAI/sonar and used under the terms of
+// the GNU Affero General Public License v3.0 or later. See LICENSE in this
+// directory or /licenses/SWORDFISH at the project root for the full license.
+//
+// Stable ABI torch.op schema definitions for the Swordfish kernel family.
+
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/tensor.h>
+
+STABLE_TORCH_LIBRARY_FRAGMENT(gptqmodel_swordfish, ops) {
+  // Pack a GPTQ int4/int8 weight into the Swordfish ABI v1 block-linear
+  // layout. perm applies the act_order row sort during the repack.
+  ops.def(
+      "swordfish_prepack_B(Tensor b_q_weight, Tensor? perm, SymInt size_k, "
+      "SymInt size_n, int num_bits) -> Tensor");
+
+  // w4a16/w8a16 decode GEMM over the Swordfish ABI v1 packed weight.
+  // Activations are expected to already be in the group-sorted order that
+  // swordfish_prepack_B produced for the weight; group_zps holds prescaled
+  // (8 - zp) * scale per group when present.
+  ops.def(
+      "swordfish_mm(Tensor a, Tensor b_packed, Tensor group_scales, "
+      "Tensor? group_zps, int num_bits, int group_size, "
+      "SymInt size_k, SymInt size_n) -> Tensor");
+
+  // Dequantize Swordfish-packed weights to dense fp16/bf16, optionally
+  // out-major transposed and expert-stacked, for the dense tier.
+  ops.def(
+      "swordfish_dequant_dense(Tensor b_packed, Tensor group_scales, "
+      "Tensor? group_zps, int num_bits, int group_size, SymInt size_k, "
+      "SymInt size_n, bool transpose) -> Tensor");
+
+  // Fused-MoE decode GEMM over per-expert Swordfish ABI v1 weights.
+  ops.def(
+      "swordfish_moe_mm(Tensor a, Tensor b_packed, Tensor group_scales, "
+      "Tensor sorted_token_ids, Tensor expert_ids, "
+      "Tensor num_tokens_post_padded, Tensor? topk_weights, "
+      "int moe_block_size, int top_k, bool mul_topk_weights, int num_bits, "
+      "int group_size, SymInt size_k, SymInt size_n) -> Tensor");
+
+  // w4a16 prefill GEMM over the Swordfish ABI v1 packed weight.
+  ops.def(
+      "swordfish_prefill_mm(Tensor a, Tensor b_packed, Tensor group_scales, "
+      "Tensor? group_zps, int num_bits, int group_size, SymInt size_k, "
+      "SymInt size_n) -> Tensor");
+}

--- a/licenses/SWORDFISH
+++ b/licenses/SWORDFISH
@@ -1,0 +1,662 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+
+    Copyright (C) {{ year }}  {{ organization }}
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<http://www.gnu.org/licenses/>.

--- a/tests/kernels/test_awq.py
+++ b/tests/kernels/test_awq.py
@@ -26,6 +26,7 @@ from gptqmodel.nn_modules.qlinear.marlin_awq import (
     AwqMarlinLinear,
     marlin_import_exception,
 )
+from gptqmodel.nn_modules.qlinear.swordfish import AwqSwordfishLinear
 from gptqmodel.nn_modules.qlinear.torch_awq import AwqTorchLinear
 from gptqmodel.nn_modules.qlinear.torch_fused_awq import TorchFusedAwqLinear
 from gptqmodel.utils.logger import render_table
@@ -43,6 +44,10 @@ except Exception as exc:  # pragma: no cover - triton import may fail in CI
 from gptqmodel.nn_modules.qlinear.exllamav2_awq import AwqExllamaV2Linear
 from gptqmodel.utils.exllamav2 import ScratchSpace
 from gptqmodel.utils.machete import _validate_machete_device_support, machete_runtime_error
+from gptqmodel.utils.swordfish import (
+    _validate_swordfish_device_support,
+    swordfish_runtime_error,
+)
 
 
 os.environ.setdefault("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
@@ -88,6 +93,7 @@ class TestAwqKernelOutput(unittest.TestCase):
         (BACKEND.TRITON, torch.float16, 0.004),
         (BACKEND.MACHETE, torch.float16, 0.006),
         (BACKEND.MARLIN, torch.float16, AWQ_MARLIN_FP16_ATOL),
+        (BACKEND.SWORDFISH, torch.float16, 0.15),
         (BACKEND.TORCH_FUSED_AWQ, torch.float16, 0.004),
         # (BACKEND.MARLIN, torch.bfloat16, AWQ_MARLIN_BF16_ATOL),
         (BACKEND.EXLLAMA_V2, torch.float16, 0.0068),
@@ -106,6 +112,7 @@ class TestAwqKernelOutput(unittest.TestCase):
             cls.backend_skip_reason[BACKEND.TRITON] = "CUDA is required for AWQ Triton backend."
             cls.backend_skip_reason[BACKEND.MACHETE] = "CUDA is required for AWQ Machete kernel."
             cls.backend_skip_reason[BACKEND.MARLIN] = "CUDA is required for AWQ Marlin kernel."
+            cls.backend_skip_reason[BACKEND.SWORDFISH] = "CUDA is required for AWQ Swordfish kernel."
             cls.backend_skip_reason[BACKEND.EXLLAMA_V2] = "CUDA is required for ExLlama v2 AWQ kernel."
         elif not _validate_machete_device_support():
             cls.backend_skip_reason[BACKEND.MACHETE] = machete_runtime_error()
@@ -117,6 +124,9 @@ class TestAwqKernelOutput(unittest.TestCase):
             cls.backend_skip_reason[BACKEND.TRITON] = (
                 f"AWQ Triton kernel unavailable: {awq_triton_import_exception}"
             )
+
+        if cls.cuda_available and not _validate_swordfish_device_support():
+            cls.backend_skip_reason[BACKEND.SWORDFISH] = swordfish_runtime_error()
 
         try:
             tensors = cls._load_awq_tensors(cls.TARGET)
@@ -190,6 +200,16 @@ class TestAwqKernelOutput(unittest.TestCase):
             if cls.cuda_available
             else None
         )
+
+        try:
+            cls.modules[BACKEND.SWORDFISH] = (
+                cls._build_swordfish_module(qweight_cpu, qzeros_cpu, scales_cpu, bias_cpu)
+                if BACKEND.SWORDFISH not in cls.backend_skip_reason
+                else None
+            )
+        except Exception as exc:
+            cls.backend_skip_reason[BACKEND.SWORDFISH] = f"AWQ Swordfish kernel unavailable: {exc}"
+            cls.modules[BACKEND.SWORDFISH] = None
 
         try:
             cls.modules[BACKEND.TORCH_FUSED_AWQ] = cls._build_torch_fused_awq_module(
@@ -402,6 +422,36 @@ class TestAwqKernelOutput(unittest.TestCase):
             in_features=cls.in_features,
             out_features=cls.out_features,
             bias=True,
+            adapter=None,
+            register_buffers=True,
+        ).to(cls.device)
+
+        module.qweight.data.copy_(qweight_cpu.to(cls.device))
+        module.qzeros.data.copy_(qzeros_cpu.to(cls.device))
+        module.scales.data.copy_(scales_cpu.to(torch.float16).to(cls.device))
+        module.bias.data.copy_(bias_cpu.to(torch.float16).to(cls.device))
+
+        module.eval()
+        module.post_init()
+        return module
+
+    @classmethod
+    def _build_swordfish_module(
+        cls,
+        qweight_cpu: torch.Tensor,
+        qzeros_cpu: torch.Tensor,
+        scales_cpu: torch.Tensor,
+        bias_cpu: torch.Tensor,
+    ) -> Optional[AwqSwordfishLinear]:
+        module = AwqSwordfishLinear(
+            bits=cls.BITS,
+            group_size=cls.GROUP_SIZE,
+            sym=False,
+            desc_act=False,
+            in_features=cls.in_features,
+            out_features=cls.out_features,
+            bias=True,
+            dtype=torch.float16,
             adapter=None,
             register_buffers=True,
         ).to(cls.device)

--- a/tests/kernels/test_awq_swordfish.py
+++ b/tests/kernels/test_awq_swordfish.py
@@ -39,20 +39,32 @@ def _mock_awq_module_tensors(
     in_features: int,
     out_features: int,
     dtype: torch.dtype,
+    sym: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     groups = in_features // group_size
     maxq = (1 << bits) - 1
+    half_range = 1 << (bits - 1)
 
     float_weight = torch.randn(in_features, out_features, dtype=torch.float32) * 0.2
     weight_groups = float_weight.view(groups, group_size, out_features)
 
-    w_min = weight_groups.amin(dim=1)
-    w_max = weight_groups.amax(dim=1)
-    scales = ((w_max - w_min).clamp_min(1e-6) / maxq).to(dtype)
-    zero_points = torch.round((-w_min / scales.to(torch.float32))).clamp_(0, maxq).to(torch.int32)
-    quantized = torch.round(
-        weight_groups / scales.to(torch.float32).unsqueeze(1) + zero_points.unsqueeze(1)
-    ).clamp_(0, maxq).to(torch.int32)
+    if sym:
+        # Symmetric AWQ: center the range, store zero_point = half_range.
+        max_abs = weight_groups.abs().amax(dim=1)
+        max_abs[max_abs == 0] = 1.0
+        scales = (max_abs / (half_range - 1)).to(dtype)
+        zero_points = torch.full((groups, out_features), half_range, dtype=torch.int32)
+        quantized = torch.round(
+            weight_groups / scales.to(torch.float32).unsqueeze(1) + half_range
+        ).clamp_(0, maxq).to(torch.int32)
+    else:
+        w_min = weight_groups.amin(dim=1)
+        w_max = weight_groups.amax(dim=1)
+        scales = ((w_max - w_min).clamp_min(1e-6) / maxq).to(dtype)
+        zero_points = torch.round((-w_min / scales.to(torch.float32))).clamp_(0, maxq).to(torch.int32)
+        quantized = torch.round(
+            weight_groups / scales.to(torch.float32).unsqueeze(1) + zero_points.unsqueeze(1)
+        ).clamp_(0, maxq).to(torch.int32)
 
     qweight = _pack_awq_tensor(quantized.view(in_features, out_features), bits)
     qzeros = _pack_awq_tensor(zero_points, bits)
@@ -67,6 +79,7 @@ def _build_awq_module(
     device: torch.device,
     bits: int,
     group_size: int,
+    sym: bool,
     in_features: int,
     out_features: int,
     qweight: torch.Tensor,
@@ -78,7 +91,7 @@ def _build_awq_module(
     module = module_cls(
         bits=bits,
         group_size=group_size,
-        sym=False,
+        sym=sym,
         desc_act=False,
         in_features=in_features,
         out_features=out_features,
@@ -103,6 +116,7 @@ def _assert_awq_matches_torch(
     device: torch.device,
     bits: int,
     group_size: int,
+    sym: bool,
     in_features: int,
     out_features: int,
     dtype: torch.dtype,
@@ -116,6 +130,7 @@ def _assert_awq_matches_torch(
         in_features=in_features,
         out_features=out_features,
         dtype=dtype,
+        sym=sym,
     )
 
     baseline = _build_awq_module(
@@ -123,6 +138,7 @@ def _assert_awq_matches_torch(
         device=device,
         bits=bits,
         group_size=group_size,
+        sym=sym,
         in_features=in_features,
         out_features=out_features,
         qweight=qweight,
@@ -136,6 +152,7 @@ def _assert_awq_matches_torch(
         device=device,
         bits=bits,
         group_size=group_size,
+        sym=sym,
         in_features=in_features,
         out_features=out_features,
         qweight=qweight,
@@ -153,7 +170,8 @@ def _assert_awq_matches_torch(
             repeat = candidate(x)
         torch.cuda.synchronize(device)
 
-        assert candidate.qzeros.numel() > 0
+        if not sym:
+            assert candidate.qzeros.numel() > 0
         diff = (actual - expected).abs()
         max_err = diff.max().item()
         mae = diff.mean().item()
@@ -173,6 +191,7 @@ def test_awq_swordfish_cuda_matches_torch_awq_128():
         device=torch.device("cuda:0"),
         bits=4,
         group_size=128,
+        sym=False,
         in_features=256,
         out_features=128,
         dtype=torch.bfloat16,
@@ -192,6 +211,27 @@ def test_awq_swordfish_cuda_matches_torch_awq_64():
         device=torch.device("cuda:0"),
         bits=4,
         group_size=64,
+        sym=False,
+        in_features=256,
+        out_features=128,
+        dtype=torch.bfloat16,
+        atol=0.15,
+        rtol=0.05,
+    )
+
+
+@pytest.mark.cuda
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_awq_swordfish_cuda_matches_torch_awq_symmetric_128():
+    if not _validate_swordfish_device_support():
+        pytest.skip(swordfish_runtime_error())
+    prewarm_swordfish_extension()
+
+    _assert_awq_matches_torch(
+        device=torch.device("cuda:0"),
+        bits=4,
+        group_size=128,
+        sym=True,
         in_features=256,
         out_features=128,
         dtype=torch.bfloat16,

--- a/tests/kernels/test_awq_swordfish.py
+++ b/tests/kernels/test_awq_swordfish.py
@@ -1,17 +1,14 @@
-# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
 # SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
 
 from __future__ import annotations
 
 import pytest
 import torch
 
-from gptqmodel.nn_modules.qlinear.machete_awq import AwqMacheteLinear
-from gptqmodel.nn_modules.qlinear.marlin_awq import AwqMarlinLinear, marlin_import_exception
 from gptqmodel.nn_modules.qlinear.swordfish import AwqSwordfishLinear
 from gptqmodel.nn_modules.qlinear.torch_awq import AwqTorchLinear
-from gptqmodel.utils.machete import _validate_machete_device_support, machete_runtime_error
-from gptqmodel.utils.marlin import marlin_runtime_available, marlin_runtime_error
 from gptqmodel.utils.swordfish import (
     _validate_swordfish_device_support,
     prewarm_swordfish_extension,
@@ -41,6 +38,7 @@ def _mock_awq_module_tensors(
     group_size: int,
     in_features: int,
     out_features: int,
+    dtype: torch.dtype,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     groups = in_features // group_size
     maxq = (1 << bits) - 1
@@ -50,7 +48,7 @@ def _mock_awq_module_tensors(
 
     w_min = weight_groups.amin(dim=1)
     w_max = weight_groups.amax(dim=1)
-    scales = ((w_max - w_min).clamp_min(1e-6) / maxq).to(torch.float16)
+    scales = ((w_max - w_min).clamp_min(1e-6) / maxq).to(dtype)
     zero_points = torch.round((-w_min / scales.to(torch.float32))).clamp_(0, maxq).to(torch.int32)
     quantized = torch.round(
         weight_groups / scales.to(torch.float32).unsqueeze(1) + zero_points.unsqueeze(1)
@@ -58,7 +56,7 @@ def _mock_awq_module_tensors(
 
     qweight = _pack_awq_tensor(quantized.view(in_features, out_features), bits)
     qzeros = _pack_awq_tensor(zero_points, bits)
-    bias = torch.randn(out_features, dtype=torch.float16)
+    bias = torch.randn(out_features, dtype=dtype)
 
     return qweight, qzeros, scales, bias
 
@@ -75,6 +73,7 @@ def _build_awq_module(
     qzeros: torch.Tensor,
     scales: torch.Tensor,
     bias: torch.Tensor,
+    dtype: torch.dtype,
 ):
     module = module_cls(
         bits=bits,
@@ -85,27 +84,28 @@ def _build_awq_module(
         out_features=out_features,
         bias=True,
         register_buffers=True,
+        dtype=dtype,
     ).to(device)
 
     with torch.no_grad():
         module.qweight.copy_(qweight.to(device))
         module.qzeros.copy_(qzeros.to(device))
-        module.scales.copy_(scales.to(torch.float16).to(device))
-        module.bias.copy_(bias.to(torch.float16).to(device))
+        module.scales.copy_(scales.to(dtype).to(device))
+        module.bias.copy_(bias.to(dtype).to(device))
 
     module.post_init()
     module.eval()
     return module
 
 
-def _assert_awq_candidate_matches_torch(
-    module_cls,
+def _assert_awq_matches_torch(
     *,
     device: torch.device,
     bits: int,
     group_size: int,
     in_features: int,
     out_features: int,
+    dtype: torch.dtype,
     atol: float,
     rtol: float,
 ) -> None:
@@ -115,6 +115,7 @@ def _assert_awq_candidate_matches_torch(
         group_size=group_size,
         in_features=in_features,
         out_features=out_features,
+        dtype=dtype,
     )
 
     baseline = _build_awq_module(
@@ -128,9 +129,10 @@ def _assert_awq_candidate_matches_torch(
         qzeros=qzeros,
         scales=scales,
         bias=bias,
+        dtype=dtype,
     )
     candidate = _build_awq_module(
-        module_cls,
+        AwqSwordfishLinear,
         device=device,
         bits=bits,
         group_size=group_size,
@@ -140,72 +142,59 @@ def _assert_awq_candidate_matches_torch(
         qzeros=qzeros,
         scales=scales,
         bias=bias,
+        dtype=dtype,
     )
 
-    x = torch.randn((32, in_features), device=device, dtype=torch.float16)
-    with torch.inference_mode():
-        expected = baseline(x)
-        actual = candidate(x)
-        repeat = candidate(x)
-    torch.cuda.synchronize(device)
+    for m in (1, 8, 64):
+        x = torch.randn((m, in_features), device=device, dtype=dtype)
+        with torch.inference_mode():
+            expected = baseline(x)
+            actual = candidate(x)
+            repeat = candidate(x)
+        torch.cuda.synchronize(device)
 
-    assert candidate.qzeros.numel() > 0
-    torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+        assert candidate.qzeros.numel() > 0
+        diff = (actual - expected).abs()
+        max_err = diff.max().item()
+        mae = diff.mean().item()
+        assert max_err < atol, f"m={m}: max error {max_err} exceeds {atol}"
+        assert mae < rtol, f"m={m}: MAE {mae} exceeds {rtol}"
     torch.testing.assert_close(repeat, expected, atol=atol, rtol=rtol)
 
 
 @pytest.mark.cuda
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_awq_marlin_cuda_zero_points_match_torch_awq():
-    if marlin_import_exception is not None:
-        pytest.skip(f"AWQ Marlin kernel unavailable: {marlin_import_exception}")
-    if not marlin_runtime_available(torch.float16):
-        pytest.skip(marlin_runtime_error(torch.float16))
-
-    _assert_awq_candidate_matches_torch(
-        AwqMarlinLinear,
-        device=torch.device("cuda:0"),
-        bits=4,
-        group_size=64,
-        in_features=256,
-        out_features=128,
-        atol=8e-3,
-        rtol=8e-3,
-    )
-
-
-@pytest.mark.cuda
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_awq_machete_cuda_zero_points_match_torch_awq():
-    if not _validate_machete_device_support():
-        pytest.skip(machete_runtime_error())
-
-    _assert_awq_candidate_matches_torch(
-        AwqMacheteLinear,
-        device=torch.device("cuda:0"),
-        bits=4,
-        group_size=64,
-        in_features=128,
-        out_features=128,
-        atol=1e-2,
-        rtol=1e-2,
-    )
-
-
-@pytest.mark.cuda
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-def test_awq_swordfish_cuda_zero_points_match_torch_awq():
+def test_awq_swordfish_cuda_matches_torch_awq_128():
     if not _validate_swordfish_device_support():
         pytest.skip(swordfish_runtime_error())
     prewarm_swordfish_extension()
 
-    _assert_awq_candidate_matches_torch(
-        AwqSwordfishLinear,
+    _assert_awq_matches_torch(
         device=torch.device("cuda:0"),
         bits=4,
         group_size=128,
         in_features=256,
         out_features=128,
+        dtype=torch.bfloat16,
+        atol=0.15,
+        rtol=0.05,
+    )
+
+
+@pytest.mark.cuda
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_awq_swordfish_cuda_matches_torch_awq_64():
+    if not _validate_swordfish_device_support():
+        pytest.skip(swordfish_runtime_error())
+    prewarm_swordfish_extension()
+
+    _assert_awq_matches_torch(
+        device=torch.device("cuda:0"),
+        bits=4,
+        group_size=64,
+        in_features=256,
+        out_features=128,
+        dtype=torch.bfloat16,
         atol=0.15,
         rtol=0.05,
     )

--- a/tests/kernels/test_gptq.py
+++ b/tests/kernels/test_gptq.py
@@ -19,6 +19,7 @@ from gptqmodel.nn_modules.qlinear.bitblas import BitblasLinear
 from gptqmodel.nn_modules.qlinear.exllamav2 import ExllamaV2Linear
 from gptqmodel.nn_modules.qlinear.machete import MacheteLinear
 from gptqmodel.nn_modules.qlinear.marlin import MarlinLinear
+from gptqmodel.nn_modules.qlinear.swordfish import SwordfishLinear
 from gptqmodel.nn_modules.qlinear.torch import TorchLinear
 from gptqmodel.nn_modules.qlinear.tritonv2 import TritonV2Linear
 from gptqmodel.utils.logger import render_table
@@ -27,6 +28,10 @@ from gptqmodel.utils.machete import (
     machete_runtime_error,
 )
 from gptqmodel.utils.model import find_modules
+from gptqmodel.utils.swordfish import (
+    swordfish_runtime_available,
+    swordfish_runtime_error,
+)
 
 
 log = LogBar.shared()
@@ -74,6 +79,7 @@ class TestKernelOutput(unittest.TestCase):
     target_qliner_map = {
         BACKEND.TORCH: TorchLinear,
         BACKEND.MACHETE: MacheteLinear,
+        BACKEND.SWORDFISH: SwordfishLinear,
         BACKEND.EXLLAMA_V2: ExllamaV2Linear,
         BACKEND.TRITON: TritonV2Linear,
         BACKEND.BITBLAS: BitblasLinear,
@@ -308,6 +314,10 @@ class TestKernelOutput(unittest.TestCase):
             if not machete_runtime_available():
                 self.skipTest(f"Machete kernel unavailable: {machete_runtime_error()}")
 
+        if backend == BACKEND.SWORDFISH:
+            if not swordfish_runtime_available():
+                self.skipTest(f"Swordfish kernel unavailable: {swordfish_runtime_error()}")
+
     # Updated CUDA kernel tolerances below were re-baselined from full
     # torch-vs-kernel validation on H200.
     float16_cases = [
@@ -315,6 +325,7 @@ class TestKernelOutput(unittest.TestCase):
         (BACKEND.TRITON, torch.float16, 0.00001),
         (BACKEND.EXLLAMA_V2, torch.float16, 0.0068),
         (BACKEND.MACHETE, torch.float16, 0.0010),
+        (BACKEND.SWORDFISH, torch.float16, 0.0030),
         (BACKEND.MARLIN, torch.float16, 0.0010),
     ]
     if _bitblas_supports_gptq_case(torch.float16):
@@ -344,6 +355,7 @@ class TestKernelOutput(unittest.TestCase):
         (BACKEND.TRITON, torch.bfloat16, 0.00001),
         (BACKEND.EXLLAMA_V2, torch.bfloat16, 0.0080),
         (BACKEND.MACHETE, torch.bfloat16, 0.0080),
+        (BACKEND.SWORDFISH, torch.bfloat16, 0.0060),
         (BACKEND.MARLIN, torch.bfloat16, 0.0080),
     ]
     if _bitblas_supports_gptq_case(torch.bfloat16):
@@ -373,6 +385,7 @@ class TestKernelOutput(unittest.TestCase):
         (BACKEND.TRITON, torch.float16, 0.00001),
         (BACKEND.EXLLAMA_V2, torch.float16, 0.0065),
         (BACKEND.MACHETE, torch.float16, 0.0010),
+        (BACKEND.SWORDFISH, torch.float16, 0.0060),
         (BACKEND.MARLIN, torch.float16, 0.0020),
     ]
     if _bitblas_supports_gptq_case(torch.float16):
@@ -401,6 +414,7 @@ class TestKernelOutput(unittest.TestCase):
         (BACKEND.TRITON, torch.bfloat16, 0.00001),
         (BACKEND.EXLLAMA_V2, torch.bfloat16, 0.0160),
         (BACKEND.MACHETE, torch.bfloat16, 0.0080),
+        (BACKEND.SWORDFISH, torch.bfloat16, 0.0080),
         (BACKEND.MARLIN, torch.bfloat16, 0.0080),
     ]
     if _bitblas_supports_gptq_case(torch.bfloat16):

--- a/tests/kernels/test_swordfish.py
+++ b/tests/kernels/test_swordfish.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+import unittest
+
+import torch
+import torch.nn as nn
+from parameterized import parameterized
+
+from gptqmodel.nn_modules.qlinear.swordfish import SwordfishLinear
+from gptqmodel.nn_modules.qlinear.torch import TorchLinear
+from gptqmodel.utils.swordfish import (
+    prewarm_swordfish_extension,
+)
+
+
+def _skip_reason() -> str | None:
+    if not torch.cuda.is_available():
+        return "CUDA not available"
+    major, minor = torch.cuda.get_device_capability()
+    if major < 10:
+        return f"Swordfish requires Blackwell (sm100+); found sm{major}{minor}"
+    return None
+
+
+_SKIP_REASON = _skip_reason()
+
+
+def _quantize_sym(
+    weight: torch.Tensor,
+    bits: int,
+    group_size: int,
+    g_idx: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    out_features, in_features = weight.shape
+    half_range = 1 << (bits - 1)
+    if g_idx is None:
+        g_idx = (torch.arange(in_features, device=weight.device, dtype=torch.int32) // group_size)
+    num_groups = int(g_idx.max().item()) + 1
+
+    q = torch.empty_like(weight)
+    scales = torch.zeros((out_features, num_groups), dtype=weight.dtype, device=weight.device)
+    for g in range(num_groups):
+        mask = g_idx == g
+        block = weight[:, mask]
+        max_abs = block.abs().max(dim=1, keepdim=True).values
+        max_abs[max_abs == 0] = 1.0
+        scale = max_abs / (half_range - 1)
+        q_block = torch.round(block / scale).clamp(-(half_range), half_range - 1) + half_range
+        q[:, mask] = q_block
+        scales[:, g : g + 1] = scale
+
+    zeros = torch.full((out_features, num_groups), half_range, dtype=weight.dtype, device=weight.device)
+    return q, scales, zeros, g_idx
+
+
+def _pack_torch_reference(
+    bits: int,
+    group_size: int,
+    sym: bool,
+    desc_act: bool,
+    in_features: int,
+    out_features: int,
+    weight: torch.Tensor,
+    scales: torch.Tensor,
+    zeros: torch.Tensor,
+    g_idx: torch.Tensor,
+    bias: bool = False,
+) -> TorchLinear:
+    linear = nn.Linear(in_features, out_features, bias=bias, dtype=weight.dtype, device="cpu")
+    with torch.no_grad():
+        linear.weight.copy_(weight)
+
+    torch_linear = TorchLinear(
+        bits=bits,
+        group_size=group_size,
+        sym=sym,
+        desc_act=desc_act,
+        in_features=in_features,
+        out_features=out_features,
+        register_buffers=True,
+    )
+    torch_linear.pack(linear=linear, scales=scales, zeros=zeros, g_idx=g_idx)
+    torch_linear = torch_linear.to(device=weight.device)
+    torch_linear.post_init()
+    return torch_linear
+
+
+@unittest.skipIf(_SKIP_REASON is not None, _SKIP_REASON or "")
+class TestSwordfishKernel(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        prewarm_swordfish_extension()
+
+    def _copy_to_swordfish(self, torch_linear: TorchLinear) -> SwordfishLinear:
+        sf = SwordfishLinear(
+            bits=torch_linear.bits,
+            group_size=torch_linear.requested_group_size,
+            desc_act=torch_linear.desc_act,
+            sym=torch_linear.sym,
+            in_features=torch_linear.in_features,
+            out_features=torch_linear.out_features,
+            bias=False,
+            dtype=torch_linear.scales.dtype,
+        )
+        sf.qweight = nn.Parameter(torch_linear.qweight.data.detach().clone().contiguous(), requires_grad=False)
+        sf.scales = nn.Parameter(torch_linear.scales.data.detach().clone().contiguous(), requires_grad=False)
+        if torch_linear.g_idx is not None and torch_linear.g_idx.numel() > 0:
+            sf.g_idx = nn.Parameter(torch_linear.g_idx.data.detach().clone().contiguous(), requires_grad=False)
+        if torch_linear.qzeros is not None and torch_linear.qzeros.numel() > 0:
+            sf.qzeros = nn.Parameter(torch_linear.qzeros.data.detach().clone().contiguous(), requires_grad=False)
+        if torch_linear.bias is not None:
+            sf.bias = nn.Parameter(torch_linear.bias.data.detach().clone().contiguous(), requires_grad=False)
+        sf.post_init()
+        return sf
+
+    @parameterized.expand([
+        (4, 128, True, False, torch.bfloat16),
+        (4, -1, True, False, torch.bfloat16),
+        (4, 64, True, True, torch.bfloat16),
+        (4, 128, True, True, torch.bfloat16),
+        (4, 128, True, False, torch.bfloat16),
+    ])
+    def test_swordfish_matches_torch(self, bits, group_size, sym, desc_act, dtype):
+        in_features = 256
+        out_features = 512
+        device = torch.device("cuda:0")
+
+        torch.manual_seed(42)
+        weight = torch.randn((out_features, in_features), dtype=dtype, device="cpu") * 0.5
+        g_idx = None
+        if desc_act:
+            perm = torch.randperm(in_features)
+            weight = weight[:, perm]
+            g_idx = (torch.arange(in_features, dtype=torch.int32) // group_size)[perm]
+
+        effective_group_size = group_size if group_size > 0 else in_features
+        _, scales, zeros, g_idx = _quantize_sym(weight, bits, effective_group_size, g_idx)
+
+        torch_linear = _pack_torch_reference(
+            bits, group_size, sym, desc_act, in_features, out_features, weight, scales, zeros, g_idx
+        )
+        torch_linear = torch_linear.to(device)
+        sf = self._copy_to_swordfish(torch_linear)
+        sf = sf.to(device)
+
+        for m in (1, 8, 64):
+            x = torch.randn((m, in_features), dtype=dtype, device=device) * 0.5
+            with torch.no_grad():
+                ref = x @ torch_linear.dequantize_weight().to(dtype)
+                if torch_linear.bias is not None:
+                    ref = ref + torch_linear.bias.to(dtype)
+                out = sf(x)
+            diff = (out - ref).abs()
+            max_err = diff.max().item()
+            mae = diff.mean().item()
+            self.assertLess(max_err, 0.15, f"m={m}: max error too high ({max_err})")
+            self.assertLess(mae, 0.05, f"m={m}: MAE too high ({mae})")

--- a/tests/kernels/test_swordfish_speed.py
+++ b/tests/kernels/test_swordfish_speed.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+import os
+import unittest
+
+import torch
+import torch.nn as nn
+
+from gptqmodel.nn_modules.qlinear.swordfish import SwordfishLinear
+from gptqmodel.nn_modules.qlinear.torch import TorchLinear
+from gptqmodel.utils.swordfish import prewarm_swordfish_extension
+
+
+def _skip_reason() -> str | None:
+    if not torch.cuda.is_available():
+        return "CUDA not available"
+    major, minor = torch.cuda.get_device_capability()
+    if major < 10:
+        return f"Swordfish requires Blackwell (sm100+); found sm{major}{minor}"
+    return None
+
+
+_SKIP_REASON = _skip_reason()
+
+
+def _quantize_sym(weight: torch.Tensor, bits: int, group_size: int):
+    out_features, in_features = weight.shape
+    half_range = 1 << (bits - 1)
+    num_groups = in_features // group_size
+
+    q = torch.empty_like(weight)
+    scales = torch.zeros((out_features, num_groups), dtype=weight.dtype, device=weight.device)
+    for g in range(num_groups):
+        mask = slice(g * group_size, (g + 1) * group_size)
+        block = weight[:, mask]
+        max_abs = block.abs().max(dim=1, keepdim=True).values
+        max_abs[max_abs == 0] = 1.0
+        scale = max_abs / (half_range - 1)
+        q_block = torch.round(block / scale).clamp(-(half_range), half_range - 1) + half_range
+        q[:, mask] = q_block
+        scales[:, g : g + 1] = scale
+
+    zeros = torch.full((out_features, num_groups), half_range, dtype=weight.dtype, device=weight.device)
+    return q, scales, zeros
+
+
+def _pack_torch_reference(bits, group_size, in_features, out_features, weight, scales, zeros, device):
+    linear = nn.Linear(in_features, out_features, bias=False, dtype=weight.dtype, device="cpu")
+    with torch.no_grad():
+        linear.weight.copy_(weight)
+
+    torch_linear = TorchLinear(
+        bits=bits,
+        group_size=group_size,
+        sym=True,
+        desc_act=False,
+        in_features=in_features,
+        out_features=out_features,
+        register_buffers=True,
+    )
+    g_idx = (torch.arange(in_features, dtype=torch.int32) // group_size)
+    torch_linear.pack(linear=linear, scales=scales, zeros=zeros, g_idx=g_idx)
+    torch_linear = torch_linear.to(device=device)
+    torch_linear.post_init()
+    return torch_linear
+
+
+def _copy_to_swordfish(torch_linear: TorchLinear) -> SwordfishLinear:
+    sf = SwordfishLinear(
+        bits=torch_linear.bits,
+        group_size=torch_linear.requested_group_size,
+        desc_act=torch_linear.desc_act,
+        sym=torch_linear.sym,
+        in_features=torch_linear.in_features,
+        out_features=torch_linear.out_features,
+        bias=False,
+    )
+    sf.qweight = nn.Parameter(torch_linear.qweight.data.detach().clone().contiguous(), requires_grad=False)
+    sf.scales = nn.Parameter(torch_linear.scales.data.detach().clone().to(torch.bfloat16).contiguous(), requires_grad=False)
+    if torch_linear.g_idx is not None and torch_linear.g_idx.numel() > 0:
+        sf.g_idx = nn.Parameter(torch_linear.g_idx.data.detach().clone().contiguous(), requires_grad=False)
+    sf.post_init()
+    return sf
+
+
+@unittest.skipIf(_SKIP_REASON is not None, _SKIP_REASON or "")
+class TestSwordfishSpeed(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        prewarm_swordfish_extension()
+
+    def _measure(self, fn, x, warmup=5, iters=20):
+        for _ in range(warmup):
+            fn(x)
+        torch.cuda.synchronize()
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(iters):
+            fn(x)
+        end.record()
+        torch.cuda.synchronize()
+        return start.elapsed_time(end) / iters
+
+    def test_swordfish_speed_vs_machete(self):
+        in_features = 4096
+        out_features = 4096
+        bits = 4
+        group_size = 128
+        dtype = torch.bfloat16
+        device = torch.device("cuda:0")
+
+        torch.manual_seed(42)
+        weight = torch.randn((out_features, in_features), dtype=dtype, device="cpu") * 0.5
+        q, scales, zeros = _quantize_sym(weight, bits, group_size)
+        torch_linear = _pack_torch_reference(bits, group_size, in_features, out_features, q, scales, zeros, device)
+        sf = _copy_to_swordfish(torch_linear)
+
+        # Dense FP16 baseline from the same quantized checkpoint.
+        with torch.no_grad():
+            dense_weight = torch_linear.dequantize_weight().to(device=device, dtype=dtype)
+
+        baseline = {}
+        machete = {}
+        swordfish = {}
+
+        m_values = [1, 8, 16, 32, 64, 128, 256]
+        for m in m_values:
+            x = torch.randn((m, in_features), dtype=dtype, device=device) * 0.5
+
+            def dense_fn(x):
+                return torch.matmul(x, dense_weight)
+
+            def sf_fn(x):
+                return sf(x)
+
+            baseline_ms = self._measure(dense_fn, x)
+            sf_ms = self._measure(sf_fn, x)
+
+            flops = 2 * m * in_features * out_features
+            baseline[m] = flops / (baseline_ms * 1e-3) / 1e12
+            swordfish[m] = flops / (sf_ms * 1e-3) / 1e12
+
+            # Compare with Machete when the runtime reports support.
+            try:
+                from gptqmodel.nn_modules.qlinear.machete import MacheteLinear
+                from gptqmodel.utils.machete import machete_runtime_available
+
+                if machete_runtime_available():
+                    mach = MacheteLinear(
+                        bits=bits,
+                        group_size=group_size,
+                        desc_act=False,
+                        sym=True,
+                        in_features=in_features,
+                        out_features=out_features,
+                        bias=False,
+                    )
+                    mach.qweight = nn.Parameter(torch_linear.qweight.data.detach().clone().contiguous(), requires_grad=False)
+                    mach.scales = nn.Parameter(torch_linear.scales.data.detach().clone().to(torch.bfloat16).contiguous(), requires_grad=False)
+                    mach.post_init()
+                    mach = mach.to(device)
+
+                    def mach_fn(x):
+                        return mach(x)
+
+                    mach_ms = self._measure(mach_fn, x)
+                    machete[m] = flops / (mach_ms * 1e-3) / 1e12
+            except Exception:
+                pass
+
+        print(f"\nSwordfish speed benchmark (in={in_features}, out={out_features}, bits={bits}, group={group_size})")
+        print(f"{'M':>5} {'Swordfish TFLOPS':>18} {'Dense TFLOPS':>15} {'Machete TFLOPS':>18}")
+        for m in m_values:
+            print(f"{m:>5} {swordfish[m]:>18.3f} {baseline[m]:>15.3f} {machete.get(m, float('nan')):>18.3f}")
+
+        # Swordfish should not be dramatically slower than the dense baseline
+        # for the small-batch decode window where it is designed to win.
+        if 1 in swordfish and 1 in baseline:
+            self.assertGreater(swordfish[1], baseline[1] * 0.25,
+                               "Swordfish bs=1 throughput should be within 4x of dense GEMM")
+
+        if os.environ.get("GPTQMODEL_SWORDFISH_WRITE_SPEED_JSON"):
+            import json
+            out = {
+                "in_features": in_features,
+                "out_features": out_features,
+                "bits": bits,
+                "group_size": group_size,
+                "swordfish": swordfish,
+                "dense": baseline,
+                "machete": machete,
+            }
+            with open("/tmp/swordfish_speed.json", "w") as f:
+                json.dump(out, f, indent=2)

--- a/tests/kernels/test_swordfish_speed_deepseek_v4.py
+++ b/tests/kernels/test_swordfish_speed_deepseek_v4.py
@@ -1,0 +1,293 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+"""DeepSeek-V4-Flash-0731 GEMM speed sweep for Swordfish, Marlin, and Machete.
+
+Runs a synthetic 4-bit GPTQ symmetric (g=128) weight for every Linear shape in
+`deepseek-ai/DeepSeek-V4-Flash-0731` and reports throughput in TFLOPS. Each
+backend is warmed up twice and then measured over 10 iterations; OOM and
+unsupported-configuration entries are recorded as "OOM" or "N/A".
+"""
+
+import gc
+import unittest
+from typing import Dict, List, Tuple
+
+import torch
+import torch.nn as nn
+
+from gptqmodel.nn_modules.qlinear.swordfish import SwordfishLinear
+from gptqmodel.nn_modules.qlinear.torch import TorchLinear
+from gptqmodel.utils.logger import setup_logger
+
+log = setup_logger()
+
+
+def _skip_reason() -> str | None:
+    if not torch.cuda.is_available():
+        return "CUDA not available"
+    major, minor = torch.cuda.get_device_capability()
+    if major < 10:
+        return f"Swordfish requires Blackwell (sm100+); found sm{major}{minor}"
+    return None
+
+
+_SKIP_REASON = _skip_reason()
+
+# Unique (in_features, out_features) Linear shapes extracted from
+# `deepseek-ai/DeepSeek-V4-Flash-0731` with `init_empty_weights()`.
+DEEPSEEK_V4_SHAPES: List[Tuple[int, int]] = [
+    (1024, 32768),
+    (1024, 8192),
+    (2048, 4096),
+    (4096, 1024),
+    (4096, 129280),
+    (4096, 2048),
+    (4096, 256),
+    (4096, 512),
+    (4096, 64),
+    (4096, 8192),
+    (8192, 4096),
+]
+
+BATCH_SIZES = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
+
+
+def _quantize_sym(weight: torch.Tensor, bits: int, group_size: int):
+    out_features, in_features = weight.shape
+    half_range = 1 << (bits - 1)
+    num_groups = in_features // group_size
+
+    q = torch.empty_like(weight)
+    scales = torch.zeros((out_features, num_groups), dtype=weight.dtype, device=weight.device)
+    for g in range(num_groups):
+        mask = slice(g * group_size, (g + 1) * group_size)
+        block = weight[:, mask]
+        max_abs = block.abs().max(dim=1, keepdim=True).values
+        max_abs[max_abs == 0] = 1.0
+        scale = max_abs / (half_range - 1)
+        q_block = torch.round(block / scale).clamp(-(half_range), half_range - 1) + half_range
+        q[:, mask] = q_block
+        scales[:, g : g + 1] = scale
+
+    zeros = torch.full((out_features, num_groups), half_range, dtype=weight.dtype, device=weight.device)
+    return q, scales, zeros
+
+
+def _pack_torch_reference(
+    bits: int,
+    group_size: int,
+    in_features: int,
+    out_features: int,
+    weight: torch.Tensor,
+    scales: torch.Tensor,
+    zeros: torch.Tensor,
+    device: torch.device,
+):
+    linear = nn.Linear(in_features, out_features, bias=False, dtype=weight.dtype, device="cpu")
+    with torch.no_grad():
+        linear.weight.copy_(weight)
+
+    torch_linear = TorchLinear(
+        bits=bits,
+        group_size=group_size,
+        sym=True,
+        desc_act=False,
+        in_features=in_features,
+        out_features=out_features,
+        register_buffers=True,
+    )
+    g_idx = (torch.arange(in_features, dtype=torch.int32) // group_size)
+    torch_linear.pack(linear=linear, scales=scales, zeros=zeros, g_idx=g_idx)
+    torch_linear = torch_linear.to(device=device)
+    torch_linear.post_init()
+    return torch_linear
+
+
+def _measure(fn, x, warmup: int = 2, iters: int = 100) -> float:
+    """Return average elapsed time in milliseconds."""
+    for _ in range(warmup):
+        fn(x)
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn(x)
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters
+
+
+@unittest.skipIf(_SKIP_REASON is not None, _SKIP_REASON or "")
+class TestSwordfishSpeedDeepSeekV4(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        from gptqmodel.utils.swordfish import prewarm_swordfish_extension
+
+        prewarm_swordfish_extension()
+
+    def _build_backend(self, torch_linear: TorchLinear, backend_class, dtype: torch.dtype, device: torch.device):
+        """Instantiate a backend, copy the packed GPTQ buffers, and run post_init."""
+        module = backend_class(
+            bits=torch_linear.bits,
+            group_size=torch_linear.requested_group_size,
+            desc_act=torch_linear.desc_act,
+            sym=torch_linear.sym,
+            in_features=torch_linear.in_features,
+            out_features=torch_linear.out_features,
+            bias=False,
+            dtype=dtype,
+        )
+        module.qweight = nn.Parameter(
+            torch_linear.qweight.data.detach().clone().contiguous(), requires_grad=False
+        )
+        module.scales = nn.Parameter(
+            torch_linear.scales.data.detach().clone().contiguous(), requires_grad=False
+        )
+        if torch_linear.g_idx is not None and torch_linear.g_idx.numel() > 0:
+            module.g_idx = nn.Parameter(
+                torch_linear.g_idx.data.detach().clone().contiguous(), requires_grad=False
+            )
+        if torch_linear.qzeros is not None and torch_linear.qzeros.numel() > 0:
+            module.qzeros = nn.Parameter(
+                torch_linear.qzeros.data.detach().clone().contiguous(), requires_grad=False
+            )
+        module = module.to(device=device)
+        module.post_init()
+        return module
+
+    def _benchmark_backend_for_shape(
+        self,
+        backend_class,
+        name: str,
+        torch_linear: TorchLinear,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> Dict[Tuple[int, int, int], str]:
+        """Return {(in, out, m): throughput string} for one backend."""
+        try:
+            module = self._build_backend(torch_linear, backend_class, dtype, device)
+        except Exception as exc:
+            log.warning("%s init failed for %dx%d: %s", name, torch_linear.in_features, torch_linear.out_features, exc)
+            return {}
+
+        results: Dict[Tuple[int, int, int], str] = {}
+        for m in BATCH_SIZES:
+            x = torch.randn((m, torch_linear.in_features), dtype=dtype, device=device) * 0.5
+            try:
+                ms = _measure(lambda x, mod=module: mod(x), x)
+                flops = 2 * m * torch_linear.in_features * torch_linear.out_features
+                tflops = flops / (ms * 1e-3) / 1e12
+                results[(torch_linear.in_features, torch_linear.out_features, m)] = f"{tflops:6.2f}"
+            except torch.cuda.OutOfMemoryError:
+                results[(torch_linear.in_features, torch_linear.out_features, m)] = "   OOM"
+            except Exception as exc:
+                log.warning("%s m=%d failed for %dx%d: %s", name, m, torch_linear.in_features, torch_linear.out_features, exc)
+                results[(torch_linear.in_features, torch_linear.out_features, m)] = "   N/A"
+            finally:
+                del x
+        del module
+        torch.cuda.empty_cache()
+        gc.collect()
+        return results
+
+    def test_deepseek_v4_flash_0731_speed(self):
+        bits = 4
+        group_size = 128
+        dtype = torch.bfloat16
+        device = torch.device("cuda:0")
+
+        backends: List[Tuple[str, type]] = [("Swordfish", SwordfishLinear)]
+        unavailable: List[str] = []
+
+        try:
+            from gptqmodel.nn_modules.qlinear.marlin import MarlinLinear
+            from gptqmodel.utils.marlin import marlin_runtime_available
+
+            if marlin_runtime_available():
+                backends.append(("Marlin", MarlinLinear))
+            else:
+                from gptqmodel.utils.marlin import marlin_runtime_error
+                unavailable.append(f"Marlin: {marlin_runtime_error()}")
+        except Exception as exc:
+            unavailable.append(f"Marlin: {exc}")
+
+        try:
+            from gptqmodel.nn_modules.qlinear.machete import MacheteLinear
+            from gptqmodel.utils.machete import machete_runtime_available, machete_runtime_error
+
+            if machete_runtime_available():
+                backends.append(("Machete", MacheteLinear))
+            else:
+                unavailable.append(f"Machete: {machete_runtime_error()}")
+        except Exception as exc:
+            unavailable.append(f"Machete: {exc}")
+
+        # Dense baseline for comparison.
+        dense_results: Dict[Tuple[int, int, int], str] = {}
+
+        all_results: Dict[str, Dict[Tuple[int, int, int], str]] = {}
+        for name, _ in backends:
+            all_results[name] = {}
+
+        for in_features, out_features in DEEPSEEK_V4_SHAPES:
+            torch.manual_seed(42)
+            weight = torch.randn((out_features, in_features), dtype=dtype, device="cpu") * 0.5
+            q, scales, zeros = _quantize_sym(weight, bits, group_size)
+            torch_linear = _pack_torch_reference(
+                bits, group_size, in_features, out_features, q, scales, zeros, device
+            )
+
+            # Dense FP16 baseline from the same quantized checkpoint.
+            with torch.no_grad():
+                dense_weight = torch_linear.dequantize_weight().to(device=device, dtype=dtype)
+
+            def _dense_fn(x, weight=dense_weight):
+                return torch.matmul(x, weight)
+
+            for m in BATCH_SIZES:
+                x = torch.randn((m, in_features), dtype=dtype, device=device) * 0.5
+                try:
+                    ms = _measure(_dense_fn, x)
+                    flops = 2 * m * in_features * out_features
+                    tflops = flops / (ms * 1e-3) / 1e12
+                    dense_results[(in_features, out_features, m)] = f"{tflops:6.2f}"
+                except torch.cuda.OutOfMemoryError:
+                    dense_results[(in_features, out_features, m)] = "   OOM"
+                except Exception:
+                    dense_results[(in_features, out_features, m)] = "   N/A"
+                finally:
+                    del x
+
+            for name, backend_class in backends:
+                backend_results = self._benchmark_backend_for_shape(
+                    backend_class, name, torch_linear, dtype, device
+                )
+                all_results[name].update(backend_results)
+
+            del torch_linear, dense_weight
+            torch.cuda.empty_cache()
+            gc.collect()
+
+        # Print one consolidated table.
+        width = 90
+        print("\nDeepSeek-V4-Flash-0731 4-bit GPTQ speed (TFLOPS) on B300")
+        print("=" * width)
+        if unavailable:
+            print("Unavailable backends: " + "; ".join(unavailable))
+            print("-" * width)
+        header = f"{'K':>6} {'N':>7} {'M':>4} {'Dense':>8}"
+        for name, _ in backends:
+            header += f" {name:>10}"
+        print(header)
+        print("-" * width)
+        for in_features, out_features in DEEPSEEK_V4_SHAPES:
+            for m in BATCH_SIZES:
+                row = f"{in_features:>6} {out_features:>7} {m:>4} {dense_results.get((in_features, out_features, m), '     -'):>8}"
+                for name, _ in backends:
+                    row += f" {all_results[name].get((in_features, out_features, m), '     -'):>10}"
+                print(row)
+        print("=" * width)

--- a/tests/models/test_llama3_2_swordfish.py
+++ b/tests/models/test_llama3_2_swordfish.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+import os
+import unittest
+
+from gptqmodel import BACKEND
+from gptqmodel.quantization import FORMAT, METHOD
+from model_test import ModelTest
+
+
+# E2E Swordfish (Blackwell sm100/sm110) integration test using the same
+# Llama-3.2-1B model harness as test_llama3_2.py.
+@unittest.skipIf(
+    os.environ.get("GPTQMODEL_SKIP_SWORDFISH_E2E", "0").lower() in {"1", "true", "yes"},
+    "Swordfish e2e test disabled by GPTQMODEL_SKIP_SWORDFISH_E2E",
+)
+class TestLlama3_2_Swordfish(ModelTest):
+    SAVE_PATH = os.environ.get(
+        "GPTQMODEL_LLAMA3_2_SWORDFISH_SAVE_PATH",
+        "/tmp/llama3_2_gptq_swordfish_saved_ckpt",
+    )
+    DELETE_QUANTIZED_MODEL = False
+    NATIVE_MODEL_ID = "/monster/data/model/Llama-3.2-1B-Instruct"
+    EVAL_BATCH_SIZE = 64
+    DATASET_CONCAT_SIZE = 2048
+
+    LOAD_BACKEND = BACKEND.GPTQ_SWORDFISH
+    QUANT_BACKEND = BACKEND.AUTO
+    BITS = 4
+    GROUP_SIZE = 128
+    DESC_ACT = False
+    SYM = True
+    FORMAT = FORMAT.GPTQ
+    METHOD = METHOD.GPTQ
+
+    # Accuracy expectations mirror the Marlin baseline in test_llama3_2.py.
+    # Swordfish should be bit-close on the same calibration seed.
+    EVAL_TASKS_FAST = {
+        "arc_challenge": {
+            "chat_template": True,
+            "acc": {
+                "value": 0.3140,
+                "floor_pct": 0.04,
+                "ceil_pct": 1.0,
+            },
+            "acc_norm": {
+                "value": 0.3507,
+                "floor_pct": 0.04,
+                "ceil_pct": 1.0,
+            },
+        },
+        "gsm8k_platinum_cot": {
+            "chat_template": True,
+            "evalution_use_model_path": True,
+            "evalution_batch_size": "auto",
+            "evalution_model_args": {
+                "dtype": "bfloat16",
+                "attn_implementation": "paged|flash_attention_2",
+                "device": "cuda:0",
+            },
+            "evalution_suite_kwargs": {
+                "batch_size": 32,
+                "max_new_tokens": 256,
+                "stream": True,
+            },
+            "acc,num": {
+                "value": 0.4690,
+                "floor_pct": 0.04,
+                "ceil_pct": 1.0,
+            },
+        },
+    }
+
+    EVAL_TASKS_SLOW = {
+        "gsm8k_platinum_cot": {
+            "chat_template": True,
+            "acc,num": {
+                "value": 0.3987,
+                "floor_pct": 0.04,
+            },
+        },
+        "arc_challenge": {
+            "chat_template": True,
+            "acc": {
+                "value": 0.3234,
+                "floor_pct": 0.04,
+            },
+            "acc_norm": {
+                "value": 0.3643,
+                "floor_pct": 0.04,
+            },
+        },
+    }
+
+    def test_llama3_2_swordfish(self):
+        self.quantize_and_evaluate()


### PR DESCRIPTION
## Summary

Add the Swordfish Blackwell (sm100/sm110) w4a16/w8a16 GPTQ/AWQ GEMM kernel family to GPTQModel as an optional, JIT-compiled extension, with proper AGPL-3.0 license attribution and dual license copies.

### What changed

- Vendored the Swordfish kernel source under `gptqmodel_ext/swordfish/` with AGPL-3.0 SPDX headers, `gptqmodel_ext/swordfish/LICENSE`, and a top-level `licenses/SWORDFISH` copy.
- Added `SwordfishLinear` and `AwqSwordfishLinear` in `gptqmodel/nn_modules/qlinear/swordfish.py` with the `gptqmodel_swordfish` torch.ops namespace, activation-permute handling, and `compute_dtype` support for bf16/fp16 scales and bias.
- Wired `BACKEND.GPTQ_SWORDFISH` and `BACKEND.AWQ_SWORDFISH` through `extension.py` (including the `awq_swordfish` extension alias), `backend.py`, and `utils/swordfish.py`.
- Rejected 8-bit asymmetric GPTQ at validation time because the C++ kernel does not support zero points for w8; 4-bit AWQ zero points are supported.
- Fixed `_nvcc_path()` to fall back to `CUDA_HOME`, `CUDAHOME`, or `/usr/local/cuda/bin/nvcc` so the JIT builder can apply NVCC-version-specific flags when `nvcc` is not on `PATH`.
- Added loader guards for Swordfish backends: refuse sharded checkpoints, refuse devices below compute capability 10.0, and restrict dtype to fp16/bf16.
- Set `SwordfishLinear.SUPPORTS_SHARDS = False` so the writer does not produce unloadable sharded checkpoints.
- Added kernel tests:
  - `tests/kernels/test_swordfish.py` — accuracy vs. `TorchLinear` for 4-bit GPTQ with group sizes 128/64, `desc_act` on/off, bf16.
  - `tests/kernels/test_awq_swordfish.py` — accuracy vs. `AwqTorchLinear` for 4-bit AWQ with group sizes 64/128, bf16.
  - `tests/kernels/test_awq_machete_marlin.py` and `tests/kernels/test_awq.py` — Swordfish added to the AWQ kernel comparison matrices.
  - `tests/kernels/test_swordfish_speed.py` and `tests/kernels/test_swordfish_speed_deepseek_v4.py` — speed benchmarks on DeepSeek-V4-Flash-0731 shapes.
  - `tests/models/test_llama3_2_swordfish.py` — Llama-3.2 e2e path.
- Added Swordfish to the `kernel_output` cross-backend comparison in `tests/kernels/test_gptq.py`.
- Updated `README.md` and `CREDITS.md` with Swordfish attribution, the AlpinDale blog/paper link, and a note that the vendored Swordfish sources are AGPL-3.0-or-later and compiled/linked at runtime via JIT.

### Verification

- `tests/kernels/test_swordfish.py` — passed
- `tests/kernels/test_awq_swordfish.py` — passed
- `tests/kernels/test_awq_machete_marlin.py` — passed (Machete skipped on B300)
- `tests/kernels/test_selection.py` — passed
- `tests/kernels/test_swordfish_speed.py` and `tests/kernels/test_swordfish_speed_deepseek_v4.py` — passed on B300
- `ruff check` on touched Python files — clean

### Notes

- Machete remains Hopper-only (SM90) and is skipped on B300 with a clear runtime message.
