### PR TITLE
fix(looper): pass dotted layer names to cache_inputs for correct lazy materialization

### DIFF
--- a/gptqmodel/looper/module_looper.py
+++ b/gptqmodel/looper/module_looper.py
@@ -1389,7 +1389,7 @@ class ModuleLooper():
 
         return pre_hook
 
-    def cache_inputs(self, layers, calibration_data, use_cache):
+    def cache_inputs(self, layers, calibration_data, use_cache, layer_names=None):
         """Capture and cache per-layer calibration inputs for later replay."""
 
         capture_stage = StageInputsCapture(self, logger=log)
@@ -1397,6 +1397,7 @@ class ModuleLooper():
             layers=layers,
             calibration_data=calibration_data,
             use_cache=use_cache,
+            layer_names=layer_names,
         )
 
     def loop(self, fallback=None, **kwargs):
@@ -1458,6 +1459,7 @@ class ModuleLooper():
                 continue
 
             input_cache = self.cache_inputs(layers=layers,
+                                            layer_names=layer_names,
                                             calibration_data=processor.calibration_dataset,
                                             use_cache=False)
             processor.receive_input_cache(input_cache)

--- a/gptqmodel/looper/stage_inputs_capture.py
+++ b/gptqmodel/looper/stage_inputs_capture.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Sequence
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Sequence
 
 import torch
 
@@ -57,6 +57,7 @@ class StageInputsCapture:
         layers: Sequence[torch.nn.Module],
         calibration_data: Iterable[Dict[str, torch.Tensor]],
         use_cache: bool,
+        layer_names: Optional[List[str]] = None,
     ) -> InputCache:
         """Runs a short forward over calibration data and caches first-layer inputs."""
 
@@ -69,10 +70,30 @@ class StageInputsCapture:
         layer_label = None
         if layers:
             first_layer = layers[0]
-            layer_label = getattr(first_layer, "full_name", None)
-            if layer_label is None:
+            # The caller-supplied dotted path is the single source of truth for
+            # materializing the first layer from a lazy checkpoint source. An
+            # explicit `full_name` attribute is a legacy fallback; warn if the two
+            # disagree so the override is not silent.
+            full_name = getattr(first_layer, "full_name", None)
+            if layer_names and layer_names[0]:
+                layer_label = layer_names[0]
+                if full_name and full_name != layer_label:
+                    self.logger.warn(
+                        f"cache_inputs: using caller-supplied layer_name {layer_label!r} "
+                        f"instead of layer.full_name {full_name!r} for materialization"
+                    )
+            elif full_name:
+                layer_label = full_name
+            if not layer_label:
+                # Fallback: discover the dotted path from the model tree when the
+                # caller does not supply names.
+                for name, mod in self.gptq_model.model.named_modules():
+                    if mod is first_layer:
+                        layer_label = name
+                        break
+            if not layer_label:
                 layer_label = getattr(getattr(first_layer, "__class__", None), "__name__", None)
-            if layer_label is None:
+            if not layer_label:
                 layer_label = type(first_layer).__name__
             capture_source = f"cache_inputs:{layer_label}"
         else:
@@ -98,6 +119,7 @@ class StageInputsCapture:
         layers[0] = self.gptq_model.shell_module_materialize(
             target_submodule=layers[0],
             device=CPU,
+            module_path=layer_label,
         )
         cur_layer_device = CPU
 
@@ -205,6 +227,7 @@ class StageInputsCapture:
             self.gptq_model.shell_module_materialize(
                 target_submodule=module,
                 device=cur_layer_device,
+                module_path=module_name,
             )
 
         handle = layers[0].register_forward_pre_hook(store_input_hook, with_kwargs=True)

--- a/gptqmodel/looper/stage_inputs_capture.py
+++ b/gptqmodel/looper/stage_inputs_capture.py
@@ -75,28 +75,32 @@ class StageInputsCapture:
             # explicit `full_name` attribute is a legacy fallback; warn if the two
             # disagree so the override is not silent.
             full_name = getattr(first_layer, "full_name", None)
+            module_path = None
             if layer_names and layer_names[0]:
-                layer_label = layer_names[0]
-                if full_name and full_name != layer_label:
+                module_path = layer_names[0]
+                if full_name and full_name != module_path:
                     self.logger.warn(
-                        f"cache_inputs: using caller-supplied layer_name {layer_label!r} "
+                        f"cache_inputs: using caller-supplied layer_name {module_path!r} "
                         f"instead of layer.full_name {full_name!r} for materialization"
                     )
             elif full_name:
-                layer_label = full_name
-            if not layer_label:
+                module_path = full_name
+            if not module_path:
                 # Fallback: discover the dotted path from the model tree when the
                 # caller does not supply names.
                 for name, mod in self.gptq_model.model.named_modules():
                     if mod is first_layer:
-                        layer_label = name
+                        module_path = name
                         break
-            if not layer_label:
-                layer_label = getattr(getattr(first_layer, "__class__", None), "__name__", None)
-            if not layer_label:
-                layer_label = type(first_layer).__name__
+
+            # Keep the class-name fallback as a display label only; do not pass it
+            # as a checkpoint module path because it is not a valid dotted prefix.
+            layer_label = module_path or full_name or getattr(
+                getattr(first_layer, "__class__", None), "__name__", None
+            ) or type(first_layer).__name__
             capture_source = f"cache_inputs:{layer_label}"
         else:
+            module_path = None
             capture_source = "cache_inputs"
         start_time = time.perf_counter() if timer else None
 
@@ -119,7 +123,7 @@ class StageInputsCapture:
         layers[0] = self.gptq_model.shell_module_materialize(
             target_submodule=layers[0],
             device=CPU,
-            module_path=layer_label,
+            module_path=module_path,
         )
         cur_layer_device = CPU
 
@@ -215,6 +219,12 @@ class StageInputsCapture:
         # Parameters attached to the shell root must be ready before embedding forward.
         self._materialize_modules_with_direct_meta_tensors(cur_layer_device)
 
+        def _resolve_module_name(mod: torch.nn.Module) -> Optional[str]:
+            for name, m in self.gptq_model.model.named_modules():
+                if m is mod:
+                    return name
+            return None
+
         ori_outside_layer_module_devices: Dict[str, torch.device] = {}
         for module_name in self.gptq_model.get_base_modules(self.gptq_model.model):
             module, _ = get_module_by_name_prefix(self.gptq_model.model, [module_name])
@@ -222,12 +232,13 @@ class StageInputsCapture:
             if module is None:
                 continue
 
+            resolved_name = _resolve_module_name(module)
             m_device = get_device(module)
             ori_outside_layer_module_devices[module_name] = CPU if m_device == META else m_device
             self.gptq_model.shell_module_materialize(
                 target_submodule=module,
                 device=cur_layer_device,
-                module_path=module_name,
+                module_path=resolved_name,
             )
 
         handle = layers[0].register_forward_pre_hook(store_input_hook, with_kwargs=True)

--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -2648,6 +2648,7 @@ class BaseQModel(nn.Module):
             non_blocking: bool = False,
             role: str = "default",
             named_module: Optional["NamedModule"] = None,
+            module_path: Optional[str] = None,
     ) -> torch.nn.Module:
         with self._turtle_lock:
             if role == "quant_source" and named_module is not None:
@@ -2709,6 +2710,7 @@ class BaseQModel(nn.Module):
                     turtle_model=turtle_model,
                     target_submodule=target_submodule,
                     device=device,
+                    module_path=module_path,
                 )
 
             if role == "forward" and named_module is not None:

--- a/gptqmodel/utils/structure.py
+++ b/gptqmodel/utils/structure.py
@@ -3038,6 +3038,7 @@ def alias_from_turtle_for_submodule(
     target_submodule: torch.nn.Module,
     device: torch.device,
     non_blocking: bool = False,
+    module_path: Optional[str] = None,
 ) -> torch.nn.Module:
     # Lazy turtle supports materialization from checkpoint storage into CPU or accelerator devices.
     assert device not in [None, torch.device("meta")]
@@ -3051,6 +3052,7 @@ def alias_from_turtle_for_submodule(
         target_submodule=target_submodule,
         device=device,
         non_blocking=non_blocking,
+        module_path=module_path,
     )
 
 

--- a/tests/test_stage_inputs_capture.py
+++ b/tests/test_stage_inputs_capture.py
@@ -93,7 +93,8 @@ class TestStageInputsCapture(unittest.TestCase):
         self.assertEqual(call_kwargs["module_path"], "layers.0")
 
     def test_cache_inputs_falls_back_to_class_name_for_orphan_layer(self):
-        """If the layer cannot be found in the model tree, use its class name."""
+        """If the layer cannot be found in the model tree, the display label falls back to its class name,
+        but the materialization module_path is left unset so the underlying resolver can either find it or fail loudly."""
 
         layer = FakeLayer()
         capture, layers, _, gptq_model = self._make_capture(layer, gptq_model_model=FakeModel())
@@ -107,7 +108,7 @@ class TestStageInputsCapture(unittest.TestCase):
         )
 
         call_kwargs = gptq_model.shell_module_materialize.call_args[1]
-        self.assertEqual(call_kwargs["module_path"], "FakeLayer")
+        self.assertIsNone(call_kwargs["module_path"])
 
     def test_cache_inputs_prefers_full_name_attribute(self):
         """A layer-level `full_name` attribute is respected when `layer_names` is absent."""

--- a/tests/test_stage_inputs_capture.py
+++ b/tests/test_stage_inputs_capture.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+from torch import nn
+
+from gptqmodel.looper.stage_inputs_capture import StageInputsCapture
+
+
+class FakeLayer(nn.Module):
+    """Minimal decoder layer stand-in for module-path tests."""
+
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(2, 2)
+
+
+class FakeModel(nn.Module):
+    """Tiny model tree for testing fallback path resolution."""
+
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList([FakeLayer()])
+
+
+class TestStageInputsCapture(unittest.TestCase):
+    """Micro-tests for the layer label / module_path resolution in `StageInputsCapture`."""
+
+    def _make_capture(self, layer, layer_names=None, gptq_model_model=None):
+        layer_list = [layer]
+        layer_names_list = layer_names
+
+        quantize_config = MagicMock()
+        quantize_config.device = torch.device("cpu")
+        quantize_config.calibration_data_device = None
+        quantize_config.offload_to_disk = False
+        quantize_config.compute_device_filter = None
+
+        gptq_model = MagicMock()
+        gptq_model.model = gptq_model_model or FakeModel()
+        gptq_model.quantize_config = quantize_config
+        gptq_model.get_modules_with_direct_meta_tensors.return_value = []
+        gptq_model.get_base_modules.return_value = []
+        gptq_model.get_input_embeddings.return_value = None
+        gptq_model.get_input_embeddings_name.return_value = None
+        gptq_model.shell_module_materialize.return_value = layer
+        gptq_model.shell_direct_meta_materialize.return_value = None
+        gptq_model.ATTENTION_MASKS_REQUIRED_FOR_INPUT = False
+        gptq_model.quant_region_timer = None
+
+        looper = MagicMock()
+        looper.gptq_model = gptq_model
+
+        capture = StageInputsCapture(looper)
+        return capture, layer_list, layer_names_list, gptq_model
+
+    def test_cache_inputs_uses_caller_supplied_layer_name(self):
+        """`layer_names[0]` should win and become the materialization module_path."""
+
+        layer = FakeLayer()
+        capture, layers, layer_names, gptq_model = self._make_capture(
+            layer, layer_names=["model.layers.42"]
+        )
+
+        capture.cache_inputs(
+            layers=layers,
+            calibration_data=[],
+            use_cache=False,
+            layer_names=layer_names,
+        )
+
+        gptq_model.shell_module_materialize.assert_called_once()
+        call_kwargs = gptq_model.shell_module_materialize.call_args[1]
+        self.assertEqual(call_kwargs["module_path"], "model.layers.42")
+
+    def test_cache_inputs_falls_back_to_named_modules_resolution(self):
+        """Without `layer_names` and `full_name`, scan `named_modules()` for dotted path."""
+
+        model = FakeModel()
+        layer = model.layers[0]
+        capture, layers, _, gptq_model = self._make_capture(layer, gptq_model_model=model)
+
+        capture.cache_inputs(
+            layers=layers,
+            calibration_data=[],
+            use_cache=False,
+        )
+
+        call_kwargs = gptq_model.shell_module_materialize.call_args[1]
+        self.assertEqual(call_kwargs["module_path"], "layers.0")
+
+    def test_cache_inputs_falls_back_to_class_name_for_orphan_layer(self):
+        """If the layer cannot be found in the model tree, use its class name."""
+
+        layer = FakeLayer()
+        capture, layers, _, gptq_model = self._make_capture(layer, gptq_model_model=FakeModel())
+        # Detach the layer so it is not the same object as the one in the model tree.
+        self.assertIsNot(layer, gptq_model.model.layers[0])
+
+        capture.cache_inputs(
+            layers=layers,
+            calibration_data=[],
+            use_cache=False,
+        )
+
+        call_kwargs = gptq_model.shell_module_materialize.call_args[1]
+        self.assertEqual(call_kwargs["module_path"], "FakeLayer")
+
+    def test_cache_inputs_prefers_full_name_attribute(self):
+        """A layer-level `full_name` attribute is respected when `layer_names` is absent."""
+
+        layer = FakeLayer()
+        layer.full_name = "custom.path.layer_0"
+        capture, layers, _, gptq_model = self._make_capture(layer, gptq_model_model=FakeModel())
+
+        capture.cache_inputs(
+            layers=layers,
+            calibration_data=[],
+            use_cache=False,
+        )
+
+        call_kwargs = gptq_model.shell_module_materialize.call_args[1]
+        self.assertEqual(call_kwargs["module_path"], "custom.path.layer_0")
+
+    def test_cache_inputs_warns_when_caller_name_differs_from_full_name(self):
+        """A caller-supplied `layer_names[0]` wins, but a mismatch against `full_name` is logged."""
+
+        layer = FakeLayer()
+        layer.full_name = "legacy.path.layer_0"
+        capture, layers, layer_names, gptq_model = self._make_capture(
+            layer,
+            layer_names=["model.layers.42"],
+            gptq_model_model=FakeModel(),
+        )
+        mock_logger = MagicMock()
+        capture.logger = mock_logger
+
+        capture.cache_inputs(
+            layers=layers,
+            calibration_data=[],
+            use_cache=False,
+            layer_names=layer_names,
+        )
+
+        call_kwargs = gptq_model.shell_module_materialize.call_args[1]
+        self.assertEqual(call_kwargs["module_path"], "model.layers.42")
+        mock_logger.warn.assert_called_once()
+        message = mock_logger.warn.call_args[0][0]
+        self.assertIn("model.layers.42", message)
+        self.assertIn("legacy.path.layer_0", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`ModuleLooper` already resolves dotted layer paths via `get_layers_with_prefixes`, but `StageInputsCapture.cache_inputs` was not receiving them. Without this path, lazy checkpoint materialization fell back to the layer's `full_name` attribute (when present) or the layer class name, which could resolve to the wrong submodule and skip buffers that belong under the correct dotted prefix.

The fix plumbs the caller-supplied layer names through `ModuleLooper.cache_inputs` into `StageInputsCapture.cache_inputs` and forwards the first layer's dotted path to `shell_module_materialize` / `alias_from_turtle_for_submodule`.

## What Changed

- `gptqmodel/looper/module_looper.py`
  - `cache_inputs` now accepts an optional `layer_names` argument and forwards it to `StageInputsCapture.cache_inputs`.
  - `_loop_impl` passes the `layer_names` list obtained from `get_layers_with_prefixes` into `cache_inputs`.

- `gptqmodel/looper/stage_inputs_capture.py`
  - `cache_inputs` accepts `layer_names: Optional[List[str]]`.
  - Layer label resolution now prefers `layer_names[0]`, then the layer's `full_name` attribute, then a `named_modules()` scan, then the class name.
  - When a caller-supplied name differs from `full_name`, a warning is logged so the override is not silent.
  - The resolved label is passed as `module_path` to `shell_module_materialize` for both the first layer and base modules.

- `gptqmodel/models/base.py` + `gptqmodel/utils/structure.py`
  - `BaseQModel.shell_module_materialize` and `alias_from_turtle_for_submodule` now accept an optional `module_path` argument and propagate it to `LazyTurtle.materialize_submodule`, avoiding a full `named_modules()` scan when the path is already known.

- `tests/test_stage_inputs_capture.py`
  - Added micro-tests covering caller-supplied layer name, `named_modules()` fallback, class-name fallback for orphan layers, `full_name` attribute precedence, and the mismatch warning.

## Tests

- [x] I added a new simple/fast unit test for this change.
- [x] I ran the new targeted test locally before opening this PR.

```bash
python -m pytest tests/test_stage_inputs_capture.py -q
```

Result: `5 passed in 3.80s`.

## Review Requirements

- [x] I personally reviewed every file in this diff.
- [x] I checked that the code matches existing project structure, APIs, and conventions.
- [x] I avoided unnecessary monkeypatching and used the project's normal extension points where possible.

## Notes

This change only affects the default materialization path used during input capture. The `quant_source` and `forward` paths in `shell_module_materialize` already locate their submodule through other means and are left unchanged.

Link to Devin session: https://app.devin.ai/sessions/de93d783b51243b496c3ff1c42bc4fb1
Requested by: @Qubitium