### PR TITLE
fix(looper): pass the missing processor arg to the AWQ subset debug log

### DIFF
--- a/gptqmodel/looper/stage_subset.py
+++ b/gptqmodel/looper/stage_subset.py
@@ -782,6 +782,7 @@ def _run_single_subset_pass(
                 layer_index,
                 subset_index + 1,
                 subset_total,
+                getattr(processor, "name", type(processor).__name__),
                 len(subset),
             )
         else:


### PR DESCRIPTION
### Problem

In `_run_single_subset_pass`, the subset hook-registration debug log has two branches. The AWQ branch's format string has **five** `%s` placeholders but only **four** arguments are supplied — the `processor=%s` value is missing:

https://github.com/ModelCloud/GPTQModel/blob/main/gptqmodel/looper/stage_subset.py#L800-L817

```python
if DEBUG_ON and logger.isEnabledFor(logging.DEBUG):
    if is_awq_processor:
        logger.debug(
            "StageSubset[awq]: layer=%s subset=%s/%s processor=%s registering hooks for %s modules",
            layer_index,
            subset_index + 1,
            subset_total,
            len(subset),              # <-- lands in processor=%s; nothing left for the last %s
        )
    else:
        logger.debug(
            "StageSubset: layer=%s subset=%s/%s processor=%s registering hooks for %s modules",
            layer_index,
            subset_index + 1,
            subset_total,
            getattr(processor, "name", type(processor).__name__),   # <-- present here
            len(subset),
        )
```

The non-AWQ branch immediately below is correct, which is what makes this look like an oversight rather than intent.

### Effect

`logging` renders the message lazily, so the mismatch surfaces at emit time as `TypeError: not enough arguments for format string`. `logging` catches it, prints a `--- Logging error ---` traceback to stderr, and **drops the record**. So the log line is lost precisely when someone has turned on `DEBUG` to inspect AWQ hook registration, and stderr gets a traceback instead.

Minimal reproduction of the two branches' formatting behaviour:

```
--- OLD (4 args, awq branch as written) ---
emitted log record: ''
stderr got Logging error: True

--- NEW (5 args, processor threaded through) ---
emitted log record: 'StageSubset[awq]: layer=3 subset=1/2 processor=AwqProcessor registering hooks for 8 modules\n'
```

### Fix

Pass the processor name as the fourth argument, exactly as the non-AWQ branch already does. One line, no behaviour change outside the debug log.

```diff
                 subset_total,
+                getattr(processor, "name", type(processor).__name__),
                 len(subset),
```

`processor` is a parameter of `_run_single_subset_pass`, so it is in scope in both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
