### PR TITLE
harden free-threaded lock ownership

### DIFF
--- a/gptqmodel/extension.py
+++ b/gptqmodel/extension.py
@@ -3,22 +3,19 @@
 
 from __future__ import annotations
 
-from importlib import import_module
-from dataclasses import dataclass
 import threading
+from dataclasses import dataclass
+from importlib import import_module
 from typing import TYPE_CHECKING, Callable
 
 from .utils.logger import setup_logger
+
 
 if TYPE_CHECKING:
     from .utils.cpp import TorchOpsJitExtension
 
 
 log = setup_logger()
-# Serialize same-extension API calls so Python 3.13t no-GIL callers do not
-# race clear/load cycles for the same JIT target.
-_EXTENSION_API_LOCKS: dict[str, threading.Lock] = {}
-_EXTENSION_API_LOCKS_GUARD = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -118,6 +115,11 @@ _EXTENSION_SPECS = (
 
 _EXTENSION_SPECS_BY_NAME = {spec.name: spec for spec in _EXTENSION_SPECS}
 
+# Serialize same-extension API calls so free-threaded callers do not race
+# clear/load cycles. The complete extension set is known at import time, so
+# lock ownership is fixed rather than created dynamically by API calls.
+_EXTENSION_API_LOCKS = {spec.name: threading.Lock() for spec in _EXTENSION_SPECS}
+
 _EXTENSION_GROUPS = {
     "marlin": ("marlin_fp16", "marlin_bf16"),
 }
@@ -177,15 +179,6 @@ def _process_loaded(extension: TorchOpsJitExtension) -> bool:
     return extension._ops_available()
 
 
-def _extension_api_lock(name: str) -> threading.Lock:
-    with _EXTENSION_API_LOCKS_GUARD:
-        lock = _EXTENSION_API_LOCKS.get(name)
-        if lock is None:
-            lock = threading.Lock()
-            _EXTENSION_API_LOCKS[name] = lock
-        return lock
-
-
 def _resolve_single_extension_name(name: str) -> str:
     resolved = _resolve_requested_extensions(name)
     if len(resolved) != 1:
@@ -205,7 +198,7 @@ def _load_one(name: str, *, use_cache: bool) -> TorchOpsJitExtension:
     spec = _EXTENSION_SPECS_BY_NAME[extension_name]
     if not _spec_supported(spec):
         raise RuntimeError(_spec_unsupported_error(spec))
-    with _extension_api_lock(extension_name):
+    with _EXTENSION_API_LOCKS[extension_name]:
         extension = spec.resolve()
 
         if not use_cache:

--- a/gptqmodel/looper/loop_processor.py
+++ b/gptqmodel/looper/loop_processor.py
@@ -30,8 +30,6 @@ from ..utils.torch import CPU, DEVICE_0, DEVICE_1, HAS_NPU
 
 log = setup_logger()
 
-# global level lock
-PROCESSOR_GLOBAL_LOCK = threading.Lock()
 _PROJECT_LOG_DIR = Path("logs")
 
 MODULE_FEATURE_COLUMN = "feat: in, out"
@@ -75,21 +73,6 @@ class _ThreadSafeDict(dict):
     def __contains__(self, key):
         with self._lock:
             return super().__contains__(key)
-
-    def _snapshot(self):
-        with self._lock:
-            return dict(super().items())
-
-    def __eq__(self, other):
-        if other is self:
-            return True
-        own_snapshot = self._snapshot()
-        other_snapshot = other._snapshot() if isinstance(other, _ThreadSafeDict) else other
-        return dict.__eq__(own_snapshot, other_snapshot)
-
-    def __ne__(self, other):
-        result = self.__eq__(other)
-        return NotImplemented if result is NotImplemented else not result
 
     def __iter__(self):
         with self._lock:
@@ -338,20 +321,6 @@ class LoopProcessor:
             if self.pb is None:
                 return
             self.pb.title(title).subtitle(subtitle).draw()
-
-    def _get_input_cache_lock(self):
-        """Returns the cache lock, including for lightweight test and script instances."""
-
-        lock = getattr(self, "_input_cache_lock", None)
-        if lock is not None:
-            return lock
-
-        with PROCESSOR_GLOBAL_LOCK:
-            lock = getattr(self, "_input_cache_lock", None)
-            if lock is None:
-                lock = threading.RLock()
-                object.__setattr__(self, "_input_cache_lock", lock)
-        return lock
 
     @staticmethod
     def _compute_total_tokens(calibration_dataset) -> int:
@@ -850,7 +819,7 @@ class LoopProcessor:
     def receive_input_cache(self, input_cache: Any):
         """Injects the shared input cache for the current processor stage."""
 
-        with self._get_input_cache_lock():
+        with self._input_cache_lock:
             current = getattr(self, "inputs_cache", None)
             if isinstance(current, _ThreadSafeInputCache):
                 current.set_cache(input_cache)
@@ -863,7 +832,7 @@ class LoopProcessor:
     def receive_layer_inputs(self, layer_inputs: List[List[Tensor]]):
         """Replaces cached layer outputs that feed the next loop stage."""
 
-        with self._get_input_cache_lock():
+        with self._input_cache_lock:
             self.inputs_cache.layer_inputs = layer_inputs
 
     def receive_layer_forward_context(
@@ -891,7 +860,7 @@ class LoopProcessor:
         """Drops transient task data and cached layer inputs after replay."""
 
         self.tasks.clear()
-        with self._get_input_cache_lock():
+        with self._input_cache_lock:
             self.inputs_cache.layer_inputs = []
 
     def pre_process_fwd_hook(self, name: str) -> Callable[[Module, Tuple[torch.Tensor, ...], torch.Tensor], None]:

--- a/gptqmodel/looper/named_module.py
+++ b/gptqmodel/looper/named_module.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 
-import contextlib
 from typing import Any, Dict, Optional
 
 import torch
@@ -13,11 +12,13 @@ from torch.nn import Parameter
 from torch.nn.modules.conv import _ConvNd
 
 from ..utils.logger import setup_logger
-from ..utils.module_locks import get_parent_lock, parent_module_lock
+from ..utils.module_locks import get_parent_lock
 from ..utils.stream import stream_sync as stream_sync_events
 from ..utils.stream import stream_tensor_dict_to_cpu
 
+
 log = setup_logger()
+
 
 class NamedModule(torch.nn.Module):
     """Thread-safe wrapper that adds stable names and scratch state to a module."""
@@ -27,12 +28,12 @@ class NamedModule(torch.nn.Module):
 
         super().__init__()
 
+        self._parent_lock = get_parent_lock(full_name)
         self.module = module  # wrapped module
         self.module_dtype = next(module.parameters()).dtype
         self.name = name  # module name
         self.full_name = full_name  # full dotted path inside model
         self.layer_index = layer_index  # layer index for repeated blocks
-        self._parent_lock = get_parent_lock(full_name)
 
         if hasattr(module, "module_name") and module.module_name is None:
             module.module_name = full_name
@@ -142,13 +143,8 @@ class NamedModule(torch.nn.Module):
     def __getattr__(self, name: str):
         """Falls back to the wrapped module while preserving lock discipline."""
 
-        try:
-            lock = object.__getattribute__(self, "_parent_lock")
-        except AttributeError:
-            lock = None
+        lock = object.__getattribute__(self, "_parent_lock")
         module = object.__getattribute__(self, "module")
-        if lock is None:
-            return getattr(module, name)
         with lock:
             return getattr(module, name)
 
@@ -173,16 +169,10 @@ class NamedModule(torch.nn.Module):
             object.__setattr__(self, name, value)
             return
 
-        try:
-            lock = object.__getattribute__(self, "_parent_lock")
-        except AttributeError:
-            lock = None
+        lock = object.__getattribute__(self, "_parent_lock")
         module = object.__getattribute__(self, "module")
-        if lock is None:
+        with lock:
             setattr(module, name, value)
-        else:
-            with lock:
-                setattr(module, name, value)
 
     def stream_state_payload_to_cpu(
         self,
@@ -202,7 +192,7 @@ class NamedModule(torch.nn.Module):
         """Streams this module's direct parameters to CPU-backed state storage."""
 
         state_lock = self._parent_lock
-        tensor_map = {name: param for name, param in self.module.named_parameters(recurse=False)}
+        tensor_map = dict(self.module.named_parameters(recurse=False))
         return stream_tensor_dict_to_cpu(
             tensor_map,
             store_callback=lambda host_map: self.state.setdefault("parameters_cpu", {}).update(host_map),
@@ -214,7 +204,7 @@ class NamedModule(torch.nn.Module):
         """Streams this module's direct buffers to CPU-backed state storage."""
 
         state_lock = self._parent_lock
-        tensor_map = {name: buf for name, buf in self.module.named_buffers(recurse=False)}
+        tensor_map = dict(self.module.named_buffers(recurse=False))
         return stream_tensor_dict_to_cpu(
             tensor_map,
             store_callback=lambda host_map: self.state.setdefault("buffers_cpu", {}).update(host_map),

--- a/gptqmodel/looper/stage_subset.py
+++ b/gptqmodel/looper/stage_subset.py
@@ -45,7 +45,9 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 
 
 ForwardMode = Literal["parallel", "serial"]
-_WORKER_FAILURES = (Exception, KeyboardInterrupt, SystemExit, GeneratorExit)
+# Catch every BaseException so worker result collection drains all submitted
+# futures before propagating the first error, including custom abort signals.
+_WORKER_FAILURES = (BaseException,)
 
 
 @dataclass

--- a/gptqmodel/quantization/gptq.py
+++ b/gptqmodel/quantization/gptq.py
@@ -51,7 +51,7 @@ def _log_hessian_verbose() -> bool:
     return env_flag("GPTQMODEL_LOG_HESSIAN")
 
 
-lock = threading.Lock()
+_WORKSPACE_LOCKS_GUARD = threading.Lock()
 
 # Shared workspaces are cached globally per device so that concurrent GPTQ
 # instances reuse temporary buffers instead of repeatedly allocating large
@@ -70,6 +70,19 @@ def _device_cache_key(device: torch.device) -> Tuple[str, Optional[int]]:
 
 def _workspace_cache_key(device: torch.device) -> Tuple[str, Optional[int]]:
     return _device_cache_key(device)
+
+
+def _workspace_lock(key: Tuple[str, Optional[int]]) -> threading.Lock:
+    lock = _WORKSPACE_LOCKS.get(key)
+    if lock is not None:
+        return lock
+
+    with _WORKSPACE_LOCKS_GUARD:
+        lock = _WORKSPACE_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _WORKSPACE_LOCKS[key] = lock
+    return lock
 
 
 def _needs_workspace_resize(
@@ -99,7 +112,7 @@ def _lease_workspace(
     required_rows: int,
 ) -> Tuple[torch.Tensor, bool]:
     key = _workspace_cache_key(device)
-    lock = _WORKSPACE_LOCKS.setdefault(key, threading.Lock())
+    lock = _workspace_lock(key)
     with lock:
         workspace = _WORKSPACE_CACHE.pop(key, None)
         reused = workspace is not None and not _needs_workspace_resize(

--- a/gptqmodel/utils/nogil_patcher.py
+++ b/gptqmodel/utils/nogil_patcher.py
@@ -118,7 +118,7 @@ def patch_triton_autotuner() -> None:
         cache_map = getattr(self, "cache", {})
         self._cache = dict(cache_map)
         self.cache = self._cache
-        self._cache_lock = getattr(self, "_cache_lock", threading.RLock())
+        self._cache_lock = threading.RLock()
         self._cache_futures = {}
 
     def patched_check_disk_cache(self, tuning_key, configs, bench_fn):

--- a/gptqmodel/utils/threadx.py
+++ b/gptqmodel/utils/threadx.py
@@ -714,7 +714,8 @@ class DeviceThreadPool:
         self._gc_pending_physical: Dict[str, int] = {}
         self._physical_children: Dict[str, Set[str]] = {}
 
-        # Device-SMI handles are created lazily for GC logging.
+        # Device-SMI handles are created lazily for GC logging, while their
+        # synchronization state is an invariant of every pool instance.
         self._device_smi_lock = threading.Lock()
         self._device_smi_handles: Dict[str, Any] = {}
         self._device_smi_failures: Set[str] = set()
@@ -1187,14 +1188,13 @@ class DeviceThreadPool:
                 for w in snapshot:
                     w.join()
 
-        if hasattr(self, "_device_smi_handles"):
-            with self._device_smi_lock:
-                for handle in list(self._device_smi_handles.values()):
-                    try:
-                        handle.close()
-                    except Exception:
-                        pass
-                self._device_smi_handles.clear()
+        with self._device_smi_lock:
+            for handle in list(self._device_smi_handles.values()):
+                try:
+                    handle.close()
+                except Exception:
+                    pass
+            self._device_smi_handles.clear()
 
         if DEBUG_ON: log.debug("DeviceThreadPool shutdown complete")
 
@@ -1556,10 +1556,6 @@ class DeviceThreadPool:
     def _query_device_vram_gib(self, key: str) -> Optional[float]:
         if Device is None:
             return None
-        if not hasattr(self, "_device_smi_lock"):
-            self._device_smi_lock = threading.Lock()
-            self._device_smi_handles = {}
-            self._device_smi_failures = set()
         dev = self._devices_by_key.get(key)
         if dev is None:
             return None

--- a/gptqmodel/utils/threadx.py
+++ b/gptqmodel/utils/threadx.py
@@ -1192,8 +1192,9 @@ class DeviceThreadPool:
             for handle in list(self._device_smi_handles.values()):
                 try:
                     handle.close()
-                except Exception:
-                    pass
+                except Exception as exc:
+                    if DEBUG_ON:
+                        log.debug("DeviceThreadPool: ignoring Device-SMI handle close failure during shutdown: %s", exc)
             self._device_smi_handles.clear()
 
         if DEBUG_ON: log.debug("DeviceThreadPool shutdown complete")

--- a/tests/test_extension_load_api.py
+++ b/tests/test_extension_load_api.py
@@ -94,6 +94,10 @@ def test_package_root_exports_extension_module():
     assert gptqmodel.extension is extension_api
 
 
+def test_extension_api_locks_are_initialized_eagerly():
+    assert set(extension_api._EXTENSION_API_LOCKS) == set(extension_api.available_extensions())
+
+
 def test_load_defaults_to_all_extensions(monkeypatch):
     fakes = _install_fake_extensions(monkeypatch)
 

--- a/tests/test_hessian.py
+++ b/tests/test_hessian.py
@@ -5,6 +5,7 @@ import contextlib
 import copy
 import math
 import statistics
+import threading
 import time
 import tracemalloc
 import types
@@ -165,6 +166,35 @@ def test_workspace_lock_is_created_once_per_device(monkeypatch):
 
     assert second is first
     assert lock_creations == 1
+
+
+def test_workspace_lock_contended_creation_returns_one_lock(monkeypatch):
+    class _ContendedLockMap(dict):
+        def __init__(self):
+            super().__init__()
+            self._initial_gets = 0
+            self._initial_gets_lock = threading.Lock()
+            self._initial_gets_barrier = threading.Barrier(2)
+
+        def get(self, key, default=None):
+            with self._initial_gets_lock:
+                initial_get = self._initial_gets < 2
+                if initial_get:
+                    self._initial_gets += 1
+            if initial_get:
+                self._initial_gets_barrier.wait(timeout=5)
+                return default
+            return super().get(key, default)
+
+    workspace_locks = _ContendedLockMap()
+    monkeypatch.setattr(gptq_impl, "_WORKSPACE_LOCKS", workspace_locks)
+    key = ("cpu", None)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        locks = list(pool.map(gptq_impl._workspace_lock, [key, key]))
+
+    assert locks[0] is locks[1]
+    assert workspace_locks == {key: locks[0]}
 
 
 def _clone_module(module: torch.nn.Module) -> torch.nn.Module:

--- a/tests/test_hessian.py
+++ b/tests/test_hessian.py
@@ -148,6 +148,25 @@ def reset_workspace_caches():
     gptq_impl._BF16_SUPPORT_CACHE.clear()
 
 
+def test_workspace_lock_is_created_once_per_device(monkeypatch):
+    real_lock = gptq_impl.threading.Lock
+    lock_creations = 0
+
+    def counting_lock():
+        nonlocal lock_creations
+        lock_creations += 1
+        return real_lock()
+
+    monkeypatch.setattr(gptq_impl.threading, "Lock", counting_lock)
+    key = ("cpu", None)
+
+    first = gptq_impl._workspace_lock(key)
+    second = gptq_impl._workspace_lock(key)
+
+    assert second is first
+    assert lock_creations == 1
+
+
 def _clone_module(module: torch.nn.Module) -> torch.nn.Module:
     replica = type(module)(module.in_features, module.out_features, bias=False)
     replica.load_state_dict(module.state_dict())

--- a/tests/test_looper_concurrency.py
+++ b/tests/test_looper_concurrency.py
@@ -59,6 +59,7 @@ def test_loop_processor_initializes_synchronized_state(monkeypatch, tmp_path):
 
     assert isinstance(processor.tasks, _ThreadSafeDict)
     assert isinstance(processor.inputs_cache, _ThreadSafeInputCache)
+    assert isinstance(processor._input_cache_lock, type(threading.RLock()))
     assert processor.inputs_cache.unwrap().layer_inputs == []
 
 
@@ -134,7 +135,41 @@ def test_collect_worker_results_drains_before_raising_submission_control_error()
     assert events == ["first", "second"]
 
 
-def test_thread_safe_dict_uses_snapshots_during_concurrent_mutation():
+class _WorkerAbort(BaseException):
+    """Custom non-Exception BaseException used for drain regression tests."""
+
+
+def test_collect_worker_results_drains_direct_baseexception_subclass():
+    events = []
+    error = _WorkerAbort("worker abort")
+    futures = [
+        _RecordingFuture(events, "first", error=error),
+        _RecordingFuture(events, "second", result=("b", 2)),
+    ]
+
+    with pytest.raises(_WorkerAbort, match="worker abort") as exc_info:
+        _collect_worker_results(futures)
+
+    assert exc_info.value is error
+    assert events == ["first", "second"]
+
+
+def test_collect_worker_results_drains_before_raising_custom_submission_error():
+    events = []
+    submission_error = _WorkerAbort("submission abort")
+    futures = [
+        _RecordingFuture(events, "first", result=("a", 1)),
+        _RecordingFuture(events, "second", result=("b", 2)),
+    ]
+
+    with pytest.raises(_WorkerAbort, match="submission abort") as exc_info:
+        _collect_worker_results(futures, prior_error=submission_error)
+
+    assert exc_info.value is submission_error
+    assert events == ["first", "second"]
+
+
+def test_thread_safe_dict_iteration_snapshots_during_concurrent_mutation():
     tasks = _ThreadSafeDict()
     barrier = threading.Barrier(8)
 
@@ -173,15 +208,16 @@ def test_thread_safe_dict_mutation_api():
     assert not tasks
 
 
-def test_thread_safe_dict_equality_uses_snapshots():
+def test_thread_safe_dict_uses_builtin_dict_equality():
     tasks = _ThreadSafeDict({"a": 1, "b": 2})
     matching = _ThreadSafeDict({"a": 1, "b": 2})
 
-    assert tasks.__eq__(tasks) is True
+    assert _ThreadSafeDict.__eq__ is dict.__eq__
+    assert _ThreadSafeDict.__ne__ is dict.__ne__
     assert tasks == matching
     assert tasks == {"a": 1, "b": 2}
     different = _ThreadSafeDict({"a": 1, "b": 2, "c": 3})
-    assert tasks.__ne__(different) is True
+    assert tasks != different
     assert tasks != {"a": 2}
 
 
@@ -203,13 +239,13 @@ def test_thread_safe_input_cache_replacement_and_attribute_access():
     assert proxy.unwrap() is replacement
 
 
-def test_receive_input_cache_initializes_missing_state_and_rewraps_raw_cache():
+def test_receive_input_cache_rewraps_missing_and_raw_cache_state():
     processor = LoopProcessor.__new__(LoopProcessor)
+    processor._input_cache_lock = threading.RLock()
     first = InputCache([[torch.tensor([1.0])]], [], [], [])
 
     processor.receive_input_cache(first)
 
-    assert isinstance(processor._input_cache_lock, type(threading.RLock()))
     assert isinstance(processor.inputs_cache, _ThreadSafeInputCache)
     assert processor.inputs_cache.unwrap() is first
 

--- a/tests/test_looper_concurrency.py
+++ b/tests/test_looper_concurrency.py
@@ -221,6 +221,31 @@ def test_thread_safe_dict_uses_builtin_dict_equality():
     assert tasks != {"a": 2}
 
 
+def test_thread_safe_dict_builtin_equality_during_concurrent_mutation():
+    tasks = _ThreadSafeDict()
+    barrier = threading.Barrier(8)
+
+    def writer(worker_index):
+        barrier.wait(timeout=5)
+        for iteration in range(1_000):
+            tasks[f"{worker_index}:{iteration}"] = iteration
+
+    def comparer(_worker_index):
+        barrier.wait(timeout=5)
+        for _ in range(5_000):
+            snapshot = dict(tasks.items())
+            assert isinstance(tasks == snapshot, bool)
+            assert isinstance(tasks != {}, bool)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = [executor.submit(writer, worker_index) for worker_index in range(4)]
+        futures.extend(executor.submit(comparer, worker_index) for worker_index in range(4))
+        for future in futures:
+            future.result()
+
+    assert len(tasks) == 4_000
+
+
 def test_thread_safe_input_cache_replacement_and_attribute_access():
     cache = _ThreadSafeInputCache(InputCache([], [], [], []))
     cache.layer_inputs = [[torch.tensor([1.0])]]

--- a/tests/test_threadx.py
+++ b/tests/test_threadx.py
@@ -427,6 +427,9 @@ class TestThreadxJanitor():
         pool._virtual_to_parent = {}
         pool._family_keys = {}
         pool._dispatch_lock = threading.Lock()
+        pool._device_smi_lock = threading.Lock()
+        pool._device_smi_handles = {}
+        pool._device_smi_failures = set()
         pool._device_warmup_lock = threading.Lock()
         pool._device_warmup_states = {}
         pool._worker_warmups = {}

--- a/tests/test_threadx.py
+++ b/tests/test_threadx.py
@@ -7,6 +7,7 @@ import contextlib
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -499,6 +500,44 @@ class TestThreadxJanitor():
         assert calls["count"] == 1
         assert pool._gc_passes == 1
         assert pool._last_consumed_gc_generation == pool._gc_generation
+
+    @pytest.mark.parametrize("debug_enabled", [False, True])
+    def test_shutdown_closes_device_handles_and_logs_failures(self, monkeypatch, debug_enabled):
+        class _Handle:
+            def __init__(self, error=None):
+                self.error = error
+                self.close_calls = 0
+
+            def close(self):
+                self.close_calls += 1
+                if self.error is not None:
+                    raise self.error
+
+        pool = self._make_pool()
+        pool._janitor = None
+        good_handle = _Handle()
+        close_error = RuntimeError("close failed")
+        failing_handle = _Handle(close_error)
+        pool._device_smi_handles = {
+            "cuda:0": good_handle,
+            "cuda:1": failing_handle,
+        }
+        debug = MagicMock()
+        monkeypatch.setattr(threadx_mod, "DEBUG_ON", debug_enabled)
+        monkeypatch.setattr(threadx_mod.log, "debug", debug)
+
+        pool.shutdown(wait=True)
+
+        assert good_handle.close_calls == 1
+        assert failing_handle.close_calls == 1
+        assert pool._device_smi_handles == {}
+        if debug_enabled:
+            debug.assert_any_call(
+                "DeviceThreadPool: ignoring Device-SMI handle close failure during shutdown: %s",
+                close_error,
+            )
+        else:
+            debug.assert_not_called()
 
 ######## test_threadx_mps.py #########
 

--- a/tests/test_triton_patch_api.py
+++ b/tests/test_triton_patch_api.py
@@ -6,7 +6,7 @@ import threading
 import time
 from pathlib import Path
 
-from triton.runtime import autotuner as triton_autotuner
+import pytest
 
 import gptqmodel
 from gptqmodel.utils import nogil_patcher
@@ -62,6 +62,7 @@ def test_triton_patch_external_usage_snippet():
 
 
 def test_patched_autotuner_constructor_owns_cache_lock(monkeypatch):
+    triton_autotuner = pytest.importorskip("triton.runtime.autotuner")
     original_lock = threading.Lock()
     existing_cache_value = object()
 

--- a/tests/test_triton_patch_api.py
+++ b/tests/test_triton_patch_api.py
@@ -6,6 +6,8 @@ import threading
 import time
 from pathlib import Path
 
+from triton.runtime import autotuner as triton_autotuner
+
 import gptqmodel
 from gptqmodel.utils import nogil_patcher
 
@@ -57,6 +59,29 @@ def test_triton_patch_external_usage_snippet():
     # Run the exact user-facing API snippet.
     from gptqmodel import TritonPatch
     TritonPatch.apply()
+
+
+def test_patched_autotuner_constructor_owns_cache_lock(monkeypatch):
+    original_lock = threading.Lock()
+    existing_cache_value = object()
+
+    class _FakeAutotuner:
+        def __init__(self):
+            self.cache = {"existing": existing_cache_value}
+            self._cache_lock = original_lock
+
+    monkeypatch.setattr(triton_autotuner, "Autotuner", _FakeAutotuner)
+    monkeypatch.setattr(triton_autotuner, "CacheFuture", None, raising=False)
+    monkeypatch.setattr(nogil_patcher, "version", lambda _package_name: "3.7.0")
+
+    nogil_patcher.patch_triton_autotuner()
+    autotuner = _FakeAutotuner()
+
+    assert autotuner._cache_lock is not original_lock
+    assert isinstance(autotuner._cache_lock, type(threading.RLock()))
+    assert autotuner.cache is autotuner._cache
+    assert autotuner._cache == {"existing": existing_cache_value}
+    assert autotuner._cache_futures == {}
 
 
 def test_package_init_uses_triton_patch_api():


### PR DESCRIPTION
## Summary

- require constructor-owned locks for Looper cache state, module wrappers, thread-pool telemetry, and patched autotuners
- pre-create locks for the known extension registry and create workspace locks once per previously unseen device, with an allocation-free established-key path
- drain every submitted worker future before propagating any `BaseException`
- use built-in dictionary equality while retaining synchronized mutation and iteration snapshots
- retain best-effort device-handle shutdown while logging ignored close failures at DEBUG level

## Why

Several fallback paths dynamically created locks during ordinary API calls or allocated a temporary lock on every workspace lease. That adds overhead and makes free-threaded ownership harder to reason about. Worker collection also used an exception allow-list, allowing a custom `BaseException` subclass to bypass the drain guarantee while other workers could still be using shared subset state.

The locks remain access-scoped or key-scoped. Worker tasks are still submitted before result collection, so module processing remains parallel.

## Validation

- focused free-threaded lock and concurrency suite — **29 passed**
- coverage-instrumented targeted suite — **41 passed, 1 skipped**
- CUDA workspace contention test — **1 passed**
- changed executable code — **36/36 lines and 8/8 branches covered (100%)**
- Ruff checks on the modified sources and tests — **passed**
- repository source audit — **0 lazy lock-attribute checks**, **0 `setdefault(..., Lock())` factories**