### PR TITLE
fix(calibration): interpolate the item index in the unsupported-sequence error

### DIFF
--- a/gptqmodel/utils/calibration.py
+++ b/gptqmodel/utils/calibration.py
@@ -259,7 +259,7 @@ def prepare_calibration_dataset(
             if len(templated) > 0 and isinstance(templated[0], int):
                 return _pack_ids(list(templated), None, idx)
             raise ValueError(
-                "tokenizer.apply_template returned an unsupported sequence type for calibration item {idx}."
+                f"tokenizer.apply_template returned an unsupported sequence type for calibration item {idx}."
             )
 
         if torch.is_tensor(templated):


### PR DESCRIPTION
### Problem

In `prepare_calibration_dataset`, the helper `_tokenize_messages_value` raises three
`ValueError`s that all report which calibration item failed. Two of them are f-strings;
the middle one is a plain string literal, so its `{idx}` is emitted verbatim:

`gptqmodel/utils/calibration.py`

```python
if templated is None:
    raise ValueError(f"tokenizer.apply_template returned None for calibration item {idx}.")   # L244  f-string
...
if isinstance(templated, (list, tuple)):
    if len(templated) > 0 and isinstance(templated[0], int):
        return _pack_ids(list(templated), None, idx)
    raise ValueError(
        "tokenizer.apply_template returned an unsupported sequence type for calibration item {idx}."  # L262  no f
    )
...
raise ValueError(
    f"tokenizer.apply_template returned unsupported type {type(templated)} for calibration item {idx}."  # L272  f-string
)
```

Rendering the two literals with `idx = 3`:

```
L244 (sibling) -> tokenizer.apply_template returned None for calibration item 3.
L262 (this fix) -> tokenizer.apply_template returned an unsupported sequence type for calibration item {idx}.
```

The index is the only actionable part of the message — it is what tells the user which
row of their calibration dataset to look at. This branch fires when a custom
`apply_template` returns a non-empty sequence whose first element is not an `int`
(e.g. a list of token *strings*), and the user is left without the item number.

Neither ruff nor flake8 flags this: `F541` covers f-strings with no placeholders, not
the reverse.

### Fix

Add the missing `f` prefix. One character, no behaviour change beyond the message text.

### Note on `AGENTS.md`

`AGENTS.md` routes tokenizer/chat-template *behaviour* changes to Tokenicer. This patch
changes no tokenization, prompt rendering, or normalization logic — it only makes an
existing diagnostic interpolate the value it already names — so it stays in
GPT-QModel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
