### PR TITLE
enable native MPS GPTQ quantization

### DIFF
--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -39,13 +39,6 @@ if 'CUDA_VISIBLE_DEVICES' in os.environ and 'ROCR_VISIBLE_DEVICES' in os.environ
 #     os.environ["NCCL_SHM_DISABLE"] = '1'
 #     log.info("ENV: Auto setting NCCL_SHM_DISABLE=1 for multi-gpu memory safety.")
 
-import sys  # noqa: E402
-
-
-# TODO: waiting for pytorch implementgation of aten ops for MPS
-if sys.platform == "darwin":
-    os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
-
 import os.path  # noqa: E402
 from os.path import isdir, join  # noqa: E402
 from typing import Dict, List, Optional, Union  # noqa: E402

--- a/gptqmodel/quantization/foem.py
+++ b/gptqmodel/quantization/foem.py
@@ -7,8 +7,6 @@
 # adapted from @qwopqwop200 's [GPTQ-for-LLaMa](https://github.com/qwopqwop200/GPTQ-for-LLaMa/tree/cuda), which itself is based on [gptq](https://github.com/IST-DASLab/gptq)
 
 import math
-import os
-import sys
 import time
 from typing import Optional
 
@@ -139,14 +137,6 @@ class FOEM(GPTQ):
         # Keep `hessian_inverse` eager: torch.compile on this path can deadlock/hang
         # when a RuntimeError is raised inside the damp-recovery loop and the graph
         # is re-entered.
-
-        # if self.device.type not in ["mps", "cpu"]:
-        #     self.module.weight.data = self.module.weight.data.cpu()
-
-        # TODO: waiting for pytorch implementation of ops for MPS
-        if sys.platform == "darwin" and os.getenv("PYTORCH_ENABLE_MPS_FALLBACK") != "1":
-            raise RuntimeError(
-                "For MacOS you must set env `PYTORCH_ENABLE_MPS_FALLBACK=1` before running quantization.")
 
         if self.module_copy is None:
             # log.info("copy W to cuda_1")

--- a/gptqmodel/quantization/gptaq.py
+++ b/gptqmodel/quantization/gptaq.py
@@ -7,8 +7,6 @@
 # adapted from @qwopqwop200 's [GPTQ-for-LLaMa](https://github.com/qwopqwop200/GPTQ-for-LLaMa/tree/cuda), which itself is based on [gptq](https://github.com/IST-DASLab/gptq)
 
 import math
-import os
-import sys
 import time
 from typing import Optional
 
@@ -124,14 +122,6 @@ class GPTAQ(GPTQ):
         # Keep `hessian_inverse` eager: torch.compile on this path can deadlock/hang
         # when a RuntimeError is raised inside the damp-recovery loop and the graph
         # is re-entered.
-
-        # if self.device.type not in ["mps", "cpu"]:
-        #     self.module.weight.data = self.module.weight.data.cpu()
-
-        # TODO: waiting for pytorch implementation of ops for MPS
-        if sys.platform == "darwin" and os.getenv("PYTORCH_ENABLE_MPS_FALLBACK") != "1":
-            raise RuntimeError(
-                "For MacOS you must set env `PYTORCH_ENABLE_MPS_FALLBACK=1` before running quantization.")
 
         if self.module_copy is None:
             # log.info("copy W to cuda_1")

--- a/gptqmodel/quantization/gptq.py
+++ b/gptqmodel/quantization/gptq.py
@@ -7,8 +7,6 @@
 
 import contextlib
 import math
-import os
-import sys
 import threading
 import time
 from typing import Dict, Optional, Tuple
@@ -1001,14 +999,6 @@ class GPTQ:
         if self.qcfg.mock_quantization:
             # Use simplified hessian inverse (identity matrix)
             self.hessian_inverse = self.mock_hessian_inverse
-
-        # if self.device.type not in ["mps", "cpu"]:
-        #     self.module.weight.data = self.module.weight.data.cpu()
-
-        # TODO: waiting for pytorch implementation of ops for MPS
-        if sys.platform == "darwin" and os.getenv("PYTORCH_ENABLE_MPS_FALLBACK") != "1":
-            raise RuntimeError(
-                "For MacOS you must set env `PYTORCH_ENABLE_MPS_FALLBACK=1` before running quantization.")
 
         if self.module_copy is None:
             # log.info("copy W to cuda_1")

--- a/tests/test_mps_gptq.py
+++ b/tests/test_mps_gptq.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+import sys
+
+import pytest
+import torch
+
+from gptqmodel.quantization.config import QuantizeConfig
+from gptqmodel.quantization.gptq import GPTQ
+
+pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="requires macOS")
+
+
+def test_auto_import_does_not_force_mps_cpu_fallback():
+    env = os.environ.copy()
+    env.pop("PYTORCH_ENABLE_MPS_FALLBACK", None)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import os; "
+                "import gptqmodel.models.auto; "
+                "assert 'PYTORCH_ENABLE_MPS_FALLBACK' not in os.environ"
+            ),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.mps
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS is not available")
+def test_gptq_quantizes_on_mps_without_cpu_fallback(monkeypatch):
+    monkeypatch.delenv("PYTORCH_ENABLE_MPS_FALLBACK", raising=False)
+    device = torch.device("mps")
+    layer = torch.nn.Linear(32, 24, bias=False, device=device)
+    gptq = GPTQ(layer, QuantizeConfig(bits=4, group_size=8, damp_percent=0.01))
+    gptq.quantizer.configure(perchannel=True)
+    gptq.add_batch(torch.randn(2, 16, 32, device=device), None)
+
+    qweight, *_ = gptq.quantize(blocksize=16)
+    torch.mps.synchronize()
+
+    assert qweight.device.type == "mps"
+    assert torch.isfinite(qweight).all()


### PR DESCRIPTION
## What changed

- stop `models.auto` from globally forcing `PYTORCH_ENABLE_MPS_FALLBACK=1` on macOS
- remove obsolete fallback requirements from GPTQ, GPTAQ, and FOEM quantization
- add macOS regression coverage for environment preservation and native MPS GPTQ quantization

## Why

Modern PyTorch MPS implements the GPTQ Hessian and quantization operations used here. The old guard forced unsupported operations onto CPU even when the Metal implementation was available, preventing native MPS execution and making Hessian math substantially slower on Apple Silicon.

Fallback remains available as an explicit PyTorch opt-in for users running older builds with unsupported operations.

## Validation

- `tests/test_mps_gptq.py`: 2 passed on Apple M4 Max with `PYTORCH_ENABLE_MPS_FALLBACK` unset
- complete GPTQ quantization produced finite MPS weights without CPU fallback
- focused GPTQ configuration tests: 2 passed
- `git diff --check`
- Ruff passes for the new regression test
