### PR TITLE
fix(eora): clamp covariance eigenvalues before inversion to avoid outlier adapters

### DIFF
--- a/gptqmodel/eora/eora.py
+++ b/gptqmodel/eora/eora.py
@@ -13,7 +13,7 @@
 #   year={2024}
 # }
 
-from typing import Sequence, Tuple
+from collections.abc import Sequence
 
 import torch
 from torch import Tensor
@@ -29,7 +29,7 @@ def eora_process_input(
         name: str,
         sample_size: int,
         device: torch.device,
-) -> Tuple[int, torch.Tensor, float]:
+) -> tuple[int, torch.Tensor, float]:
     """Prepare the per-batch covariance contribution required for EoRA.
 
     The contribution remains on the originating device so multi-GPU execution
@@ -55,7 +55,7 @@ def eora_process_input(
     return batch, contribution, scale
 
 
-def merge_eora_segments(segments: Sequence[Tuple[torch.Tensor, float]]) -> torch.Tensor:
+def merge_eora_segments(segments: Sequence[tuple[torch.Tensor, float]]) -> torch.Tensor:
     """Combine pre-aggregated EoRA segments using their scale products.
 
     Each segment entry is a tuple ``(total, scale_product)`` where ``total`` is
@@ -85,7 +85,7 @@ def eora_compute_lora(
         rank: int,
         dtype: torch.dtype,
         device: torch.device,
-) -> Tuple[Tensor, Tensor]:
+) -> tuple[Tensor, Tensor]:
 
     assert w_wq_delta.dtype == torch.float32
 
@@ -99,16 +99,36 @@ def eora_compute_lora(
 
     L, Q = torch.linalg.eigh(raw_scaling_diag_matrix)
 
-    if (L < 0).any():
-        ## When expanding the calibration data size for EoRA, I suggest maintaining the balance by allocating 50% to general input (C4) and the remaining 50% to downstream task data.
-        log.warn(f"Found negative eigenvalues in `{name}`. Please increase your calibration data set for EoRA.")
-        minimum = torch.min(L[L > 0])
-        L[L < 0] = minimum
+    if not torch.isfinite(L).all():
+        raise FloatingPointError(f"EoRA covariance eigensolve produced non-finite eigenvalues for `{name}`.")
 
-    sqrtEigenvalues = torch.sqrt(L)
-    scaling_diag_matrix = Q @ torch.diag(sqrtEigenvalues)
+    # Eigenvalues below the numerical-rank cutoff cannot be inverted reliably.
+    # Tiny or slightly negative values from float32 covariance accumulation
+    # become arbitrarily large outliers in 1/sqrt(lambda) and propagate into
+    # the low-rank adapter, so clamp the spectrum by truncating them to zero.
+    relative_tolerance = min(1.0, max(1, L.numel()) * torch.finfo(torch.float32).eps)
+    maximum = L[-1].clamp_min(0.0)
+    cutoff = maximum * relative_tolerance
+    retained = L > cutoff
 
-    scaling_matrix_inv = torch.diag(1/sqrtEigenvalues) @ Q.T
+    discarded_count = int((~retained).sum().item())
+    if discarded_count:
+        negative_count = int((L < 0).sum().item())
+        log.warning(
+            f"EoRA: covariance for `{name}` is numerically rank deficient; using a truncated pseudoinverse "
+            f"and discarding {discarded_count}/{L.numel()} eigenvalues at or below {cutoff.item():.3e} "
+            f"(negative={negative_count}, min={L[0].item():.3e}, max={L[-1].item():.3e}, "
+            f"rtol={relative_tolerance:.3e})."
+        )
+
+    sqrtEigenvalues = torch.zeros_like(L)
+    sqrtEigenvalues[retained] = torch.sqrt(L[retained])
+
+    invSqrtEigenvalues = torch.zeros_like(L)
+    invSqrtEigenvalues[retained] = torch.rsqrt(L[retained])
+
+    scaling_diag_matrix = Q * sqrtEigenvalues.unsqueeze(0)
+    scaling_matrix_inv = invSqrtEigenvalues.unsqueeze(1) * Q.T
 
     scaling_diag_matrix = scaling_diag_matrix.to(dtype=torch.float32)
     scaling_matrix_inv = scaling_matrix_inv.to(dtype=torch.float32)

--- a/gptqmodel/eora/eora.py
+++ b/gptqmodel/eora/eora.py
@@ -86,6 +86,12 @@ def eora_compute_lora(
         dtype: torch.dtype,
         device: torch.device,
 ) -> tuple[Tensor, Tensor]:
+    """Compute EoRA low-rank A/B from the original/quantized weight residual.
+
+    When expanding the calibration data size for EoRA, I suggest maintaining
+    the balance by allocating 50% to general input (C4) and the remaining 50%
+    to downstream task data.
+    """
 
     assert w_wq_delta.dtype == torch.float32
 

--- a/tests/test_eora.py
+++ b/tests/test_eora.py
@@ -1,0 +1,74 @@
+import pytest
+import torch
+
+from gptqmodel.eora.eora import eora_compute_lora
+
+
+def _random_symmetric_with_spectrum(eigenvalues: torch.Tensor) -> torch.Tensor:
+    """Build a symmetric matrix with the requested eigenvalue spectrum."""
+
+    dim = eigenvalues.numel()
+    Q, _ = torch.linalg.qr(torch.randn(dim, dim, dtype=torch.float64))
+    return Q @ torch.diag(eigenvalues.to(dtype=torch.float64)) @ Q.T
+
+
+@pytest.mark.parametrize("dim", [8, 16])
+@pytest.mark.parametrize("rank", [2, 4])
+def test_eora_compute_lora_clamps_negative_and_tiny_eigenvalues(dim, rank):
+    """A covariance with negative/tiny eigenvalues must not produce Inf/NaN adapters."""
+
+    torch.manual_seed(0)
+    device = torch.device("cpu")
+
+    # Construct a spectrum with clearly bad lower-tail values and one usable mode.
+    eigenvalues = torch.zeros(dim, dtype=torch.float64)
+    eigenvalues[-1] = 1.0
+    eigenvalues[-2] = 1e-12
+    eigenvalues[0] = -1e-8
+    eigenvalues[1] = -1e-6
+
+    eigen_scaling = _random_symmetric_with_spectrum(eigenvalues)
+    w_wq_delta = torch.randn(8, dim, dtype=torch.float32, device=device)
+
+    A, B = eora_compute_lora(
+        w_wq_delta=w_wq_delta,
+        name="test",
+        eigen_scaling_diag_matrix=eigen_scaling,
+        rank=rank,
+        dtype=torch.float16,
+        device=device,
+    )
+
+    assert A.shape == (rank, dim)
+    assert B.shape == (8, rank)
+    assert torch.isfinite(A).all()
+    assert torch.isfinite(B).all()
+    assert torch.isfinite(B @ A).all()
+
+
+def test_eora_compute_lora_handles_all_negative_eigenvalues():
+    """A pathological negative-definite covariance must not crash or return non-finite values."""
+
+    torch.manual_seed(0)
+    device = torch.device("cpu")
+    dim = 8
+    rank = 4
+
+    eigenvalues = -torch.logspace(-8, -2, dim)
+    eigen_scaling = _random_symmetric_with_spectrum(eigenvalues)
+    w_wq_delta = torch.randn(8, dim, dtype=torch.float32, device=device)
+
+    A, B = eora_compute_lora(
+        w_wq_delta=w_wq_delta,
+        name="test",
+        eigen_scaling_diag_matrix=eigen_scaling,
+        rank=rank,
+        dtype=torch.float32,
+        device=device,
+    )
+
+    assert A.shape == (rank, dim)
+    assert B.shape == (8, rank)
+    assert torch.isfinite(A).all()
+    assert torch.isfinite(B).all()
+    assert torch.isfinite(B @ A).all()


### PR DESCRIPTION
@nbasyl @hutm @cmhungsteve Please review. The following bug was encountered by me doing testing on EoRA. The lower the bpw, the higher the chance this becomes and the more damage it will cause. Most of the time it just manifest it self silently as lower EoRA recovery scores and was very sneaky to catch. It often does not manifest as catastrophic failure which is the sneaky part. 

## Summary

`eora_compute_lora` eigendecomposes the activation covariance matrix and forms a pseudoinverse via `1 / sqrt(eigenvalue)`. Numerical noise in the float32 accumulated covariance can yield tiny or slightly negative eigenvalues; the old code replaced negatives with the smallest positive eigenvalue, then computed `1/sqrt(lambda)` for every mode. When `lambda` is near zero this creates arbitrarily large inverse values that propagate as `NaN`/`Inf` outliers in the low-rank `A`/`B` tensors and, in the worst case, the branch `torch.min(L[L > 0])` crashes when every eigenvalue is non-positive.

Clamp the spectrum to a numerical-rank tolerance: discard eigenvalues at or below `max(lambda) * max(1, n) * float32_eps` by setting their `sqrt`/`rsqrt` contributions to zero, so they do not participate in the pseudoinverse. This produces finite adapters for rank-deficient or numerically indefinite covariances.

## What Changed

- `gptqmodel/eora/eora.py`: In `eora_compute_lora`, replace the `minimum`-replacement logic with a relative tolerance cutoff and zero-pad the discarded spectrum before `sqrt`/`rsqrt`. Also raise `FloatingPointError` if the eigensolve returns non-finite eigenvalues.
- `tests/test_eora.py`: New focused unit tests for covariance spectra containing negative/tiny eigenvalues and the all-negative pathological case.

## Tests

- [x] I added a new simple/fast unit test for this change.
- [x] I ran the new targeted test locally before opening this PR.

```bash
cd tests && python -m pytest test_eora.py -x -q
```

Result: `5 passed in 2.55s`

## Review Requirements

- [ ] Every changed file has been reviewed by a human.
- [x] I checked that the code matches existing project structure, APIs, and conventions.
- [x] I avoided unnecessary monkeypatching and used the project's normal extension points where possible.

## Notes

This fix keeps the existing `eora_compute_lora` signature and does not change the public EoRA API. The cutoff follows the same float32 numerical-rank reasoning used in the codebase's other Hessian/covariance paths.

