### PR TITLE
Optimize asymmetric 2-bit zero-point search

### DIFF
--- a/gptqmodel/quantization/quantizer.py
+++ b/gptqmodel/quantization/quantizer.py
@@ -41,6 +41,30 @@ class Quantizer(nn.Module):
     def requires_groupwise_processing(self) -> bool:
         return False
 
+    def _search_adjacent_zero_points(self) -> bool:
+        """Return whether range search should optimize the 2-bit affine orientation."""
+
+        return (
+            int(self.maxq.item()) == 3
+            and not self.qcfg.sym
+            and not self.requires_groupwise_processing()
+        )
+
+    @staticmethod
+    def _adjacent_zero_point(
+        xmin: torch.Tensor,
+        scale: torch.Tensor,
+        primary: torch.Tensor,
+        *,
+        maxq: int,
+    ) -> torch.Tensor:
+        """Return the other integer neighboring the ideal affine zero point."""
+
+        ideal = -xmin / scale
+        lower = torch.floor(ideal).clamp_(0, maxq)
+        upper = torch.ceil(ideal).clamp_(0, maxq)
+        return torch.where(primary == lower, upper, lower)
+
     # FIXME, optimum shouldn't call this directly, it should call hf_configure
     def configure(
         self,
@@ -117,6 +141,8 @@ class Quantizer(nn.Module):
         mse = float(getattr(self.qcfg, "mse", 0.0) or 0.0)
         if mse > 0.0:
             best = torch.full([x.shape[0]], float("inf"), device=dev)
+            search_adjacent_zero_points = self._search_adjacent_zero_points()
+            maxq_value = int(self.maxq.item()) if search_adjacent_zero_points else 0
             for i in range(int(self.maxshrink * self.grid)):
                 p = 1 - i / self.grid
                 xmin1 = p * xmin
@@ -127,16 +153,33 @@ class Quantizer(nn.Module):
                     else (xmax1 - xmin1) / self.maxq
                 )
                 zero1 = torch.round(-xmin1 / scale1) if not self.qcfg.sym else self.zero
-                q = quantize(x, scale1.unsqueeze(1), zero1.unsqueeze(1), self.maxq, self.requires_groupwise_processing())
-                q -= x
-                q.abs_()
-                q.pow_(mse)
-                err = torch.sum(q, 1)
-                tmp = err < best
-                if torch.any(tmp):
-                    best[tmp] = err[tmp]
-                    self.scale[tmp] = scale1[tmp]
-                    self.zero[tmp] = zero1[tmp]
+                zero_candidates = (zero1,)
+                if search_adjacent_zero_points:
+                    alternate_zero = self._adjacent_zero_point(
+                        xmin1,
+                        scale1,
+                        zero1,
+                        maxq=maxq_value,
+                    )
+                    zero_candidates = (zero1, alternate_zero)
+
+                for zero_candidate in zero_candidates:
+                    q = quantize(
+                        x,
+                        scale1.unsqueeze(1),
+                        zero_candidate.unsqueeze(1),
+                        self.maxq,
+                        self.requires_groupwise_processing(),
+                    )
+                    q -= x
+                    q.abs_()
+                    q.pow_(mse)
+                    err = torch.sum(q, 1)
+                    tmp = err < best
+                    if torch.any(tmp):
+                        best[tmp] = err[tmp]
+                        self.scale[tmp] = scale1[tmp]
+                        self.zero[tmp] = zero_candidate[tmp]
         if not self.perchannel:
             if weight:
                 tmp = shape[0]

--- a/tests/test_gptq.py
+++ b/tests/test_gptq.py
@@ -18,6 +18,7 @@ from models.model_test import ModelTest
 from gptqmodel.quantization import gptq as gptq_mod
 from gptqmodel.quantization.config import HessianConfig, QuantizeConfig
 from gptqmodel.quantization.gptq import GPTQ
+from gptqmodel.quantization.quantizer import Quantizer
 
 
 def _make_module(hidden_dim: int, device: torch.device) -> nn.Linear:
@@ -146,6 +147,28 @@ def test_gptq_act_group_aware_rejects_non_positive_group_size():
 
     with pytest.raises(ValueError, match="group_size > 0"):
         GPTQ(layer, qcfg=qcfg)
+
+
+@torch.inference_mode()
+def test_two_bit_asymmetric_mse_search_optimizes_zero_point_orientation(monkeypatch):
+    weights = torch.tensor([[-1.0, 0.9, 0.9, 0.9, 0.9]], dtype=torch.float32)
+    qcfg = QuantizeConfig(bits=2, group_size=-1, sym=False, mse=2.0)
+
+    optimized = Quantizer(qcfg)
+    optimized.configure(perchannel=True)
+    optimized.find_params(weights, weight=True)
+
+    legacy = Quantizer(qcfg)
+    legacy.configure(perchannel=True)
+    monkeypatch.setattr(legacy, "_search_adjacent_zero_points", lambda: False)
+    legacy.find_params(weights, weight=True)
+
+    optimized_loss = (optimized.quantize(weights) - weights).square().sum()
+    legacy_loss = (legacy.quantize(weights) - weights).square().sum()
+
+    assert optimized.zero.item() == 1.0
+    assert legacy.zero.item() == 2.0
+    assert optimized_loss < legacy_loss
 
 
 class TestGPTQAddBatchCPU(ModelTest):


### PR DESCRIPTION
## Summary

- evaluate both adjacent integer zero-point orientations during asymmetric 2-bit MSE range search
- select the scale and zero-point pair with the lower configured reconstruction objective
- add a synthetic regression covering a distribution where the alternate orientation reduces error

## Root cause

An affine 2-bit grid has four codes. With zero point 2 its reconstructed levels are proportional to `[-2, -1, 0, 1]`; with zero point 1 they are proportional to `[-1, 0, 1, 2]`.

The existing range search rounded the ideal affine zero point before measuring reconstruction error. At two bits, that rounding decision chooses which side receives the fourth level, so range geometry could select the orientation independently of the MSE objective.

For each scale candidate, this change retains the rounded zero point and also evaluates the other adjacent legal integer zero point. The previous candidate remains in the search set, so the selected local objective cannot become worse.

## Scope

The additional candidate is restricted to `bits=2`, `sym=False`, non-groupwise affine quantization when MSE range search is enabled. Symmetric quantization, other bit widths, groupwise signed quantization, configuration, packing, and serialized formats are unchanged.

## Validation

- `pytest -q tests/test_gptq.py`: 3 passed, 4 accelerator-only tests skipped
- synthetic regression selects zero point 1 and has lower MSE than the prior zero-point-2 candidate restriction
- critical Ruff rules (`E9,F63,F7,F82`) passed on changed files
- Python compilation and `git diff --check` passed
