### PR TITLE
fix(swordfish): apply post-review fixes from GPT-QModel-Ultra PR #183

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,8 @@ recursive-include gptqmodel_ext/cutlass_extensions *.h *.hpp *.cuh *.cu *.cpp *.
 recursive-include gptqmodel_ext/paroquant *.h *.cuh *.cu *.cpp
 recursive-include gptqmodel_ext/qqq *.h *.cuh *.cu *.cpp
 recursive-include gptqmodel_ext/hadamard *.h *.cuh *.cu *.cpp LICENSE
-recursive-include gptqmodel_ext/swordfish *.h *.hpp *.cuh *.cu *.cpp *.py
+recursive-include gptqmodel_ext/cannoe *.h *.hpp *.cpp *.json *.md
+recursive-include gptqmodel_ext/swordfish *.h *.hpp *.cuh *.cu *.cpp *.py LICENSE
 include gptqmodel_ext/swordfish/licenses/LICENSE
 recursive-include gptqmodel/exllamav3/util/hadamard_data *.txt
 include licenses/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,6 @@ recursive-include gptqmodel_ext/cutlass_extensions *.h *.hpp *.cuh *.cu *.cpp *.
 recursive-include gptqmodel_ext/paroquant *.h *.cuh *.cu *.cpp
 recursive-include gptqmodel_ext/qqq *.h *.cuh *.cu *.cpp
 recursive-include gptqmodel_ext/hadamard *.h *.cuh *.cu *.cpp LICENSE
-recursive-include gptqmodel_ext/cannoe *.h *.hpp *.cpp *.json *.md
 recursive-include gptqmodel_ext/swordfish *.h *.hpp *.cuh *.cu *.cpp *.py LICENSE
 include gptqmodel_ext/swordfish/licenses/LICENSE
 recursive-include gptqmodel/exllamav3/util/hadamard_data *.txt

--- a/gptqmodel/nn_modules/qlinear/__init__.py
+++ b/gptqmodel/nn_modules/qlinear/__init__.py
@@ -79,6 +79,7 @@ class BaseQuantLinear(nn.Module):
     SUPPORTS_FORMATS: Dict[FORMAT, int] = None
     SUPPORTS_BITS: List[int] = None
     SUPPORTS_SHARDS: bool = None
+    SUPPORTS_SHARDED_LOAD: bool = True
     SUPPORTS_TRAINING: bool = None
 
     # IPEX kernel will use Torch for training only and switches back to IPEX for eval/inference

--- a/gptqmodel/nn_modules/qlinear/swordfish.py
+++ b/gptqmodel/nn_modules/qlinear/swordfish.py
@@ -44,6 +44,7 @@ class SwordfishLinear(GPTQQuantLinear):
     SUPPORTS_DESC_ACT = [True, False]
     SUPPORTS_SYM = [True, False]
     SUPPORTS_SHARDS = False
+    SUPPORTS_SHARDED_LOAD = False
     SUPPORTS_TRAINING = False
     SUPPORTS_AUTO_PADDING = False
     SUPPORTS_IN_FEATURES_DIVISIBLE_BY = [64]
@@ -402,6 +403,7 @@ class AwqSwordfishLinear(AWQuantLinear):
     SUPPORTS_DESC_ACT = [False]
     SUPPORTS_SYM = [True, False]
     SUPPORTS_SHARDS = False
+    SUPPORTS_SHARDED_LOAD = False
     SUPPORTS_TRAINING = False
     SUPPORTS_AUTO_PADDING = False
     SUPPORTS_IN_FEATURES_DIVISIBLE_BY = [64]

--- a/gptqmodel/nn_modules/qlinear/swordfish.py
+++ b/gptqmodel/nn_modules/qlinear/swordfish.py
@@ -583,8 +583,14 @@ class AwqSwordfishLinear(AWQuantLinear):
         shifts = torch.arange(
             0, 32, self.bits, dtype=torch.int32, device=qweight_int.device
         )
-        packed = (qweight_int << shifts.view(1, 1, pack_factor, 1)).sum(dim=2, dtype=torch.int32)
-        packed = packed.view(self.in_features // pack_factor, self.out_features).contiguous()
+        # Accumulate in int64 so the shift/sum does not rely on signed int32
+        # overflow, then cast back to the packed int32 bit pattern.
+        packed = (qweight_int.to(torch.int64) << shifts.view(1, 1, pack_factor, 1)).sum(
+            dim=2, dtype=torch.int64
+        )
+        packed = packed.to(torch.int32).view(
+            self.in_features // pack_factor, self.out_features
+        ).contiguous()
 
         prepacked = swordfish_prepack_B(
             packed,

--- a/gptqmodel/nn_modules/qlinear/swordfish.py
+++ b/gptqmodel/nn_modules/qlinear/swordfish.py
@@ -611,6 +611,23 @@ class AwqSwordfishLinear(AWQuantLinear):
         effective_group_size = self.in_features if self.requested_group_size == -1 else self.group_size
         num_groups = self.in_features // effective_group_size
 
+        expected_zp = 1 << (self.bits - 1)
+        if self.sym:
+            # Symmetric AWQ checkpoints are consumed without zero points, but
+            # only if the stored zero points are exactly 2^(bits-1).
+            qzeros_unpacked = _unpack_cols_torch(
+                self.qzeros,
+                self.bits,
+                num_groups,
+                self.out_features,
+            )
+            qzeros_unpacked = _undo_awq_interleave(qzeros_unpacked, self.bits)
+            if torch.any(qzeros_unpacked != expected_zp):
+                raise ValueError(
+                    f"AwqSwordfishLinear symmetric checkpoint expects all zero points "
+                    f"to be {expected_zp} (2^(bits-1))."
+                )
+
         if self.has_zero_points:
             qzeros_unpacked = _unpack_cols_torch(
                 self.qzeros,

--- a/gptqmodel/utils/cpp.py
+++ b/gptqmodel/utils/cpp.py
@@ -77,14 +77,14 @@ def _log_cache_clear_callsite(*, reason: str, target_path: str | Path) -> None:
 
 
 def _nvcc_path() -> Optional[str]:
-    path = shutil.which("nvcc")
-    if path:
-        return path
     # Prefer the CUDA toolkit that PyTorch will use for compilation.
     if CUDA_HOME:
         candidate = os.path.join(CUDA_HOME, "bin", "nvcc")
         if os.path.isfile(candidate):
             return candidate
+    path = shutil.which("nvcc")
+    if path:
+        return path
     for env in ("CUDA_HOME", "CUDAHOME"):
         home = os.environ.get(env)
         if home:

--- a/gptqmodel/utils/importer.py
+++ b/gptqmodel/utils/importer.py
@@ -554,7 +554,8 @@ def select_quant_linear(
                 if os.environ.get("DEBUG"):
                     log.info(f"skip {k} for unsupported device `{device}`")
                 continue
-            if is_sharded and not cls.SUPPORTS_SHARDS:
+            supports_sharded_load = getattr(cls, "SUPPORTS_SHARDED_LOAD", cls.SUPPORTS_SHARDS)
+            if is_sharded and not supports_sharded_load:
                 if os.environ.get("DEBUG"):
                     log.info(f"skip {k} because sharded checkpoints are not supported")
                 continue
@@ -622,7 +623,8 @@ def select_quant_linear(
     # Handle the case where backend is not AUTO.
     qlinear = get_kernel_for_backend(backend, quant_method, format)
 
-    if is_sharded and not qlinear.SUPPORTS_SHARDS:
+    supports_sharded_load = getattr(qlinear, "SUPPORTS_SHARDED_LOAD", qlinear.SUPPORTS_SHARDS)
+    if is_sharded and not supports_sharded_load:
         raise ValueError(f"Selected backend `{backend}` with kernel `{qlinear.__name__}` does not support sharded checkpoints.")
 
     validate, err = qlinear.validate(

--- a/gptqmodel/utils/swordfish.py
+++ b/gptqmodel/utils/swordfish.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import torch
 
@@ -33,13 +33,15 @@ log = setup_logger()
 _SWORDFISH_OPS_NAME = "gptqmodel_swordfish_ops"
 _SWORDFISH_OPS_NAMESPACE = "gptqmodel_swordfish"
 
-_SWORDFISH_GENCODE_RE = re.compile(r"code=(?:sm_|compute_)(\d+)(?:[a-z])?")
+_SWORDFISH_GENCODE_SM_RE = re.compile(r"code=sm_(\d+)([a-z]?)")
+_SWORDFISH_GENCODE_PTX_RE = re.compile(r"code=compute_(\d+)([a-z]?)")
 
 _SWORDFISH_ARCH_FLAGS = (
     # Blackwell TMA/tcgen05 features require the "a" (all) architecture suffix.
     # The B300 in this environment reports compute capability 10.3 (sm_103a).
     # Emit native cubins for the common Blackwell datacenter variants plus a
-    # forward-compatible PTX fallback.
+    # same-architecture PTX fallback.  The 'a' suffix is architecture-specific,
+    # so PTX from compute_103a only JITs to sm_103a, not to future chips.
     "-gencode=arch=compute_100a,code=sm_100a",
     "-gencode=arch=compute_103a,code=sm_103a",
     "-gencode=arch=compute_110a,code=sm_110a",
@@ -177,24 +179,49 @@ def _extension_api():
     return extension_api
 
 
-def _swordfish_min_supported_compute_capability() -> Tuple[int, int]:
-    """Parse _SWORDFISH_ARCH_FLAGS and return the lowest compute capability we
-    emit code for, including the PTX fallback.  Any device with this or a
-    higher compute capability can load Swordfish (subject to driver PTX JIT)."""
-    caps: set[Tuple[int, int]] = set()
+def _swordfish_supported_compute_capabilities() -> Tuple[
+    set[Tuple[int, int]], Dict[int, int], set[Tuple[int, int]]
+]:
+    """Parse _SWORDFISH_ARCH_FLAGS and return the supported capability sets.
+
+    Returns:
+        exact_caps: native cubin targets (`code=sm_*`) plus architecture-specific
+            PTX targets (`code=compute_*` with an 'a' suffix).
+        ptx_forward_min_minor: mapping from major version to the minimum minor
+            for forward-compatible (non-'a') PTX targets, if any.
+        ptx_exact_caps: architecture-specific PTX targets that only JIT to the
+            exact matching compute capability.
+    """
+    exact_caps: set[Tuple[int, int]] = set()
+    ptx_forward_min_minor: Dict[int, int] = {}
+    ptx_exact_caps: set[Tuple[int, int]] = set()
     for flag in _SWORDFISH_ARCH_FLAGS:
-        for match in _SWORDFISH_GENCODE_RE.finditer(flag):
+        for match in _SWORDFISH_GENCODE_SM_RE.finditer(flag):
             cap = int(match.group(1))
-            caps.add((cap // 10, cap % 10))
-    if not caps:
+            exact_caps.add((cap // 10, cap % 10))
+        for match in _SWORDFISH_GENCODE_PTX_RE.finditer(flag):
+            cap = int(match.group(1))
+            suffix = match.group(2)
+            major, minor = cap // 10, cap % 10
+            if suffix:
+                # Architecture-specific PTX (e.g. compute_103a) only JITs to the
+                # exact matching sm.
+                ptx_exact_caps.add((major, minor))
+            else:
+                # Forward-compatible PTX covers same-major devices with a minor
+                # greater than or equal to the PTX target minor.
+                prev = ptx_forward_min_minor.get(major)
+                if prev is None or minor < prev:
+                    ptx_forward_min_minor[major] = minor
+    if not exact_caps and not ptx_forward_min_minor and not ptx_exact_caps:
         # Fallback in case the gencode format ever changes unexpectedly.
-        caps = {(10, 0)}
-    return min(caps)
+        exact_caps = {(10, 0), (10, 3), (11, 0)}
+    return exact_caps, ptx_forward_min_minor, ptx_exact_caps
 
 
-_SWORDFISH_MIN_SUPPORTED_COMPUTE_CAPABILITY: Tuple[int, int] = (
-    _swordfish_min_supported_compute_capability()
-)
+_SWORDFISH_SUPPORTED_CAPABILITIES: Tuple[
+    set[Tuple[int, int]], Dict[int, int], set[Tuple[int, int]]
+] = _swordfish_supported_compute_capabilities()
 
 
 def _swordfish_static_runtime_error() -> str:
@@ -203,13 +230,21 @@ def _swordfish_static_runtime_error() -> str:
     if not torch.cuda.is_available():
         return "Swordfish kernel requires CUDA."
     major, minor = torch.cuda.get_device_capability()
-    if (major, minor) < _SWORDFISH_MIN_SUPPORTED_COMPUTE_CAPABILITY:
-        mj, mn = _SWORDFISH_MIN_SUPPORTED_COMPUTE_CAPABILITY
-        return (
-            f"Swordfish kernel requires Blackwell (sm{mj}{mn}+) or newer; "
-            f"found compute capability {major}.{minor}."
-        )
-    return ""
+    exact_caps, ptx_forward, ptx_exact = _SWORDFISH_SUPPORTED_CAPABILITIES
+    if (
+        (major, minor) in exact_caps
+        or (major, minor) in ptx_exact
+        or (major in ptx_forward and minor >= ptx_forward[major])
+    ):
+        return ""
+    supported = ", ".join(
+        f"sm{mj}{mn}"
+        for mj, mn in sorted(exact_caps | ptx_exact)
+    )
+    return (
+        f"Swordfish kernel only supports Blackwell variants "
+        f"({supported}); found compute capability {major}.{minor}."
+    )
 
 
 def _validate_swordfish_device_support() -> bool:

--- a/gptqmodel/utils/swordfish.py
+++ b/gptqmodel/utils/swordfish.py
@@ -33,7 +33,7 @@ log = setup_logger()
 _SWORDFISH_OPS_NAME = "gptqmodel_swordfish_ops"
 _SWORDFISH_OPS_NAMESPACE = "gptqmodel_swordfish"
 
-_SWORDFISH_GENCODE_SM_RE = re.compile(r"code=sm_(\d+)(?:[a-z])?")
+_SWORDFISH_GENCODE_RE = re.compile(r"code=(?:sm_|compute_)(\d+)(?:[a-z])?")
 
 _SWORDFISH_ARCH_FLAGS = (
     # Blackwell TMA/tcgen05 features require the "a" (all) architecture suffix.
@@ -177,21 +177,23 @@ def _extension_api():
     return extension_api
 
 
-def _swordfish_supported_compute_capabilities() -> set[Tuple[int, int]]:
-    """Parse _SWORDFISH_ARCH_FLAGS and return the real SMs with native cubins."""
+def _swordfish_min_supported_compute_capability() -> Tuple[int, int]:
+    """Parse _SWORDFISH_ARCH_FLAGS and return the lowest compute capability we
+    emit code for, including the PTX fallback.  Any device with this or a
+    higher compute capability can load Swordfish (subject to driver PTX JIT)."""
     caps: set[Tuple[int, int]] = set()
     for flag in _SWORDFISH_ARCH_FLAGS:
-        for match in _SWORDFISH_GENCODE_SM_RE.finditer(flag):
+        for match in _SWORDFISH_GENCODE_RE.finditer(flag):
             cap = int(match.group(1))
             caps.add((cap // 10, cap % 10))
     if not caps:
         # Fallback in case the gencode format ever changes unexpectedly.
-        caps = {(10, 0), (10, 3), (11, 0)}
-    return caps
+        caps = {(10, 0)}
+    return min(caps)
 
 
-_SWORDFISH_SUPPORTED_COMPUTE_CAPABILITIES: set[Tuple[int, int]] = (
-    _swordfish_supported_compute_capabilities()
+_SWORDFISH_MIN_SUPPORTED_COMPUTE_CAPABILITY: Tuple[int, int] = (
+    _swordfish_min_supported_compute_capability()
 )
 
 
@@ -201,13 +203,11 @@ def _swordfish_static_runtime_error() -> str:
     if not torch.cuda.is_available():
         return "Swordfish kernel requires CUDA."
     major, minor = torch.cuda.get_device_capability()
-    if (major, minor) not in _SWORDFISH_SUPPORTED_COMPUTE_CAPABILITIES:
-        supported = ", ".join(
-            f"sm{mj}{mn}" for mj, mn in sorted(_SWORDFISH_SUPPORTED_COMPUTE_CAPABILITIES)
-        )
+    if (major, minor) < _SWORDFISH_MIN_SUPPORTED_COMPUTE_CAPABILITY:
+        mj, mn = _SWORDFISH_MIN_SUPPORTED_COMPUTE_CAPABILITY
         return (
-            f"Swordfish kernel only supports native Blackwell variants "
-            f"({supported}); found compute capability {major}.{minor}."
+            f"Swordfish kernel requires Blackwell (sm{mj}{mn}+) or newer; "
+            f"found compute capability {major}.{minor}."
         )
     return ""
 

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_device_utils.cuh
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_device_utils.cuh
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 AlpinDale and the dphnAI/sonar contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Swordfish: Blackwell (sm100/sm110) weight-quantized GEMM kernels.
+// Host-only helpers for querying runtime GPU properties without assuming
+// a fixed CUDA device index.
+
+#pragma once
+
+#ifndef __CUDA_ARCH__
+
+#include <cuda_runtime.h>
+#include <mutex>
+#include <unordered_map>
+
+namespace swordfish {
+
+// Return the SM count for the requested CUDA device, caching the result
+// per device.  If device_index is -1 the current device is used.
+inline int cached_device_sm_count(int device_index = -1) {
+  if (device_index < 0) {
+    cudaGetDevice(&device_index);
+  }
+
+  static std::mutex mutex;
+  static std::unordered_map<int, int> cache;
+  std::lock_guard<std::mutex> lock(mutex);
+
+  auto it = cache.find(device_index);
+  if (it != cache.end()) {
+    return it->second;
+  }
+
+  int sms = 0;
+  cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, device_index);
+  if (sms <= 0) sms = 1;
+  cache[device_index] = sms;
+  return sms;
+}
+
+// Return the per-SM active-block count for `kernel` on `device_index`,
+// caching per device.  The caller must ensure the device guard is set if
+// device_index == -1 (current device).
+template <typename Kernel>
+inline int cached_occupancy_for_device(int device_index, Kernel kernel,
+                                       int block_size, int fallback) {
+  if (device_index < 0) {
+    cudaGetDevice(&device_index);
+  }
+
+  static std::mutex mutex;
+  static std::unordered_map<int, int> cache;
+  std::lock_guard<std::mutex> lock(mutex);
+
+  auto it = cache.find(device_index);
+  if (it != cache.end()) {
+    return it->second;
+  }
+
+  int ctas = 0;
+  cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &ctas, kernel, block_size, 0);
+  if (ctas <= 0) ctas = fallback;
+  cache[device_index] = ctas;
+  return ctas;
+}
+
+}  // namespace swordfish
+
+#endif  // __CUDA_ARCH__

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_device_utils.cuh
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_device_utils.cuh
@@ -10,6 +10,7 @@
 #ifndef __CUDA_ARCH__
 
 #include <cuda_runtime.h>
+#include <functional>
 #include <mutex>
 #include <unordered_map>
 
@@ -38,9 +39,29 @@ inline int cached_device_sm_count(int device_index = -1) {
   return sms;
 }
 
-// Return the per-SM active-block count for `kernel` on `device_index`,
-// caching per device.  The caller must ensure the device guard is set if
-// device_index == -1 (current device).
+struct OccupancyCacheKey {
+  const void* kernel;
+  int device_index;
+  int block_size;
+
+  bool operator==(const OccupancyCacheKey& other) const {
+    return kernel == other.kernel && device_index == other.device_index &&
+           block_size == other.block_size;
+  }
+};
+
+struct OccupancyCacheKeyHash {
+  std::size_t operator()(const OccupancyCacheKey& k) const noexcept {
+    std::size_t h = std::hash<const void*>{}(k.kernel);
+    h ^= std::hash<int>{}(k.device_index) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+    h ^= std::hash<int>{}(k.block_size) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+    return h;
+  }
+};
+
+// Return the per-SM active-block count for `kernel` on `device_index` and
+// `block_size`, caching per (kernel, device, block_size).  The caller must set
+// the CUDA device guard when device_index == -1.
 template <typename Kernel>
 inline int cached_occupancy_for_device(int device_index, Kernel kernel,
                                        int block_size, int fallback) {
@@ -49,10 +70,12 @@ inline int cached_occupancy_for_device(int device_index, Kernel kernel,
   }
 
   static std::mutex mutex;
-  static std::unordered_map<int, int> cache;
+  static std::unordered_map<OccupancyCacheKey, int, OccupancyCacheKeyHash> cache;
   std::lock_guard<std::mutex> lock(mutex);
 
-  auto it = cache.find(device_index);
+  OccupancyCacheKey key{
+      reinterpret_cast<const void*>(kernel), device_index, block_size};
+  auto it = cache.find(key);
   if (it != cache.end()) {
     return it->second;
   }
@@ -61,7 +84,7 @@ inline int cached_occupancy_for_device(int device_index, Kernel kernel,
   cudaOccupancyMaxActiveBlocksPerMultiprocessor(
       &ctas, kernel, block_size, 0);
   if (ctas <= 0) ctas = fallback;
-  cache[device_index] = ctas;
+  cache[key] = ctas;
   return ctas;
 }
 

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_mm.cu
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_mm.cu
@@ -24,6 +24,7 @@
 #include "libtorch_stable/ops.h"
 #include "libtorch_stable/torch_utils.h"
 #include "swordfish_decode.cuh"
+#include "swordfish_device_utils.cuh"
 
 namespace swordfish {
 
@@ -48,7 +49,7 @@ namespace {
 // the compiled graph. Here the true runtime M decides on every call and on
 // every captured CUDA graph.
 inline bool use_prefill(int64_t m, torch::headeronly::ScalarType a_st, bool w8,
-                        int64_t group_size, int64_t k, int64_t n) {
+                        int64_t group_size, int64_t k, int64_t n, int sms) {
   if (a_st != torch::headeronly::ScalarType::BFloat16 &&
       a_st != torch::headeronly::ScalarType::Half) {
     return false;
@@ -61,11 +62,6 @@ inline bool use_prefill(int64_t m, torch::headeronly::ScalarType a_st, bool w8,
   // The prefill grid launches about n/128 CTAs per M tile. When that fills
   // the machine the tcgen05 path wins from M 48 up; when it underfills
   // (many SMs, narrow N), the Stream-K decode window carries [17, 96).
-  static int sms = 0;
-  if (sms == 0) {
-    cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, 0);
-    if (sms <= 0) sms = 1;
-  }
   const bool prefill_fills = n / 128 >= sms;
   // The four-tile decode window carries [48, 56) even at wide N; the
   // tcgen05 wave only pulls ahead of it from 56 rows up. K-heavy narrow-N
@@ -113,35 +109,20 @@ inline bool force_deterministic() {
   return v;
 }
 
-inline int cached_sm_count() {
-  static int sms = 0;
-  if (sms == 0) {
-    cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, 0);
-    if (sms <= 0) sms = 1;
-  }
-  return sms;
-}
 
 template <aphrodite::ScalarTypeId type_id, int T, bool HAS_ZP, bool W8 = false,
           bool CTA_QUAD = false>
 void launch_decode_streamk_t(const void* a, const int32_t* b, const void* s,
                              const void* z, void* c, int m, int k, int n,
-                             int group_size, cudaStream_t stream,
+                             int group_size, cudaStream_t stream, int sms,
                              bool c_zeroed = false) {
   using scalar_t = typename marlin::MarlinScalarType<type_id>::scalar_t;
   constexpr int kStagesT =
       T == 1 ? kStages : (T == 2 ? (W8 ? 5 : 4) : (T == 3 ? 3 : (W8 ? 4 : 2)));
   constexpr int kUnitK = W8 ? 16 : 32;
-  static int ctas_per_sm = 0;
-  if (ctas_per_sm == 0) {
-    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-        &ctas_per_sm,
-        swordfish_decode_streamk_kernel<type_id, T, HAS_ZP, W8, CTA_QUAD>,
-        kDecodeThreads, 0);
-    if (ctas_per_sm <= 0) ctas_per_sm = 2;
-  }
-  int sms = 0;
-  cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, 0);
+  const int ctas_per_sm = cached_occupancy_for_device(
+      -1, swordfish_decode_streamk_kernel<type_id, T, HAS_ZP, W8, CTA_QUAD>,
+      kDecodeThreads, 2);
   const int m_tiles = (m + 15) / 16;
   const int m_groups = (m_tiles + T - 1) / T;
   const int nb = n / (CTA_QUAD ? kBlockN * kDecodeWarps : kBlockN);
@@ -175,19 +156,14 @@ void launch_decode_streamk_t(const void* a, const int32_t* b, const void* s,
 template <aphrodite::ScalarTypeId type_id, int T, bool HAS_ZP, bool W8 = false>
 void launch_decode_atomic_t(const void* a, const int32_t* b, const void* s,
                             const void* z, void* c, int m, int k, int n,
-                            int group_size, cudaStream_t stream,
+                            int group_size, cudaStream_t stream, int sms,
                             bool c_zeroed = false) {
   using scalar_t = typename marlin::MarlinScalarType<type_id>::scalar_t;
   constexpr int kStagesT = T == 1 ? kStages : (T == 2 ? 4 : 3);
-  static int ctas_per_sm = 0;  // per (type, T) instantiation
-  if (ctas_per_sm == 0) {
-    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-        &ctas_per_sm, swordfish_decode_kernel<type_id, true, T, HAS_ZP, W8>,
-        kDecodeThreads, 0);
-    if (ctas_per_sm <= 0) ctas_per_sm = 4;
-  }
-  int sms = 0;
-  cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, 0);
+  // per (type, T) instantiation
+  const int ctas_per_sm = cached_occupancy_for_device(
+      -1, swordfish_decode_kernel<type_id, true, T, HAS_ZP, W8>,
+      kDecodeThreads, 4);
   const int m_ctas = (m + 16 * T - 1) / (16 * T);
   const int nb = n / kBlockN;
   const int num_pairs = k / (W8 ? 16 : 32);
@@ -223,24 +199,24 @@ void launch_decode_atomic_t(const void* a, const int32_t* b, const void* s,
 template <aphrodite::ScalarTypeId type_id, bool HAS_ZP, bool W8 = false>
 void launch_decode_atomic(int T, const void* a, const int32_t* b, const void* s,
                           const void* z, void* c, int m, int k, int n,
-                          int group_size, cudaStream_t stream,
+                          int group_size, cudaStream_t stream, int sms,
                           bool c_zeroed = false) {
   if (T == 1) {
     launch_decode_atomic_t<type_id, 1, HAS_ZP, W8>(
-        a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+        a, b, s, z, c, m, k, n, group_size, stream, sms, c_zeroed);
   } else if (T == 2) {
     launch_decode_atomic_t<type_id, 2, HAS_ZP, W8>(
-        a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+        a, b, s, z, c, m, k, n, group_size, stream, sms, c_zeroed);
   } else {
     launch_decode_atomic_t<type_id, 3, HAS_ZP, W8>(
-        a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+        a, b, s, z, c, m, k, n, group_size, stream, sms, c_zeroed);
   }
 }
 
 template <aphrodite::ScalarTypeId type_id, bool HAS_ZP, bool W8 = false>
 void launch_decode(const void* a, const int32_t* b, const void* s,
                    const void* z, void* c, int m, int k, int n, int group_size,
-                   cudaStream_t stream, bool c_zeroed = false) {
+                   cudaStream_t stream, int sms, bool c_zeroed = false) {
   using scalar_t = typename marlin::MarlinScalarType<type_id>::scalar_t;
   if (force_deterministic()) {
     dim3 grid((m + 15) / 16, n / kBlockN);
@@ -253,49 +229,50 @@ void launch_decode(const void* a, const int32_t* b, const void* s,
   } else if (m <= 16) {
     // Tuned single-tile path with in-kernel C zeroing and heuristic split-K.
     launch_decode_atomic<type_id, HAS_ZP, W8>(1, a, b, s, z, c, m, k, n,
-                                              group_size, stream, c_zeroed);
+                                              group_size, stream, sms,
+                                              c_zeroed);
   } else if (m <= 127) {
     // Window dispatch. When columns alone fill the machine the fused atomic
     // grid (in-kernel zeroing, no memset) is already balanced; otherwise
     // Stream-K hands each warp a contiguous flat range of (fused tile,
     // column, pair) work and the atomic epilogue merges segments, removing
     // split-K heuristics and wave quantization.
-    const bool wide_n = n / kBlockN >= 4 * cached_sm_count();
+    const bool wide_n = n / kBlockN >= 4 * sms;
     // On many-SM parts the whole [17, 48] band belongs to the fused atomic
     // grid at any width: its CTA shares one weight stream across four
     // warps, where Stream-K's warp-private B and A staging pays for itself
     // only when the machine is small enough for warps to get long claims.
     // Few-SM parts keep Stream-K outside wide N (measured 0.73-0.96 of
     // marlin the other way around on 20 SMs).
-    const bool band_atomic = cached_sm_count() >= 100 && m <= 48;
+    const bool band_atomic = sms >= 100 && m <= 48;
     if (band_atomic || (wide_n && m <= 47)) {
       launch_decode_atomic<type_id, HAS_ZP, W8>(m <= 32 ? 2 : 3, a, b, s, z, c,
-                                                m, k, n, group_size, stream,
+                                                m, k, n, group_size, stream, sms,
                                                 c_zeroed);
     } else if (m <= 48 && n % (4 * kBlockN) == 0) {
       // Few-SM band: CTA-granular claims over n256 column quads.
       if (m <= 32) {
         launch_decode_streamk_t<type_id, 2, HAS_ZP, W8, true>(
-            a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+            a, b, s, z, c, m, k, n, group_size, stream, sms, c_zeroed);
       } else {
         launch_decode_streamk_t<type_id, 3, HAS_ZP, W8, true>(
-            a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+            a, b, s, z, c, m, k, n, group_size, stream, sms, c_zeroed);
       }
     } else if (m <= 32) {
       launch_decode_streamk_t<type_id, 2, HAS_ZP, W8>(
-          a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+          a, b, s, z, c, m, k, n, group_size, stream, sms, c_zeroed);
     } else if (m <= 48) {
       launch_decode_streamk_t<type_id, 3, HAS_ZP, W8>(
-          a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+          a, b, s, z, c, m, k, n, group_size, stream, sms, c_zeroed);
     } else if (m <= 64) {
       // Four-tile fusion amortizes the dequant across the whole band; the
       // m-shared CTA it replaces dequantized the same weights once per warp
       // and issued 2.7x the instructions for it.
       launch_decode_streamk_t<type_id, 4, HAS_ZP, W8>(
-          a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+          a, b, s, z, c, m, k, n, group_size, stream, sms, c_zeroed);
     } else {
       launch_decode_streamk_t<type_id, 3, HAS_ZP, W8>(
-          a, b, s, z, c, m, k, n, group_size, stream, c_zeroed);
+          a, b, s, z, c, m, k, n, group_size, stream, sms, c_zeroed);
     }
   } else {
     dim3 grid((m + 15) / 16, n / kBlockN);
@@ -378,17 +355,21 @@ torch::stable::Tensor swordfish_mm(
 
   const int64_t size_m = a.size(0);
 
+  // Bind to the tensor's device and query its SM count once; all
+  // launch-tier heuristics use this device rather than assuming device 0.
+  const int32_t device_index = a.get_device_index();
+  torch::stable::accelerator::DeviceGuard device_guard(device_index);
+  const int sms = cached_device_sm_count(device_index);
+  const cudaStream_t stream = get_current_cuda_stream(device_index);
+
   // Activations are expected to be in the group-sorted order produced by
   // swordfish_prepack_B (or explicitly permuted by the caller); the runtime
   // GEMM no longer consumes an explicit permutation tensor.
   const bool has_perm = false;
 
   if (size_m >=
-          dense_tier_min_m(cached_sm_count(), w8, size_k, size_n, has_perm) &&
+          dense_tier_min_m(sms, w8, size_k, size_n, has_perm) &&
       !force_deterministic()) {
-    const int32_t device_index = a.get_device_index();
-    torch::stable::accelerator::DeviceGuard device_guard(device_index);
-    const cudaStream_t stream = get_current_cuda_stream(device_index);
     torch::stable::Tensor c =
         torch::stable::empty({size_m, size_n}, a_st, std::nullopt, a.device());
     torch::stable::Tensor w_dense =
@@ -410,17 +391,13 @@ torch::stable::Tensor swordfish_mm(
   // The fused paths consume group-sorted K. Activations are already
   // group-sorted by the caller, so no extra permute is needed here.
   const bool will_prefill =
-      use_prefill(size_m, a_st, w8, tier_group, size_k, size_n);
+      use_prefill(size_m, a_st, w8, tier_group, size_k, size_n, sms);
   const bool prep_perm = false;
 
   if (will_prefill) {
     return swordfish_prefill_mm(a, b_packed, group_scales, group_zps,
                                 num_bits, tier_group, size_k, size_n);
   }
-
-  const int32_t device_index = a.get_device_index();
-  torch::stable::accelerator::DeviceGuard device_guard(device_index);
-  const cudaStream_t stream = get_current_cuda_stream(device_index);
 
   torch::stable::Tensor c =
       torch::stable::empty({size_m, size_n}, a_st, std::nullopt, a.device());
@@ -437,29 +414,29 @@ torch::stable::Tensor swordfish_mm(
     if (has_zp) {
       launch_decode<aphrodite::kFloat16.id(), true>(
           a_ptr, b_ptr, s_ptr, z_ptr, c_ptr, size_m, size_k, size_n, group_size,
-          stream, prep_perm);
+          stream, sms, prep_perm);
     } else if (w8) {
       launch_decode<aphrodite::kFloat16.id(), false, true>(
           a_ptr, b_ptr, s_ptr, z_ptr, c_ptr, size_m, size_k, size_n, group_size,
-          stream, prep_perm);
+          stream, sms, prep_perm);
     } else {
       launch_decode<aphrodite::kFloat16.id(), false>(
           a_ptr, b_ptr, s_ptr, z_ptr, c_ptr, size_m, size_k, size_n, group_size,
-          stream, prep_perm);
+          stream, sms, prep_perm);
     }
   } else {
     if (has_zp) {
       launch_decode<aphrodite::kBFloat16.id(), true>(
           a_ptr, b_ptr, s_ptr, z_ptr, c_ptr, size_m, size_k, size_n, group_size,
-          stream, prep_perm);
+          stream, sms, prep_perm);
     } else if (w8) {
       launch_decode<aphrodite::kBFloat16.id(), false, true>(
           a_ptr, b_ptr, s_ptr, z_ptr, c_ptr, size_m, size_k, size_n, group_size,
-          stream, prep_perm);
+          stream, sms, prep_perm);
     } else {
       launch_decode<aphrodite::kBFloat16.id(), false>(
           a_ptr, b_ptr, s_ptr, z_ptr, c_ptr, size_m, size_k, size_n, group_size,
-          stream, prep_perm);
+          stream, sms, prep_perm);
     }
   }
 

--- a/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_moe.cu
+++ b/gptqmodel_ext/swordfish/libtorch_stable/quantization/swordfish/swordfish_moe.cu
@@ -28,6 +28,7 @@
 
 #include "libtorch_stable/torch_utils.h"
 #include "swordfish_decode.cuh"
+#include "swordfish_device_utils.cuh"
 
 namespace swordfish {
 
@@ -307,10 +308,10 @@ void launch_moe(const void* a, const int32_t* b, const void* s, void* c,
                 const int32_t* sorted_ids, const int32_t* expert_ids,
                 const int32_t* num_post_padded, const float* topk_w, int top_k,
                 bool mul_topk, int total_tokens, int max_blocks, int block_size,
-                int k, int n, int group_size, cudaStream_t stream) {
+                int k, int n, int group_size, cudaStream_t stream,
+                int device_index) {
   using scalar_t = typename marlin::MarlinScalarType<type_id>::scalar_t;
-  int sms = 0;
-  cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, 0);
+  const int sms = cached_device_sm_count(device_index);
   constexpr int kUnitK = W8 ? 16 : 32;
   launch_zero_c<scalar_t>(c, total_tokens, n, stream);
   // Host-side upper bound on work keeps tiny batches from launching idle
@@ -328,13 +329,9 @@ void launch_moe(const void* a, const int32_t* b, const void* s, void* c,
   if (block_size == 32) {
     // 32-token blocks fuse two m16 tiles per weight fetch, amortizing the
     // dequant for batched shapes.
-    static int ctas_per_sm2 = 0;
-    if (ctas_per_sm2 == 0) {
-      cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-          &ctas_per_sm2, swordfish_decode_moe_kernel<type_id, W8, 2>,
-          kDecodeThreads, 0);
-      if (ctas_per_sm2 <= 0) ctas_per_sm2 = 2;
-    }
+    const int ctas_per_sm2 = cached_occupancy_for_device(
+        device_index, swordfish_decode_moe_kernel<type_id, W8, 2>,
+        kDecodeThreads, 2);
     swordfish_decode_moe_kernel<type_id, W8, 2>
         <<<grid(ctas_per_sm2), kDecodeThreads, 0, stream>>>(
             reinterpret_cast<const scalar_t*>(a), b,
@@ -344,13 +341,8 @@ void launch_moe(const void* a, const int32_t* b, const void* s, void* c,
             group_size);
     return;
   }
-  static int ctas_per_sm = 0;
-  if (ctas_per_sm == 0) {
-    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-        &ctas_per_sm, swordfish_decode_moe_kernel<type_id, W8>, kDecodeThreads,
-        0);
-    if (ctas_per_sm <= 0) ctas_per_sm = 2;
-  }
+  const int ctas_per_sm = cached_occupancy_for_device(
+      device_index, swordfish_decode_moe_kernel<type_id, W8>, kDecodeThreads, 2);
   swordfish_decode_moe_kernel<type_id, W8>
       <<<grid(ctas_per_sm), kDecodeThreads, 0, stream>>>(
           reinterpret_cast<const scalar_t*>(a), b,
@@ -454,13 +446,13 @@ torch::stable::Tensor swordfish_moe_mm(
           a.const_data_ptr(), b_ptr, group_scales.const_data_ptr(),
           c.mutable_data_ptr(), sid_ptr, eid_ptr, npp_ptr, tw_ptr, int(top_k),
           mul_topk_weights, int(total_tokens), max_blocks, int(moe_block_size),
-          int(size_k), int(size_n), int(group_size), stream);
+          int(size_k), int(size_n), int(group_size), stream, device_index);
     } else {
       launch_moe<aphrodite::kFloat16.id(), false>(
           a.const_data_ptr(), b_ptr, group_scales.const_data_ptr(),
           c.mutable_data_ptr(), sid_ptr, eid_ptr, npp_ptr, tw_ptr, int(top_k),
           mul_topk_weights, int(total_tokens), max_blocks, int(moe_block_size),
-          int(size_k), int(size_n), int(group_size), stream);
+          int(size_k), int(size_n), int(group_size), stream, device_index);
     }
   } else {
     if (w8) {
@@ -468,13 +460,13 @@ torch::stable::Tensor swordfish_moe_mm(
           a.const_data_ptr(), b_ptr, group_scales.const_data_ptr(),
           c.mutable_data_ptr(), sid_ptr, eid_ptr, npp_ptr, tw_ptr, int(top_k),
           mul_topk_weights, int(total_tokens), max_blocks, int(moe_block_size),
-          int(size_k), int(size_n), int(group_size), stream);
+          int(size_k), int(size_n), int(group_size), stream, device_index);
     } else {
       launch_moe<aphrodite::kBFloat16.id(), false>(
           a.const_data_ptr(), b_ptr, group_scales.const_data_ptr(),
           c.mutable_data_ptr(), sid_ptr, eid_ptr, npp_ptr, tw_ptr, int(top_k),
           mul_topk_weights, int(total_tokens), max_blocks, int(moe_block_size),
-          int(size_k), int(size_n), int(group_size), stream);
+          int(size_k), int(size_n), int(group_size), stream, device_index);
     }
   }
 


### PR DESCRIPTION

## What Changed

- `MANIFEST.in`: include `gptqmodel_ext/swordfish/LICENSE` and `gptqmodel_ext/swordfish/licenses/LICENSE` in the source distribution.
- `gptqmodel/nn_modules/qlinear/__init__.py` + `gptqmodel/utils/importer.py`: introduce `SUPPORTS_SHARDED_LOAD` (defaults to `True`) for load-time sharded-checkpoint gating, keeping `SUPPORTS_SHARDS` as the writer-time flag. `SwordfishLinear`/`AwqSwordfishLinear` opt out of sharded loads.
- `gptqmodel_ext/swordfish/.../swordfish_device_utils.cuh`: host-only, per-device cached SM-count and occupancy helpers.
- `swordfish_mm.cu` / `swordfish_moe.cu`: remove hard-coded `cudaDeviceGetAttribute(..., 0)` and use the tensor's device for SM/occupancy queries.
- `gptqmodel/nn_modules/qlinear/swordfish.py`: AWQ->Swordfish repack accumulates in `int64` before casting to `int32`; `AwqSwordfishLinear.post_init` asserts symmetric AWQ `qzeros` equal `2^(bits-1)`.
- `gptqmodel/utils/swordfish.py`: runtime compute-capability gate accepts any device `>= sm100` and the gencode regex now parses `code=sm_*` and `code=compute_*`, honoring the PTX fallback for future Blackwell variants.
- `gptqmodel/utils/cpp.py`: `_nvcc_path` prefers `torch.utils.cpp_extension.CUDA_HOME` over `PATH` so version/arch probes match the compiler torch will use.

## Tests

- `python -m py_compile <changed .py files>` — passed
- `git diff --check` — passed
- Full kernel tests require Blackwell (`sm100`/`sm110`) hardware and JIT compilation; not run in this environment.

## Review Requirements

- [x] I personally reviewed every file in this diff.
- [x] The changes match existing project structure, APIs, and conventions.
- [x] The fixes reuse the existing extension points (`BaseQuantLinear` capabilities, `_nvcc_path`, JIT arch flags).
