### PR TITLE
feat: axk2 (A.X-K2) model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 ## Latest News
 
+* 08/04/2026 7.4.0 `main`: ✨ Added `axk2` (A.X-K2) model support
 * 08/04/2026 7.4.0 `main`: 🚀🔥⚡ Added `Swordfish` Blackwell (>= sm100) GPTQ/AWQ kernel from [AlpinDale](https://x.com/AlpinDale): [Paper](https://blog.alpindale.net/posts/swordfish/).
 * 07/24/2026 7.3.1 `main`: ✨ Added `solar_open` and `solar_open2` model support
 * 07/23/2026 7.3.1 `main`: ✨ Added `Intern S2 PreView` model support

--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -73,6 +73,7 @@ from ..utils.torch import torch_empty_cache  # noqa: E402
 from .base import BaseQModel  # noqa: E402
 from .definitions.afmoe import AfMoeQModel  # noqa: E402
 from .definitions.apertus import ApertusQModel  # noqa: E402
+from .definitions.axk2 import AXK2QModel  # noqa: E402
 from .definitions.baichuan import BaiChuanQModel  # noqa: E402
 from .definitions.bailing_moe import BailingMoeQModel  # noqa: E402
 from .definitions.bloom import BloomQModel  # noqa: E402
@@ -209,6 +210,7 @@ else:
 
 MODEL_MAP = {
     "apertus": ApertusQModel,
+    "axk2": AXK2QModel,
     "dream": DreamQModel,
     "bloom": BloomQModel,
     "brumby": BrumbyQModel,

--- a/gptqmodel/models/definitions/__init__.py
+++ b/gptqmodel/models/definitions/__init__.py
@@ -103,6 +103,7 @@ from .zamba2 import Zamba2QModel
 from .pangu_alpha import PanguAlphaQModel
 from .longcat_flash import LongCatFlashQModel
 from .apertus import ApertusQModel
+from .axk2 import AXK2QModel
 from .klear import KlearQModel
 from .laguna import LagunaQModel
 from .llava_qwen2 import LlavaQwen2QModel

--- a/gptqmodel/models/definitions/axk2.py
+++ b/gptqmodel/models/definitions/axk2.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from ..base import BaseQModel
+from ..moe_lifecycle import GateUpDownMoELifecycleHooks
+
+
+class AXK2QModel(BaseQModel):
+    """A.X-K2 (SKT) sparse MoE/MLA model support.
+
+    Architecture highlights:
+    - DeepSeek-V3-style MLA attention with a fused q_gate_proj that emits both
+      query states and the post-attention sigmoid gate.
+    - Per-layer input_layernorm is an AXK2GatedRMSNorm; its small MLP gate is not
+      quantized.
+    - Dense MLP fallback on layer 0, sparse AXK2MoE on all other layers.
+    - Shared expert and routed experts both use gate_proj/up_proj/down_proj.
+    """
+
+    require_trust_remote_code = False
+    require_fast_init = False
+
+    # allow dynamic expert index for layer_modules so we don't need to write out 256 layers
+    dynamic_expert_index = "n_routed_experts"
+
+    pre_lm_head_norm_module = "model.norm"
+
+    # MoE lifecycle hooks for gate_proj/up_proj/down_proj pattern
+    moe_lifecycle_hooks = GateUpDownMoELifecycleHooks()
+
+    # Layer 0 is a dense MLP while the rest are MoE; don't fail if some expected
+    # MoE modules are missing on a given layer.
+    layer_modules_strict = False
+
+    module_tree = [
+        "model",
+        "layers",
+        "#",
+        {
+            "input_layernorm": ("input_layernorm:!",),
+            "self_attn": (
+                "q_a_proj:0:q",
+                "kv_a_proj_with_mqa:0:k:v",
+                "q_gate_proj:1:q",
+                "kv_b_proj:1:k:v",
+                "o_proj:2",
+            ),
+            "post_attention_layernorm": ("post_attention_layernorm:!",),
+            "mlp:moe": {
+                "": ("gate_proj:0:gate", "up_proj:0:up", "down_proj:1:down"),
+                "gate": ("gate:!", "e_score_correction_bias:!"),
+                "experts:routed": {
+                    "#": ("gate_proj:0:gate", "up_proj:0:up", "down_proj:1:down"),
+                },
+                "shared_experts:shared": ("gate_proj:0:gate", "up_proj:0:up", "down_proj:1:down"),
+            },
+        },
+    ]
+
+
+__all__ = ["AXK2QModel"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ datasets>=3.6.0
 pyarrow>=21.0
 dill>=0.3.8
 torchao>=0.16.0
-defuser>=0.0.24
+defuser>=0.0.25

--- a/tests/models/test_axk2.py
+++ b/tests/models/test_axk2.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-FileCopyrightText: 2024-2025 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+import json
+import os
+import tempfile
+
+import pytest
+import torch
+
+
+pytest.importorskip("defuser")
+pytest.importorskip("transformers.models.axk2")
+
+from transformers import AutoModelForCausalLM  # noqa: E402
+from transformers.models.axk2.configuration_axk2 import AXK2Config  # noqa: E402
+
+from gptqmodel.models.auto import MODEL_MAP, check_and_get_model_definition  # noqa: E402
+from gptqmodel.models.definitions.axk2 import AXK2QModel  # noqa: E402
+from gptqmodel.quantization import QuantizeConfig  # noqa: E402
+from gptqmodel.utils.model import find_modules  # noqa: E402
+
+
+def _tiny_axk2_config() -> AXK2Config:
+    return AXK2Config(
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=128,
+        moe_intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        q_lora_rank=16,
+        kv_lora_rank=8,
+        qk_nope_head_dim=8,
+        qk_rope_head_dim=4,
+        v_head_dim=8,
+        index_n_heads=2,
+        index_head_dim=8,
+        first_k_dense_replace=1,
+        moe_layer_freq=1,
+        bos_token_id=1,
+        eos_token_id=2,
+    )
+
+
+def test_model_map_registration():
+    assert MODEL_MAP.get("axk2") is AXK2QModel
+
+
+def test_check_and_get_model_definition():
+    with tempfile.TemporaryDirectory() as d:
+        cfg = {
+            "model_type": "axk2",
+            "architectures": ["AXK2ForCausalLM"],
+            "hidden_size": 64,
+            "intermediate_size": 128,
+            "moe_intermediate_size": 32,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "n_routed_experts": 4,
+            "n_shared_experts": 1,
+            "num_experts_per_tok": 2,
+            "q_lora_rank": 16,
+            "kv_lora_rank": 8,
+            "qk_nope_head_dim": 8,
+            "qk_rope_head_dim": 4,
+            "v_head_dim": 8,
+            "index_n_heads": 2,
+            "index_head_dim": 8,
+            "first_k_dense_replace": 1,
+            "moe_layer_freq": 1,
+            "vocab_size": 128,
+            "rms_norm_eps": 1e-06,
+            "hidden_act": "silu",
+            "bos_token_id": 1,
+            "eos_token_id": 2,
+        }
+        with open(os.path.join(d, "config.json"), "w") as f:
+            json.dump(cfg, f)
+        definition = check_and_get_model_definition(d)
+        assert definition is AXK2QModel
+
+
+def test_simple_layer_modules_expand():
+    cfg = _tiny_axk2_config()
+    qcfg = QuantizeConfig(bits=4, group_size=128)
+    layer_modules = AXK2QModel.simple_layer_modules(cfg, qcfg)
+    flat = [name for block in layer_modules for name in block]
+    # Attention projections
+    assert "self_attn.q_a_proj" in flat
+    assert "self_attn.kv_a_proj_with_mqa" in flat
+    assert "self_attn.q_gate_proj" in flat
+    assert "self_attn.kv_b_proj" in flat
+    assert "self_attn.o_proj" in flat
+    # MoE projections
+    assert any("mlp.experts.0.gate_proj" in name for name in flat)
+    assert any("mlp.experts.3.down_proj" in name for name in flat)
+    assert "mlp.shared_experts.gate_proj" in flat
+
+
+@pytest.mark.parametrize("num_experts", [2, 4, 8])
+def test_dynamic_expert_index(num_experts: int):
+    cfg = _tiny_axk2_config()
+    cfg.n_routed_experts = num_experts
+    qcfg = QuantizeConfig(bits=4, group_size=128)
+    layer_modules = AXK2QModel.simple_layer_modules(cfg, qcfg)
+    flat = [name for block in layer_modules for name in block]
+    assert any(f"mlp.experts.{num_experts - 1}.gate_proj" in name for name in flat)
+    assert not any(f"mlp.experts.{num_experts}.gate_proj" in name for name in flat)
+
+
+def test_defuser_unfuses_axk2_experts():
+    cfg = _tiny_axk2_config()
+    with torch.device("meta"):
+        model = AutoModelForCausalLM.from_config(cfg, dtype=torch.float32, trust_remote_code=False)
+
+    # Defuser registration is performed when AXK2QModel is imported.
+    import defuser
+
+    converted = defuser.convert_model(model, cleanup_original=False)
+    assert converted is True
+
+    modules = find_modules(model)
+    # Routed experts should be per-expert nn.Linear modules.
+    assert "model.layers.1.mlp.experts.0.gate_proj" in modules
+    assert "model.layers.1.mlp.experts.0.up_proj" in modules
+    assert "model.layers.1.mlp.experts.0.down_proj" in modules
+    # Shared experts should stay reachable.
+    assert "model.layers.1.mlp.shared_experts.gate_proj" in modules
+
+
+def test_quantizable_modules_match_tree():
+    cfg = _tiny_axk2_config()
+    with torch.device("meta"):
+        model = AutoModelForCausalLM.from_config(cfg, dtype=torch.float32, trust_remote_code=False)
+
+    import defuser
+
+    defuser.convert_model(model, cleanup_original=False)
+    qcfg = QuantizeConfig(bits=4, group_size=128)
+    slm = AXK2QModel.simple_layer_modules(cfg, qcfg)
+    modules = find_modules(model)
+    matched = {name for name in modules if any(name.endswith(suffix) for sublist in slm for suffix in sublist)}
+    # Core attention and MoE modules should be matched.
+    assert any("self_attn.q_a_proj" in n for n in matched)
+    assert any("self_attn.q_gate_proj" in n for n in matched)
+    assert any("mlp.experts.0.gate_proj" in n for n in matched)
+    # Indexer and gated-RMSNorm internals are not part of the tree.
+    assert not any("self_attn.indexer" in n for n in matched)
+    assert not any("input_layernorm.mlp" in n for n in matched)


### PR DESCRIPTION
## Summary

Port `axk2` (SKT A.X-K2) model support from GPT-QModel-Ultra, including the `module_tree` role/semantic flags (`:q`, `:k`, `:v`, `:gate`, `:up`, `:down`) used in the Ultra definition.

### What changed

- Added `gptqmodel/models/definitions/axk2.py` with `AXK2QModel`.
  - DeepSeek-V3-style MLA attention with `q_a_proj`, `kv_a_proj_with_mqa`, `q_gate_proj`, `kv_b_proj`, and `o_proj`.
  - MoE `module_tree` using `GateUpDownMoELifecycleHooks`, `dynamic_expert_index = "n_routed_experts"`, and `layer_modules_strict = False`.
- Registered `AXK2QModel` in `gptqmodel/models/auto.py` and `gptqmodel/models/definitions/__init__.py`.
- Added `tests/models/test_axk2.py` with `pytest.importorskip` guards for `defuser` and `transformers.models.axk2`.
- Bumped `defuser` requirement to `>=0.0.25` (required for `axk2` defusing).

### Why

A.X-K2 uses `AXK2Experts` with 3D fused `gate_up_proj`/`down_proj` expert weights. Defuser `0.0.25` supports `axk2`, so the generic fused-experts pass can unfuse them into per-expert `gate_proj`/`up_proj`/`down_proj` `nn.Linear` modules.

### Validation

```bash
PYTHONPATH=/root/GPTQModel-port-axk2 python -m pytest tests/models/test_axk2.py -q
```

All 8 tests pass:
- `MODEL_MAP['axk2']` resolves to `AXK2QModel`.
- `simple_layer_modules` expands correctly for a tiny `AXK2Config`.
- `defuser.convert_model` unfuses `AXK2Experts` into numbered `_ExpertContainer` children.
- `find_modules` matches the expanded `simple_layer_modules`.

Link to Devin session: https://app.devin.ai/sessions/71567c016a914e238fdce232181bfbec
Requested by: @Qubitium