### PR TITLE
fix looper concurrency safety

### DIFF
--- a/gptqmodel/looper/eora_processor.py
+++ b/gptqmodel/looper/eora_processor.py
@@ -240,7 +240,7 @@ class EoraProcessor(LoopProcessor):
 
         assert isinstance(module.adapter_cfg, Lora)
 
-        self.pb.title(f"EoRA: Processing {module.name} ({module.module_dtype}) in layer").draw()
+        self.draw_progress(f"EoRA: Processing {module.name} ({module.module_dtype}) in layer")
 
         start = time.time()
 

--- a/gptqmodel/looper/loop_processor.py
+++ b/gptqmodel/looper/loop_processor.py
@@ -76,6 +76,21 @@ class _ThreadSafeDict(dict):
         with self._lock:
             return super().__contains__(key)
 
+    def _snapshot(self):
+        with self._lock:
+            return dict(super().items())
+
+    def __eq__(self, other):
+        if other is self:
+            return True
+        own_snapshot = self._snapshot()
+        other_snapshot = other._snapshot() if isinstance(other, _ThreadSafeDict) else other
+        return dict.__eq__(own_snapshot, other_snapshot)
+
+    def __ne__(self, other):
+        result = self.__eq__(other)
+        return NotImplemented if result is NotImplemented else not result
+
     def __iter__(self):
         with self._lock:
             return iter(list(super().__iter__()))
@@ -323,6 +338,20 @@ class LoopProcessor:
             if self.pb is None:
                 return
             self.pb.title(title).subtitle(subtitle).draw()
+
+    def _get_input_cache_lock(self):
+        """Returns the cache lock, including for lightweight test and script instances."""
+
+        lock = getattr(self, "_input_cache_lock", None)
+        if lock is not None:
+            return lock
+
+        with PROCESSOR_GLOBAL_LOCK:
+            lock = getattr(self, "_input_cache_lock", None)
+            if lock is None:
+                lock = threading.RLock()
+                object.__setattr__(self, "_input_cache_lock", lock)
+        return lock
 
     @staticmethod
     def _compute_total_tokens(calibration_dataset) -> int:
@@ -732,14 +761,14 @@ class LoopProcessor:
                 try:
                     handle.close()
                 except Exception:
-                    pass
+                    log.debug("Failed to close device telemetry handle during cleanup.", exc_info=True)
             self._device_smi_handles.clear()
 
             if self._cpu_device_smi is not None:
                 try:
                     self._cpu_device_smi.close()
                 except Exception:
-                    pass
+                    log.debug("Failed to close CPU telemetry handle during cleanup.", exc_info=True)
                 self._cpu_device_smi = None
 
     # Loop Procssor level scoped state data
@@ -821,15 +850,20 @@ class LoopProcessor:
     def receive_input_cache(self, input_cache: Any):
         """Injects the shared input cache for the current processor stage."""
 
-        with self._input_cache_lock:
-            self.inputs_cache.set_cache(input_cache)
+        with self._get_input_cache_lock():
+            current = getattr(self, "inputs_cache", None)
+            if isinstance(current, _ThreadSafeInputCache):
+                current.set_cache(input_cache)
+            else:
+                cache = input_cache.unwrap() if isinstance(input_cache, _ThreadSafeInputCache) else input_cache
+                self.inputs_cache = _ThreadSafeInputCache(cache)
 
     # called after every module generate
     # may be called multiple times due to batch
     def receive_layer_inputs(self, layer_inputs: List[List[Tensor]]):
         """Replaces cached layer outputs that feed the next loop stage."""
 
-        with self._input_cache_lock:
+        with self._get_input_cache_lock():
             self.inputs_cache.layer_inputs = layer_inputs
 
     def receive_layer_forward_context(
@@ -857,7 +891,7 @@ class LoopProcessor:
         """Drops transient task data and cached layer inputs after replay."""
 
         self.tasks.clear()
-        with self._input_cache_lock:
+        with self._get_input_cache_lock():
             self.inputs_cache.layer_inputs = []
 
     def pre_process_fwd_hook(self, name: str) -> Callable[[Module, Tuple[torch.Tensor, ...], torch.Tensor], None]:

--- a/gptqmodel/looper/loop_processor.py
+++ b/gptqmodel/looper/loop_processor.py
@@ -53,6 +53,107 @@ DEFAULT_LOG_COLUMNS: List[str] = [
 ]
 
 
+class _ThreadSafeDict(dict):
+    """Dictionary with synchronized mutations and snapshot-based iteration."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._lock = threading.RLock()
+
+    def __getitem__(self, key):
+        with self._lock:
+            return super().__getitem__(key)
+
+    def __setitem__(self, key, value):
+        with self._lock:
+            super().__setitem__(key, value)
+
+    def __delitem__(self, key):
+        with self._lock:
+            super().__delitem__(key)
+
+    def __contains__(self, key):
+        with self._lock:
+            return super().__contains__(key)
+
+    def __iter__(self):
+        with self._lock:
+            return iter(list(super().__iter__()))
+
+    def __len__(self):
+        with self._lock:
+            return super().__len__()
+
+    def get(self, key, default=None):
+        with self._lock:
+            return super().get(key, default)
+
+    def setdefault(self, key, default=None):
+        with self._lock:
+            return super().setdefault(key, default)
+
+    def pop(self, key, *args):
+        with self._lock:
+            return super().pop(key, *args)
+
+    def popitem(self):
+        with self._lock:
+            return super().popitem()
+
+    def clear(self):
+        with self._lock:
+            super().clear()
+
+    def update(self, *args, **kwargs):
+        with self._lock:
+            super().update(*args, **kwargs)
+
+    def keys(self):
+        with self._lock:
+            return list(super().keys())
+
+    def values(self):
+        with self._lock:
+            return list(super().values())
+
+    def items(self):
+        with self._lock:
+            return list(super().items())
+
+
+class _ThreadSafeInputCache:
+    """Synchronize replacement and attribute access for a shared ``InputCache``."""
+
+    def __init__(self, cache: InputCache):
+        object.__setattr__(self, "_cache", cache)
+        object.__setattr__(self, "_lock", threading.RLock())
+
+    def set_cache(self, cache: Any) -> None:
+        if isinstance(cache, _ThreadSafeInputCache):
+            cache = cache.unwrap()
+        with self._lock:
+            object.__setattr__(self, "_cache", cache)
+
+    def unwrap(self) -> InputCache:
+        with self._lock:
+            return object.__getattribute__(self, "_cache")
+
+    def __getattr__(self, name: str):
+        with self._lock:
+            return getattr(object.__getattribute__(self, "_cache"), name)
+
+    def __setattr__(self, name: str, value):
+        if name in {"_cache", "_lock"}:
+            object.__setattr__(self, name, value)
+            return
+        with self._lock:
+            setattr(object.__getattribute__(self, "_cache"), name, value)
+
+    def __delattr__(self, name: str):
+        with self._lock:
+            delattr(object.__getattribute__(self, "_cache"), name)
+
+
 @dataclass
 class ExecutionConfig:
     """Describe how a processor participates in forward replay and activation capture.
@@ -110,6 +211,10 @@ class LoopProcessor:
         # result is total collection of all module results mapped by module.full_name
         self._results: Dict[str, Any] = {}
         self._results_lock = threading.Lock()
+        self._progress_lock = threading.Lock()
+        self._fwd_time_lock = threading.Lock()
+        self._device_smi_lock = threading.RLock()
+        self._input_cache_lock = threading.RLock()
 
         self.tokenizer = tokenizer
         self.qcfg = qcfg
@@ -119,8 +224,8 @@ class LoopProcessor:
         # one execution mode instead of a scattered set of booleans.
         self.execution_config = execution_config or ExecutionConfig()
 
-        self.inputs_cache: InputCache = InputCache(None, None, None, None)
-        self.tasks = {}
+        self.inputs_cache = _ThreadSafeInputCache(InputCache([], [], [], []))
+        self.tasks = _ThreadSafeDict()
 
         self.pb = None
         self.fwd_time = None
@@ -214,9 +319,10 @@ class LoopProcessor:
     def draw_progress(self, title: str, subtitle: str = "") -> None:
         """Best-effort progress-bar redraw for processors with an attached progress handle."""
 
-        if self.pb is None:
-            return
-        self.pb.title(title).subtitle(subtitle).draw()
+        with self._progress_lock:
+            if self.pb is None:
+                return
+            self.pb.title(title).subtitle(subtitle).draw()
 
     @staticmethod
     def _compute_total_tokens(calibration_dataset) -> int:
@@ -544,34 +650,37 @@ class LoopProcessor:
     def _safe_query_metric(self, device_key: str, handle: Device):
         """Queries Device-SMI metrics once per device, suppressing repeated failures."""
 
-        try:
-            return handle.metrics(fast=True)
-        except Exception as exc:  # pragma: no cover - defensive, external tool
-            if device_key not in self._device_metric_failures:
-                log.debug(f"Device-SMI metrics failed for `{device_key}`: {exc}")
-                self._device_metric_failures.add(device_key)
-            return None
+        with self._device_smi_lock:
+            try:
+                return handle.metrics(fast=True)
+            except Exception as exc:  # pragma: no cover - defensive, external tool
+                if device_key not in self._device_metric_failures:
+                    log.debug(f"Device-SMI metrics failed for `{device_key}`: {exc}")
+                    self._device_metric_failures.add(device_key)
+                return None
 
     def _snapshot_device_memory_gib(self) -> Dict[str, float]:
         """Captures current accelerator memory usage in GiB per device."""
 
-        snapshot: Dict[str, float] = {}
-        for device_id, handle in self._device_smi_handles.items():
-            metrics = self._safe_query_metric(device_id, handle)
-            if metrics is None:
-                continue
-            snapshot[device_id] = metrics.memory_used / (1024 ** 3)
-        return snapshot
+        with self._device_smi_lock:
+            snapshot: Dict[str, float] = {}
+            for device_id, handle in self._device_smi_handles.items():
+                metrics = self._safe_query_metric(device_id, handle)
+                if metrics is None:
+                    continue
+                snapshot[device_id] = metrics.memory_used / (1024 ** 3)
+            return snapshot
 
     def _snapshot_cpu_memory_gib(self) -> Optional[float]:
         """Captures current CPU memory usage in GiB when supported."""
 
-        if self._cpu_device_smi is None:
-            return None
-        metrics = self._safe_query_metric("cpu", self._cpu_device_smi)
-        if metrics is None:
-            return None
-        return metrics.memory_used / (1024 ** 3)
+        with self._device_smi_lock:
+            if self._cpu_device_smi is None:
+                return None
+            metrics = self._safe_query_metric("cpu", self._cpu_device_smi)
+            if metrics is None:
+                return None
+            return metrics.memory_used / (1024 ** 3)
 
     def device_memory_report(self) -> str:
         """Formats current accelerator memory usage for processor log rows."""
@@ -618,19 +727,20 @@ class LoopProcessor:
     def _close_device_smi_handles(self) -> None:
         """Closes all Device-SMI handles owned by this processor."""
 
-        for handle in self._device_smi_handles.values():
-            try:
-                handle.close()
-            except Exception:
-                pass
-        self._device_smi_handles.clear()
+        with self._device_smi_lock:
+            for handle in self._device_smi_handles.values():
+                try:
+                    handle.close()
+                except Exception:
+                    pass
+            self._device_smi_handles.clear()
 
-        if self._cpu_device_smi is not None:
-            try:
-                self._cpu_device_smi.close()
-            except Exception:
-                pass
-            self._cpu_device_smi = None
+            if self._cpu_device_smi is not None:
+                try:
+                    self._cpu_device_smi.close()
+                except Exception:
+                    pass
+                self._cpu_device_smi = None
 
     # Loop Procssor level scoped state data
     def result_save(self, key: str, value: Any):
@@ -658,7 +768,8 @@ class LoopProcessor:
     def results(self):
         """Returns the full processor result mapping."""
 
-        return self._results
+        with self._results_lock:
+            return dict(self._results)
 
     def collect_memory_info(self, layer_index: int):
         """Records current accelerator and CPU memory snapshots for diagnostics."""
@@ -685,13 +796,15 @@ class LoopProcessor:
     def set_fwd_time(self, fwd_time: float):
         """Stores the latest forward-pass duration for logging."""
 
-        self.fwd_time = fwd_time
+        with self._fwd_time_lock:
+            self.fwd_time = fwd_time
 
     def formatted_fwd_time(self) -> str:
         """Returns the stored forward time as a fixed-width string."""
 
-        fwd_time = self.fwd_time if self.fwd_time is not None else 0.0
-        return f"{fwd_time:.3f}"
+        with self._fwd_time_lock:
+            fwd_time = self.fwd_time if self.fwd_time is not None else 0.0
+            return f"{fwd_time:.3f}"
 
     # called first
     def preprocess(self, module: NamedModule, **kwargs):
@@ -705,17 +818,19 @@ class LoopProcessor:
 
         pass
 
-    def receive_input_cache(self, input_cache: InputCache):
+    def receive_input_cache(self, input_cache: Any):
         """Injects the shared input cache for the current processor stage."""
 
-        self.inputs_cache = input_cache
+        with self._input_cache_lock:
+            self.inputs_cache.set_cache(input_cache)
 
     # called after every module generate
     # may be called multiple times due to batch
     def receive_layer_inputs(self, layer_inputs: List[List[Tensor]]):
         """Replaces cached layer outputs that feed the next loop stage."""
 
-        self.inputs_cache.layer_inputs = layer_inputs
+        with self._input_cache_lock:
+            self.inputs_cache.layer_inputs = layer_inputs
 
     def receive_layer_forward_context(
         self,
@@ -741,8 +856,9 @@ class LoopProcessor:
     def clear_cache_data(self):
         """Drops transient task data and cached layer inputs after replay."""
 
-        self.tasks = {}
-        self.inputs_cache.layer_inputs = []
+        self.tasks.clear()
+        with self._input_cache_lock:
+            self.inputs_cache.layer_inputs = []
 
     def pre_process_fwd_hook(self, name: str) -> Callable[[Module, Tuple[torch.Tensor, ...], torch.Tensor], None]:
         """Override point for per-module forward hooks used during capture."""

--- a/gptqmodel/looper/stage_subset.py
+++ b/gptqmodel/looper/stage_subset.py
@@ -147,6 +147,25 @@ class SubsetStageResult:
     plan: Optional[SubsetPlan]
 
 
+def _collect_worker_results(futures, prior_error: Optional[BaseException] = None):
+    """Resolve every submitted worker before propagating the first error."""
+
+    results = []
+    worker_error = None
+    for future in futures:
+        try:
+            results.append(future.result())
+        except BaseException as exc:
+            if worker_error is None:
+                worker_error = exc
+
+    if prior_error is not None:
+        raise prior_error
+    if worker_error is not None:
+        raise worker_error
+    return results
+
+
 def _resolve_cache_flush_device(
     cur_layer_device: Optional[torch.device],
     used_devices,
@@ -1049,36 +1068,38 @@ def _run_single_subset_pass(
                 )
         return nm.name, nm
 
-    for name in active_subset_names:
-        named_module = subset[name]
-        # Launch processing for every module in the subset; tasks may run in
-        # parallel as allowed by the device thread pool.
-        tgt_dev = quant_target_devices.get(name, cur_layer_device)
-        futures.append(
-            DEVICE_THREAD_POOL.submit(
-                tgt_dev,
-                _process_on_worker,
-                processor,
-                named_module,
-                tgt_dev,
-                subset,
-                previous_processed_subset,
-                subset_index,
-                subset_total,
+    submission_error = None
+    try:
+        for name in active_subset_names:
+            named_module = subset[name]
+            # Launch processing for every module in the subset; tasks may run in
+            # parallel as allowed by the device thread pool.
+            tgt_dev = quant_target_devices.get(name, cur_layer_device)
+            futures.append(
+                DEVICE_THREAD_POOL.submit(
+                    tgt_dev,
+                    _process_on_worker,
+                    processor,
+                    named_module,
+                    tgt_dev,
+                    subset,
+                    previous_processed_subset,
+                    subset_index,
+                    subset_total,
+                )
             )
+        _emit_moe_parallel_quant_subset_telemetry(
+            plan=plan,
+            quant_target_devices=quant_target_devices,
+            futures_count=len(futures),
+            layer_index=layer_index,
         )
+    except BaseException as exc:
+        submission_error = exc
 
-    _emit_moe_parallel_quant_subset_telemetry(
-        plan=plan,
-        quant_target_devices=quant_target_devices,
-        futures_count=len(futures),
-        layer_index=layer_index,
-    )
-
-    for fut in futures:
+    for name, named_module in _collect_worker_results(futures, prior_error=submission_error):
         # Collect results in submission order so the final subset map preserves
         # deterministic iteration for downstream consumers.
-        name, named_module = fut.result()
         if isinstance(named_module, NamedModule) and named_module.state.get("capture_only"):
             # Capture-only modules should not be finalized or offloaded.
             continue

--- a/gptqmodel/looper/stage_subset.py
+++ b/gptqmodel/looper/stage_subset.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 
 
 ForwardMode = Literal["parallel", "serial"]
+_WORKER_FAILURES = (Exception, KeyboardInterrupt, SystemExit, GeneratorExit)
 
 
 @dataclass
@@ -155,7 +156,7 @@ def _collect_worker_results(futures, prior_error: Optional[BaseException] = None
     for future in futures:
         try:
             results.append(future.result())
-        except BaseException as exc:
+        except _WORKER_FAILURES as exc:
             if worker_error is None:
                 worker_error = exc
 
@@ -1094,7 +1095,7 @@ def _run_single_subset_pass(
             futures_count=len(futures),
             layer_index=layer_index,
         )
-    except BaseException as exc:
+    except _WORKER_FAILURES as exc:
         submission_error = exc
 
     for name, named_module in _collect_worker_results(futures, prior_error=submission_error):

--- a/tests/test_looper_concurrency.py
+++ b/tests/test_looper_concurrency.py
@@ -177,11 +177,11 @@ def test_thread_safe_dict_equality_uses_snapshots():
     tasks = _ThreadSafeDict({"a": 1, "b": 2})
     matching = _ThreadSafeDict({"a": 1, "b": 2})
 
-    assert tasks == tasks
+    assert tasks.__eq__(tasks) is True
     assert tasks == matching
     assert tasks == {"a": 1, "b": 2}
-    matching["c"] = 3
-    assert tasks != matching
+    different = _ThreadSafeDict({"a": 1, "b": 2, "c": 3})
+    assert tasks.__ne__(different) is True
     assert tasks != {"a": 2}
 
 

--- a/tests/test_looper_concurrency.py
+++ b/tests/test_looper_concurrency.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
+from gptqmodel.adapter.adapter import Lora
+from gptqmodel.looper.eora_processor import EoraProcessor
 from gptqmodel.looper.input_cache import InputCache
 from gptqmodel.looper.loop_processor import LoopProcessor, _ThreadSafeDict, _ThreadSafeInputCache
 from gptqmodel.looper.stage_subset import _collect_worker_results
@@ -102,6 +104,36 @@ def test_collect_worker_results_drains_before_raising_submission_error():
     assert events == ["first", "second"]
 
 
+@pytest.mark.parametrize("control_error", [KeyboardInterrupt("stop"), SystemExit("stop")])
+def test_collect_worker_results_drains_before_raising_control_error(control_error):
+    events = []
+    futures = [
+        _RecordingFuture(events, "first", error=control_error),
+        _RecordingFuture(events, "second", result=("b", 2)),
+    ]
+
+    with pytest.raises(type(control_error)) as exc_info:
+        _collect_worker_results(futures)
+
+    assert exc_info.value is control_error
+    assert events == ["first", "second"]
+
+
+def test_collect_worker_results_drains_before_raising_submission_control_error():
+    events = []
+    submission_error = KeyboardInterrupt("submission interrupted")
+    futures = [
+        _RecordingFuture(events, "first", error=ValueError("worker failed")),
+        _RecordingFuture(events, "second", result=("b", 2)),
+    ]
+
+    with pytest.raises(KeyboardInterrupt, match="submission interrupted") as exc_info:
+        _collect_worker_results(futures, prior_error=submission_error)
+
+    assert exc_info.value is submission_error
+    assert events == ["first", "second"]
+
+
 def test_thread_safe_dict_uses_snapshots_during_concurrent_mutation():
     tasks = _ThreadSafeDict()
     barrier = threading.Barrier(8)
@@ -133,11 +165,24 @@ def test_thread_safe_dict_mutation_api():
     assert tasks.setdefault("a", 3) == 1
     assert tasks.setdefault("c", 3) == 3
     del tasks["b"]
-    assert tasks.pop("missing", None) is None
+    missing_value = tasks.pop("missing", None)
+    assert missing_value is None
     key, value = tasks.popitem()
     assert (key, value) in {("a", 1), ("c", 3)}
     tasks.clear()
     assert not tasks
+
+
+def test_thread_safe_dict_equality_uses_snapshots():
+    tasks = _ThreadSafeDict({"a": 1, "b": 2})
+    matching = _ThreadSafeDict({"a": 1, "b": 2})
+
+    assert tasks == tasks
+    assert tasks == matching
+    assert tasks == {"a": 1, "b": 2}
+    matching["c"] = 3
+    assert tasks != matching
+    assert tasks != {"a": 2}
 
 
 def test_thread_safe_input_cache_replacement_and_attribute_access():
@@ -156,6 +201,41 @@ def test_thread_safe_input_cache_replacement_and_attribute_access():
     proxy = _ThreadSafeInputCache(InputCache([], [], [], []))
     proxy.set_cache(cache)
     assert proxy.unwrap() is replacement
+
+
+def test_receive_input_cache_initializes_missing_state_and_rewraps_raw_cache():
+    processor = LoopProcessor.__new__(LoopProcessor)
+    first = InputCache([[torch.tensor([1.0])]], [], [], [])
+
+    processor.receive_input_cache(first)
+
+    assert isinstance(processor._input_cache_lock, type(threading.RLock()))
+    assert isinstance(processor.inputs_cache, _ThreadSafeInputCache)
+    assert processor.inputs_cache.unwrap() is first
+
+    processor.inputs_cache = InputCache([], [], [], [])
+    replacement = InputCache([[torch.tensor([2.0])]], [], [], [])
+    processor.receive_input_cache(replacement)
+
+    assert isinstance(processor.inputs_cache, _ThreadSafeInputCache)
+    assert processor.inputs_cache.unwrap() is replacement
+
+
+def test_eora_progress_uses_synchronized_draw_helper():
+    class _ProgressObserved(Exception):
+        pass
+
+    processor = EoraProcessor.__new__(EoraProcessor)
+    processor.draw_progress = MagicMock(side_effect=_ProgressObserved)
+    module = MagicMock()
+    module.adapter_cfg = object.__new__(Lora)
+    module.name = "layer.proj"
+    module.module_dtype = torch.float16
+
+    with pytest.raises(_ProgressObserved):
+        processor.process(module)
+
+    processor.draw_progress.assert_called_once_with("EoRA: Processing layer.proj (torch.float16) in layer")
 
 
 def test_loop_processor_shared_accessors_are_synchronized():
@@ -220,5 +300,24 @@ def test_device_metric_handles_are_serialized_and_closed():
 
     assert cuda_handle.closed is True
     assert cpu_handle.closed is True
+    assert processor._device_smi_handles == {}
+    assert processor._cpu_device_smi is None
+
+
+def test_device_metric_close_failures_are_logged_and_suppressed(monkeypatch):
+    class _FailingHandle:
+        def close(self):
+            raise RuntimeError("close failed")
+
+    debug = MagicMock()
+    monkeypatch.setattr("gptqmodel.looper.loop_processor.log.debug", debug)
+    processor = _make_processor()
+    processor._device_smi_handles = {"cuda:0": _FailingHandle()}
+    processor._cpu_device_smi = _FailingHandle()
+
+    processor._close_device_smi_handles()
+
+    assert debug.call_count == 2
+    assert all(call.kwargs == {"exc_info": True} for call in debug.call_args_list)
     assert processor._device_smi_handles == {}
     assert processor._cpu_device_smi is None

--- a/tests/test_looper_concurrency.py
+++ b/tests/test_looper_concurrency.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+"""Concurrency coverage for shared looper state and worker completion."""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from gptqmodel.looper.input_cache import InputCache
+from gptqmodel.looper.loop_processor import LoopProcessor, _ThreadSafeDict, _ThreadSafeInputCache
+from gptqmodel.looper.stage_subset import _collect_worker_results
+
+
+class _RecordingFuture:
+    def __init__(self, events, label, *, result=None, error=None):
+        self.events = events
+        self.label = label
+        self.value = result
+        self.error = error
+
+    def result(self):
+        self.events.append(self.label)
+        if self.error is not None:
+            raise self.error
+        return self.value
+
+
+def _make_processor() -> LoopProcessor:
+    processor = LoopProcessor.__new__(LoopProcessor)
+    processor.lock = threading.Lock()
+    processor._results_lock = threading.Lock()
+    processor._progress_lock = threading.Lock()
+    processor._fwd_time_lock = threading.Lock()
+    processor._device_smi_lock = threading.RLock()
+    processor._input_cache_lock = threading.RLock()
+    processor._results = {}
+    processor.tasks = _ThreadSafeDict()
+    processor.inputs_cache = _ThreadSafeInputCache(InputCache([], [], [], []))
+    processor.pb = None
+    processor.fwd_time = None
+    processor._device_smi_handles = {}
+    processor._cpu_device_smi = None
+    processor._device_metric_failures = set()
+    return processor
+
+
+def test_loop_processor_initializes_synchronized_state(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(LoopProcessor, "_init_device_smi_handles", lambda _self: {})
+    monkeypatch.setattr(LoopProcessor, "_init_cpu_device_handle", lambda _self: None)
+
+    processor = LoopProcessor(tokenizer=None, qcfg=MagicMock(), calibration=None)
+
+    assert isinstance(processor.tasks, _ThreadSafeDict)
+    assert isinstance(processor.inputs_cache, _ThreadSafeInputCache)
+    assert processor.inputs_cache.unwrap().layer_inputs == []
+
+
+def test_collect_worker_results_preserves_submission_order():
+    events = []
+    futures = [
+        _RecordingFuture(events, "first", result=("a", 1)),
+        _RecordingFuture(events, "second", result=("b", 2)),
+    ]
+
+    assert _collect_worker_results(futures) == [("a", 1), ("b", 2)]
+    assert events == ["first", "second"]
+
+
+def test_collect_worker_results_drains_after_failure_and_raises_first_error():
+    events = []
+    first_error = RuntimeError("first worker failed")
+    futures = [
+        _RecordingFuture(events, "first", error=first_error),
+        _RecordingFuture(events, "second", result=("b", 2)),
+        _RecordingFuture(events, "third", error=ValueError("later worker failed")),
+    ]
+
+    with pytest.raises(RuntimeError, match="first worker failed") as exc_info:
+        _collect_worker_results(futures)
+
+    assert exc_info.value is first_error
+    assert events == ["first", "second", "third"]
+
+
+def test_collect_worker_results_drains_before_raising_submission_error():
+    events = []
+    submission_error = RuntimeError("submission failed")
+    futures = [
+        _RecordingFuture(events, "first", error=ValueError("worker failed")),
+        _RecordingFuture(events, "second", result=("b", 2)),
+    ]
+
+    with pytest.raises(RuntimeError, match="submission failed") as exc_info:
+        _collect_worker_results(futures, prior_error=submission_error)
+
+    assert exc_info.value is submission_error
+    assert events == ["first", "second"]
+
+
+def test_thread_safe_dict_uses_snapshots_during_concurrent_mutation():
+    tasks = _ThreadSafeDict()
+    barrier = threading.Barrier(8)
+
+    def worker(worker_index):
+        barrier.wait(timeout=5)
+        for iteration in range(100):
+            key = f"{worker_index}:{iteration}"
+            tasks[key] = iteration
+            assert key in tasks
+            assert tasks.get(key) == iteration
+            list(tasks)
+            tasks.keys()
+            tasks.values()
+            tasks.items()
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = [executor.submit(worker, worker_index) for worker_index in range(8)]
+        for future in futures:
+            future.result()
+
+    assert len(tasks) == 800
+    assert len(tasks.items()) == 800
+
+
+def test_thread_safe_dict_mutation_api():
+    tasks = _ThreadSafeDict()
+    tasks.update({"a": 1, "b": 2})
+    assert tasks.setdefault("a", 3) == 1
+    assert tasks.setdefault("c", 3) == 3
+    del tasks["b"]
+    assert tasks.pop("missing", None) is None
+    key, value = tasks.popitem()
+    assert (key, value) in {("a", 1), ("c", 3)}
+    tasks.clear()
+    assert not tasks
+
+
+def test_thread_safe_input_cache_replacement_and_attribute_access():
+    cache = _ThreadSafeInputCache(InputCache([], [], [], []))
+    cache.layer_inputs = [[torch.tensor([1.0])]]
+    assert len(cache.layer_inputs) == 1
+
+    replacement = InputCache([[torch.tensor([2.0])]], [], [], [])
+    cache.set_cache(replacement)
+    assert cache.unwrap() is replacement
+    assert torch.equal(cache.layer_inputs[0][0], torch.tensor([2.0]))
+    cache.transient = True
+    del cache.transient
+    assert not hasattr(cache.unwrap(), "transient")
+
+    proxy = _ThreadSafeInputCache(InputCache([], [], [], []))
+    proxy.set_cache(cache)
+    assert proxy.unwrap() is replacement
+
+
+def test_loop_processor_shared_accessors_are_synchronized():
+    processor = _make_processor()
+    processor.pb = MagicMock()
+    processor.pb.title.return_value = processor.pb
+    processor.pb.subtitle.return_value = processor.pb
+
+    def worker(worker_index):
+        processor.result_save(str(worker_index), worker_index)
+        processor.set_fwd_time(float(worker_index))
+        processor.draw_progress(str(worker_index))
+        processor.receive_layer_inputs([[torch.tensor([float(worker_index)])]])
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = [executor.submit(worker, worker_index) for worker_index in range(50)]
+        for future in futures:
+            future.result()
+
+    snapshot = processor.results()
+    snapshot["external"] = True
+    assert "external" not in processor.results()
+    assert len(processor.results()) == 50
+    assert processor.formatted_fwd_time().endswith(".000")
+    assert processor.pb.draw.call_count == 50
+    assert len(processor.inputs_cache.layer_inputs) == 1
+
+    processor.receive_input_cache(InputCache([], [], [], []))
+    processor.tasks["task"] = object()
+    processor.clear_cache_data()
+    assert processor.inputs_cache.layer_inputs == []
+    assert not processor.tasks
+
+
+def test_device_metric_handles_are_serialized_and_closed():
+    class _Metrics:
+        memory_used = 2 * 1024**3
+
+    class _Handle:
+        def __init__(self):
+            self.closed = False
+
+        def metrics(self, fast=True):
+            assert fast is True
+            assert not self.closed
+            return _Metrics()
+
+        def close(self):
+            self.closed = True
+
+    processor = _make_processor()
+    cuda_handle = _Handle()
+    cpu_handle = _Handle()
+    processor._device_smi_handles = {"cuda:0": cuda_handle}
+    processor._cpu_device_smi = cpu_handle
+
+    report = processor.device_memory_report()
+    assert report.startswith("cuda ")
+    assert "2" in report
+    assert processor._snapshot_cpu_memory_gib() == 2.0
+    processor._close_device_smi_handles()
+
+    assert cuda_handle.closed is True
+    assert cpu_handle.closed is True
+    assert processor._device_smi_handles == {}
+    assert processor._cpu_device_smi is None


### PR DESCRIPTION
## Summary

- synchronize mutable looper task, input-cache, result, progress, timing, and device-monitor state shared by parallel workers
- resolve every submitted quantization worker before propagating a submission or worker failure
- preserve submission-order result collection and raise the first relevant error after workers are drained
- add synthetic concurrency coverage for worker failures, task-map snapshots, cache replacement, shared accessors, and device-handle cleanup

## Root cause

Parallel quantization workers can access processor-owned state while the orchestration thread updates or clears it. In addition, result collection previously stopped at the first failed future, allowing later submitted workers to remain active while the subset stage unwound.

## Impact

Worker failures no longer leave sibling quantization work running during stage teardown. Shared looper state is protected for parallel and free-threaded execution. This does not change quantization math, checkpoint formats, or user configuration.

## Validation

- `python -m pytest -q tests/test_looper_concurrency.py tests/test_weight_only_looper.py tests/test_moe_expert_batching.py` — 25 passed under Python 3.14t with the GIL disabled
- Ruff checks passed for all changed code, excluding only pre-existing diagnostics in the two edited modules
- ty reported no diagnostics on changed lines; the repository retains pre-existing diagnostics outside this patch
- `git diff --check` passed