### PR TITLE
feat(models): add Cohere Compass quantization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 ## Latest News
 
+* 08/18/2026 7.4.0 `main`: ✨ Added Cohere `North Micro Vision` (`cohere_compass`) model support
 * 08/04/2026 7.4.0 `main`: ✨ Added `axk2` (A.X-K2) model support
 * 08/04/2026 7.4.0 `main`: 🚀🔥⚡ Added `Swordfish` Blackwell (>= sm100) GPTQ/AWQ kernel from [AlpinDale](https://x.com/AlpinDale): [Paper](https://blog.alpindale.net/posts/swordfish/).
 * 07/24/2026 7.3.1 `main`: ✨ Added `solar_open` and `solar_open2` model support
@@ -280,7 +281,15 @@ Selected public references where teams or companies explicitly mention GPT-QMode
 | XVERSE                        | ✅ | Brumby                          | ✅ | Hymba                      | ✅ | Mistral                         | ✅ | Qwen 1/2/3/3.5         | ✅ |
 | MiniMax M2/M3                 | ✅ | AfMoE                           | ✅ | Bailing-MoE                | ✅ | LFM2 / LFM2-VL / LFM2-MoE       | ✅ | Marin                  | ✅ |
 | InternVL Chat                 | ✅ | Laguna                          | ✅ | Mimo / Mimo V2             | ✅ | Zamba / Zamba2                  | ✅ | Intern S1 / S2 Preview             | ✅ |
-| HunYuan V1 Dense / MoE        | ✅ | HY-V3                           | ✅ | Inkling           | ✅ | Solar Open / Open 2                    | ✅ |                |   |
+| HunYuan V1 Dense / MoE        | ✅ | HY-V3                           | ✅ | Inkling           | ✅ | Solar Open / Open 2                    | ✅ | North Micro Vision | ✅ |
+
+[CohereLabs/North-Micro-Vision-Instruct](https://huggingface.co/CohereLabs/North-Micro-Vision-Instruct) currently
+requires unreleased Transformers 5.16 APIs. Install the runtime dependencies and Transformers from Git:
+
+```bash
+uv pip install accelerate pillow
+uv pip install "git+https://github.com/huggingface/transformers.git"
+```
 
 Prism Bonsai GGUF checkpoints are supported for inference only through GPT-QModel's native GGUF path and internal GGUF runtime. Bonsai checkpoints load through the normal model path or repo argument and do not require the external `gguf` package. Prism model quantization is not included.
 

--- a/README.md
+++ b/README.md
@@ -283,13 +283,6 @@ Selected public references where teams or companies explicitly mention GPT-QMode
 | InternVL Chat                 | ✅ | Laguna                          | ✅ | Mimo / Mimo V2             | ✅ | Zamba / Zamba2                  | ✅ | Intern S1 / S2 Preview             | ✅ |
 | HunYuan V1 Dense / MoE        | ✅ | HY-V3                           | ✅ | Inkling           | ✅ | Solar Open / Open 2                    | ✅ | North Micro Vision | ✅ |
 
-[CohereLabs/North-Micro-Vision-Instruct](https://huggingface.co/CohereLabs/North-Micro-Vision-Instruct) currently
-requires unreleased Transformers 5.16 APIs. Install the runtime dependencies and Transformers from Git:
-
-```bash
-uv pip install accelerate pillow
-uv pip install "git+https://github.com/huggingface/transformers.git"
-```
 
 Prism Bonsai GGUF checkpoints are supported for inference only through GPT-QModel's native GGUF path and internal GGUF runtime. Bonsai checkpoints load through the normal model path or repo argument and do not require the external `gguf` package. Prism model quantization is not included.
 

--- a/gptqmodel/looper/awq_processor.py
+++ b/gptqmodel/looper/awq_processor.py
@@ -1610,7 +1610,12 @@ class AWQProcessor(LoopProcessor):
             seq_len = x.shape[0]
 
         rotary = self._get_root_rotary()
-        if seq_len is not None and rotary is not None and supports_position_embeddings:
+        if (
+            seq_len is not None
+            and rotary is not None
+            and supports_position_embeddings
+            and "position_embeddings" not in module_kwargs
+        ):
             rotary = self._get_rotary_for_device(target_device or x.device)
             rotary_device = self._get_rotary_device(rotary, target_device or x.device)
             pos_ids = module_kwargs.get("position_ids") if supports_position_ids else None

--- a/gptqmodel/looper/awq_processor.py
+++ b/gptqmodel/looper/awq_processor.py
@@ -1610,11 +1610,15 @@ class AWQProcessor(LoopProcessor):
             seq_len = x.shape[0]
 
         rotary = self._get_root_rotary()
+        preserve_position_embeddings = (
+            getattr(self.gptq_model, "awq_preserve_explicit_position_embeddings", False)
+            and "position_embeddings" in module_kwargs
+        )
         if (
             seq_len is not None
             and rotary is not None
             and supports_position_embeddings
-            and "position_embeddings" not in module_kwargs
+            and not preserve_position_embeddings
         ):
             rotary = self._get_rotary_for_device(target_device or x.device)
             rotary_device = self._get_rotary_device(rotary, target_device or x.device)

--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -74,6 +74,7 @@ from .definitions.brumby import BrumbyQModel  # noqa: E402
 from .definitions.chatglm import ChatGLMQModel  # noqa: E402
 from .definitions.codegen import CodeGenQModel  # noqa: E402
 from .definitions.cohere2_moe import Cohere2MoeQModel  # noqa: E402
+from .definitions.cohere_compass import CohereCompassQModel  # noqa: E402
 from .definitions.dbrx import DbrxQModel  # noqa: E402
 from .definitions.dbrx_converted import DbrxConvertedQModel  # noqa: E402
 from .definitions.decilm import DeciLMQModel  # noqa: E402
@@ -236,6 +237,7 @@ MODEL_MAP = {
     "cohere": LlamaQModel, # 100% llama clone
     "cohere2": LlamaQModel, # 100% llama clone
     "cohere2_moe": Cohere2MoeQModel,
+    "cohere_compass": CohereCompassQModel,
     "refinedWebModel": RwgQModel,
     "refinedWeb": RwgQModel,
     "falcon": RwgQModel,

--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -199,6 +199,9 @@ class BaseQModel(nn.Module):
     # list modules where they must match the shape of previous module in execution to consider for scaling optimization
     awq_scale_optimize_shape_dependent_modules: List[str] = None
 
+    # Preserve adapter-supplied position_embeddings during AWQ replay instead of rebuilding them from the root rotary.
+    awq_preserve_explicit_position_embeddings = False
+
     # some models require trust_remove_code = True (dbrx_converted)
     require_trust_remote_code = None
 

--- a/gptqmodel/models/definitions/__init__.py
+++ b/gptqmodel/models/definitions/__init__.py
@@ -14,6 +14,7 @@ from .brumby import BrumbyQModel
 from .chatglm import ChatGLMQModel
 from .codegen import CodeGenQModel
 from .cohere2_moe import Cohere2MoeQModel
+from .cohere_compass import CohereCompassQModel
 from .dbrx import DbrxQModel
 from .dbrx_converted import DbrxConvertedQModel
 from .decilm import DeciLMQModel

--- a/gptqmodel/models/definitions/cohere_compass.py
+++ b/gptqmodel/models/definitions/cohere_compass.py
@@ -1,0 +1,380 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from typing import Any, Dict
+
+import torch
+from transformers import AutoModelForImageTextToText, AutoProcessor, ProcessorMixin
+from transformers.masking_utils import create_causal_mask, create_sliding_window_causal_mask
+
+from ...utils.calibration import batched
+from ...utils.device import get_device
+from ...utils.model import MODALITY, get_module_by_name_prefix, move_to, nested_move_to
+from ...utils.offload import offload_to_disk
+from .._const import CPU
+from ..base import BaseQModel
+
+
+_RAW_ATTENTION_MASK = "__gptqmodel_cohere_compass_attention_mask"
+_POSITION_IDS_BATCH_FIRST = "__gptqmodel_cohere_compass_position_ids_batch_first"
+_DEEPSTACK_VISUAL_MASK = "__gptqmodel_cohere_compass_visual_pos_masks"
+_DEEPSTACK_VISUAL_EMBEDS = "__gptqmodel_cohere_compass_deepstack_visual_embeds"
+_MISSING = object()
+
+
+class CohereCompassQModel(BaseQModel):
+    """Cohere Compass VLM adapter used by North Micro Vision.
+
+    The vision tower stays in its native dtype. Quantization targets the text
+    decoder, whose attention and MLP consume the same normalized layer input.
+    """
+
+    loader = AutoModelForImageTextToText
+
+    require_load_processor = True
+    require_trust_remote_code = False
+    require_pkgs = ["transformers>=5.16.0.dev0"]
+
+    modality = [MODALITY.TEXT, MODALITY.IMAGE_TO_TEXT]
+
+    pre_lm_head_norm_module = "model.language_model.norm"
+    rotary_embedding = "model.language_model.rotary_emb"
+
+    # Cohere Compass uses GQA, so o_proj does not match v_proj's output shape.
+    awq_scale_optimize_shape_dependent_modules = ["self_attn.o_proj"]
+
+    # Decoder forward order is:
+    #   normalized = input_layernorm(hidden_states)
+    #   hidden_states + self_attn(normalized) + mlp(normalized)
+    module_tree = [
+        "model",
+        "language_model",
+        "layers",
+        "#",
+        {
+            "input_layernorm": ("input_layernorm:!",),
+            "self_attn": ("q_proj:0:q", "k_proj:0:k", "v_proj:0:v", "o_proj:1"),
+            "mlp": ("gate_proj:0:gate", "up_proj:0:up", "down_proj:1:down"),
+        },
+    ]
+
+    def _language_model(self):
+        core_model = getattr(self.model, "model", self.model)
+        return getattr(core_model, "language_model", core_model)
+
+    def _start_outer_input_capture(self) -> None:
+        """Capture state owned by the outer text loop before first-layer early stop."""
+
+        self._stop_outer_input_capture()
+        language_model = self._language_model()
+
+        def capture_outer_inputs(module, args, kwargs):
+            del args
+            setattr(module, _RAW_ATTENTION_MASK, kwargs.get("attention_mask"))
+            position_ids = kwargs.get("position_ids")
+            if torch.is_tensor(position_ids) and position_ids.ndim == 3:
+                position_ids = position_ids.transpose(0, 1)
+            setattr(module, _POSITION_IDS_BATCH_FIRST, position_ids)
+            setattr(module, _DEEPSTACK_VISUAL_MASK, kwargs.get("visual_pos_masks"))
+            setattr(module, _DEEPSTACK_VISUAL_EMBEDS, kwargs.get("deepstack_visual_embeds"))
+
+        self._cohere_compass_input_capture_handle = language_model.register_forward_pre_hook(
+            capture_outer_inputs,
+            with_kwargs=True,
+        )
+
+    def _stop_outer_input_capture(self) -> None:
+        handle = getattr(self, "_cohere_compass_input_capture_handle", None)
+        if handle is not None:
+            handle.remove()
+            delattr(self, "_cohere_compass_input_capture_handle")
+
+        language_model = self._language_model()
+        for name in (
+            _RAW_ATTENTION_MASK,
+            _POSITION_IDS_BATCH_FIRST,
+            _DEEPSTACK_VISUAL_MASK,
+            _DEEPSTACK_VISUAL_EMBEDS,
+        ):
+            if hasattr(language_model, name):
+                delattr(language_model, name)
+
+    @staticmethod
+    def _layer_type(layer, text_config):
+        self_attn = getattr(layer, "self_attn", None)
+        layer_index = getattr(self_attn, "layer_idx", None)
+        layer_types = getattr(text_config, "layer_types", ())
+        if layer_index is None or not 0 <= layer_index < len(layer_types):
+            return None
+        return layer_types[layer_index]
+
+    @staticmethod
+    def _position_ids_for_replay(position_ids_batch_first, hidden_states, target_device):
+        batch_size = hidden_states.shape[0] if hidden_states.dim() >= 3 else 1
+        seq_len = hidden_states.shape[1] if hidden_states.dim() >= 3 else hidden_states.shape[0]
+
+        if position_ids_batch_first is None:
+            position_ids = torch.arange(seq_len, device=target_device, dtype=torch.long)
+            position_ids = position_ids.view(1, 1, -1).expand(4, batch_size, -1)
+        else:
+            position_ids = move_to(position_ids_batch_first, device=target_device)
+            if position_ids.ndim == 3:
+                position_ids = position_ids.transpose(0, 1)
+            elif position_ids.ndim == 2:
+                position_ids = position_ids[None, ...].expand(4, position_ids.shape[0], -1)
+
+        if position_ids.ndim == 3 and position_ids.shape[0] == 4:
+            return position_ids[0], position_ids[1:]
+        return None, position_ids
+
+    def _prepare_layer_forward_kwargs(
+        self,
+        layer,
+        layer_input,
+        module_kwargs: Dict,
+        target_device,
+    ) -> Dict:
+        """Rebuild kwargs normally selected by Cohere's outer sliding/full decoder loop."""
+
+        prepared_kwargs = dict(module_kwargs)
+        raw_attention_mask = prepared_kwargs.pop(_RAW_ATTENTION_MASK, _MISSING)
+        position_ids_batch_first = prepared_kwargs.pop(_POSITION_IDS_BATCH_FIRST, _MISSING)
+        prepared_kwargs.pop(_DEEPSTACK_VISUAL_MASK, None)
+        prepared_kwargs.pop(_DEEPSTACK_VISUAL_EMBEDS, None)
+
+        text_config = getattr(self.model.config, "text_config", self.model.config)
+        layer_type = self._layer_type(layer, text_config)
+        if layer_type is None:
+            return prepared_kwargs
+
+        rope_parameters = getattr(text_config, "rope_parameters", {})
+        if layer_type in rope_parameters and rope_parameters[layer_type] is None:
+            prepared_kwargs["position_embeddings"] = None
+
+        if not layer_input or not torch.is_tensor(layer_input[0]):
+            return prepared_kwargs
+
+        hidden_states = layer_input[0]
+        target_device = torch.device(target_device)
+        text_position_ids = None
+        rotary_position_ids = None
+        if position_ids_batch_first is not _MISSING:
+            text_position_ids, rotary_position_ids = self._position_ids_for_replay(
+                position_ids_batch_first,
+                hidden_states,
+                target_device,
+            )
+
+            if (
+                layer_type in rope_parameters
+                and rope_parameters[layer_type] is not None
+                and rotary_position_ids is not None
+            ):
+                rotary, _ = get_module_by_name_prefix(self.model, [self.rotary_embedding])
+                if rotary is not None:
+                    rotary_device = get_device(rotary)
+                    rotary_input = torch.empty(1, device=rotary_device, dtype=hidden_states.dtype)
+                    rotary_position_ids = move_to(rotary_position_ids, device=rotary_device)
+                    prepared_kwargs["position_embeddings"] = nested_move_to(
+                        rotary(rotary_input, rotary_position_ids, layer_type),
+                        device=target_device,
+                    )
+
+        if raw_attention_mask is not _MISSING:
+            if isinstance(raw_attention_mask, dict):
+                prepared_kwargs["attention_mask"] = nested_move_to(
+                    raw_attention_mask[layer_type],
+                    device=target_device,
+                )
+            else:
+                raw_attention_mask = nested_move_to(raw_attention_mask, device=target_device)
+                mask_builder = (
+                    create_sliding_window_causal_mask
+                    if layer_type == "sliding_attention"
+                    else create_causal_mask
+                )
+                prepared_kwargs["attention_mask"] = mask_builder(
+                    config=text_config,
+                    inputs_embeds=hidden_states,
+                    attention_mask=raw_attention_mask,
+                    past_key_values=None,
+                    position_ids=text_position_ids,
+                )
+
+        return prepared_kwargs
+
+    def prepare_layer_replay_kwargs(self, layer, layer_input, additional_inputs, target_device):
+        """Keep isolated decoder replay aligned with Cohere's outer text loop."""
+
+        additional_inputs = super().prepare_layer_replay_kwargs(
+            layer,
+            layer_input,
+            additional_inputs,
+            target_device,
+        )
+        return self._prepare_layer_forward_kwargs(layer, layer_input, additional_inputs, target_device)
+
+    def capture_first_layer_input_kwargs(self, args, kwargs, batch_device, layer_input_kwargs):
+        """Persist outer-loop masks, positions, and DeepStack inputs for isolated replay."""
+
+        layer_input_kwargs = super().capture_first_layer_input_kwargs(
+            args,
+            kwargs,
+            batch_device,
+            layer_input_kwargs,
+        )
+        language_model = self._language_model()
+        for name in (_RAW_ATTENTION_MASK, _POSITION_IDS_BATCH_FIRST):
+            value = getattr(language_model, name, None)
+            layer_input_kwargs[name] = nested_move_to(value, device=batch_device)
+
+        visual_pos_masks = getattr(language_model, _DEEPSTACK_VISUAL_MASK, None)
+        deepstack_visual_embeds = getattr(language_model, _DEEPSTACK_VISUAL_EMBEDS, None)
+        if visual_pos_masks is not None and deepstack_visual_embeds is not None:
+            layer_input_kwargs[_DEEPSTACK_VISUAL_MASK] = nested_move_to(
+                visual_pos_masks,
+                device=batch_device,
+            )
+            layer_input_kwargs[_DEEPSTACK_VISUAL_EMBEDS] = nested_move_to(
+                deepstack_visual_embeds,
+                device=batch_device,
+            )
+
+        return layer_input_kwargs
+
+    def update_layer_replay_kwargs_from_output(self, layer, layer_output, layer_input_kwargs, target_device):
+        """Apply the DeepStack residual that the outer text loop adds after early decoder layers."""
+
+        del target_device
+        visual_pos_masks = layer_input_kwargs.get(_DEEPSTACK_VISUAL_MASK)
+        deepstack_visual_embeds = layer_input_kwargs.get(_DEEPSTACK_VISUAL_EMBEDS)
+        layer_index = getattr(getattr(layer, "self_attn", None), "layer_idx", None)
+        if (
+            visual_pos_masks is None
+            or deepstack_visual_embeds is None
+            or layer_index is None
+            or not 0 <= layer_index < len(deepstack_visual_embeds)
+        ):
+            return layer_input_kwargs
+
+        primary_output = layer_output[0] if isinstance(layer_output, tuple) else layer_output
+        if not torch.is_tensor(primary_output):
+            return layer_input_kwargs
+
+        updated_output = self._language_model()._deepstack_process(
+            primary_output,
+            visual_pos_masks,
+            deepstack_visual_embeds[layer_index],
+        )
+        primary_output.copy_(updated_output)
+        return layer_input_kwargs
+
+    def awq_get_modules_for_scaling(self, module, input_feat, module_kwargs):
+        """Apply the same outer-loop kwargs to AWQ attention replays."""
+
+        fallback_input = next(
+            (value for value in input_feat.values() if torch.is_tensor(value) and value.numel() > 0),
+            None,
+        )
+        layer_input = [fallback_input] if fallback_input is not None else []
+        target_device = fallback_input.device if fallback_input is not None else get_device(module)
+        prepared_kwargs = self._prepare_layer_forward_kwargs(
+            module,
+            layer_input,
+            module_kwargs,
+            target_device,
+        )
+        feature_kwargs = prepared_kwargs.get("_awq_feature_kwargs")
+        if isinstance(feature_kwargs, dict):
+            prepared_feature_kwargs = {}
+            for name, kwargs in feature_kwargs.items():
+                if not isinstance(kwargs, dict):
+                    prepared_feature_kwargs[name] = kwargs
+                    continue
+
+                feature_input = input_feat.get(name, fallback_input)
+                feature_layer_input = [feature_input] if feature_input is not None else []
+                feature_device = feature_input.device if feature_input is not None else target_device
+                prepared_feature_kwargs[name] = self._prepare_layer_forward_kwargs(
+                    module,
+                    feature_layer_input,
+                    kwargs,
+                    feature_device,
+                )
+            prepared_kwargs["_awq_feature_kwargs"] = prepared_feature_kwargs
+        return super().awq_get_modules_for_scaling(module, input_feat, prepared_kwargs)
+
+    def pre_quantize_generate_hook_start(self):
+        core_model = self.model.model
+        language_model = core_model.language_model
+        self.shell_module_materialize(language_model.embed_tokens, self.quantize_config.device)
+        self.shell_module_materialize(language_model.norm, self.quantize_config.device)
+        self.shell_module_materialize(language_model.rotary_emb, self.quantize_config.device)
+        self.shell_module_materialize(core_model.visual, self.quantize_config.device)
+        self._start_outer_input_capture()
+
+    def pre_quantize_generate_hook_end(self):
+        core_model = self.model.model
+        language_model = core_model.language_model
+        self._stop_outer_input_capture()
+        if self.quantize_config.offload_to_disk:
+            offload_to_disk(
+                model=language_model,
+                module=language_model.embed_tokens,
+                disk_path=self.quantize_config.offload_to_disk_path,
+            )
+            offload_to_disk(
+                model=language_model,
+                module=language_model.norm,
+                disk_path=self.quantize_config.offload_to_disk_path,
+            )
+            offload_to_disk(
+                model=language_model,
+                module=language_model.rotary_emb,
+                disk_path=self.quantize_config.offload_to_disk_path,
+            )
+            offload_to_disk(
+                model=core_model,
+                module=core_model.visual,
+                disk_path=self.quantize_config.offload_to_disk_path,
+            )
+            return
+
+        language_model.embed_tokens = move_to(language_model.embed_tokens, device=CPU)
+        language_model.norm = move_to(language_model.norm, device=CPU)
+        language_model.rotary_emb = move_to(language_model.rotary_emb, device=CPU)
+        core_model.visual = move_to(core_model.visual, device=CPU)
+
+    def preprocess_dataset(self, sample: Dict[str, Any]) -> Dict[str, Any]:
+        return sample
+
+    def load_processor(self) -> ProcessorMixin:
+        return AutoProcessor.from_pretrained(self.model_local_path, trust_remote_code=False)
+
+    @classmethod
+    def prepare_inputs_for_conversations(
+        cls,
+        processor: ProcessorMixin,
+        conversations: list[dict] | list[list[dict]],
+    ):
+        return processor.apply_chat_template(
+            conversations,
+            tokenize=True,
+            add_generation_prompt=True,
+            return_tensors="pt",
+            return_dict=True,
+        )
+
+    def prepare_dataset(self, calibration_dataset, batch_size: int = 1, **kwargs):
+        del kwargs
+        processor = self.load_processor()
+        calib_data = []
+        for batch in batched(calibration_dataset, batch_size, process_func=self.preprocess_dataset):
+            calib_data.append(self.prepare_inputs_for_conversations(processor, batch))
+        del processor
+        return calib_data
+
+
+__all__ = ["CohereCompassQModel"]

--- a/gptqmodel/models/definitions/cohere_compass.py
+++ b/gptqmodel/models/definitions/cohere_compass.py
@@ -44,6 +44,7 @@ class CohereCompassQModel(BaseQModel):
 
     # Cohere Compass uses GQA, so o_proj does not match v_proj's output shape.
     awq_scale_optimize_shape_dependent_modules = ["self_attn.o_proj"]
+    awq_preserve_explicit_position_embeddings = True
 
     # Decoder forward order is:
     #   normalized = input_layernorm(hidden_states)

--- a/gptqmodel/quantization/awq/quantize/scale.py
+++ b/gptqmodel/quantization/awq/quantize/scale.py
@@ -33,10 +33,17 @@ try:
 except Exception:  # pragma: no cover - older transformers builds do not expose Gemma 4 yet
     Gemma4RMSNorm = None
 
+try:
+    from transformers.models.cohere_compass.modeling_cohere_compass import CohereCompassLayerNorm
+except Exception:  # pragma: no cover - older transformers builds do not expose Cohere Compass yet
+    CohereCompassLayerNorm = None
+
 
 allowed_norms = [nn.LayerNorm, LlamaRMSNorm, GemmaRMSNorm, Gemma2RMSNorm, CohereLayerNorm]
 if Gemma4RMSNorm is not None:
     allowed_norms.append(Gemma4RMSNorm)
+if CohereCompassLayerNorm is not None:
+    allowed_norms.append(CohereCompassLayerNorm)
 allowed_act_fns = [
     nn.GELU,
     BloomGelu,

--- a/tests/models/ovis/image_to_test_dataset.py
+++ b/tests/models/ovis/image_to_test_dataset.py
@@ -4,6 +4,7 @@
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 from gptqmodel.models.definitions.base_qwen2_5_omni import BaseQwen2_5_OmniGPTQ
 from gptqmodel.models.definitions.base_qwen2_vl import BaseQwen2VLGPTQ
+from gptqmodel.models.definitions.cohere_compass import CohereCompassQModel
 from gptqmodel.models.definitions.deepseek_ocr2 import DeepSeekOCR2QModel
 from gptqmodel.models.definitions.deepseek_vl import DeepSeekVLQModel
 from gptqmodel.models.definitions.deepseek_vl_v2 import DeepSeekVLV2QModel
@@ -179,7 +180,7 @@ def get_calib_dataset(model):
     if isinstance(model, DeepSeekVLV2QModel):
         return prepare_deepseek_vl_v2_dataset(n_sample=20)
 
-    if isinstance(model, DeepSeekVLQModel):
+    if isinstance(model, (CohereCompassQModel, DeepSeekVLQModel)):
         return prepare_deepseek_vl_dataset(n_sample=20)
 
     if isinstance(model, DeepSeekOCR2QModel):

--- a/tests/models/test_cohere_compass.py
+++ b/tests/models/test_cohere_compass.py
@@ -7,7 +7,6 @@ import os.path
 from pathlib import Path
 from types import SimpleNamespace
 
-import pytest
 import torch
 from model_test import ModelTest
 from PIL import Image

--- a/tests/models/test_cohere_compass.py
+++ b/tests/models/test_cohere_compass.py
@@ -374,8 +374,6 @@ class TestCohereCompass(ModelTest):
     EVAL_BATCH_SIZE = 8
     MODEL_COMPAT_FAST_LAYER_COUNT = 4
     MODEL_COMPAT_FAST_LAYER_POSITION = "first"
-    # Exercise both benchmarks without inventing score thresholds; the test below
-    # still requires each task and its expected metrics to be returned.
     EVAL_TASKS_SLOW = {
         "gsm8k_platinum_cot": {
             "chat_template": True,
@@ -387,16 +385,36 @@ class TestCohereCompass(ModelTest):
     EVAL_TASKS_FAST = {
         "gsm8k_platinum_cot": {
             "chat_template": True,
-            "evalution_batch_size": 8,
+            "evalution_use_model_path": True,
+            "evalution_batch_size": "auto",
+            "evalution_model_args": {
+                "dtype": "bfloat16",
+                "attn_implementation": "paged|flash_attention_2",
+                "device": "cuda:0",
+            },
             "evalution_suite_kwargs": {
-                "batch_size": 8,
+                "batch_size": 32,
                 "max_new_tokens": 256,
                 "stream": True,
+            },
+            "acc,num": {
+                "value": 0.47229114971050457,
+                "floor_pct": 0.04,
+                "ceil_pct": 1.0,
             },
         },
         "arc_challenge": {
             "chat_template": True,
-            "evalution_batch_size": 8,
+            "acc": {
+                "value": 0.3242320819112628,
+                "floor_pct": 0.04,
+                "ceil_pct": 1.0,
+            },
+            "acc_norm": {
+                "value": 0.3515358361774744,
+                "floor_pct": 0.04,
+                "ceil_pct": 1.0,
+            },
         },
     }
 
@@ -465,15 +483,55 @@ def test_cohere_compass_eval_configuration(monkeypatch):
     test_case = TestCohereCompass(methodName="test_cohere_compass")
 
     assert test_case.get_eval_tasks() == {
-        "gsm8k_platinum_cot": {},
-        "arc_challenge": {},
+        "gsm8k_platinum_cot": {
+            "acc,num": {
+                "value": 0.47229114971050457,
+                "floor_pct": 0.04,
+                "ceil_pct": 1.0,
+                "metric_key": None,
+            },
+        },
+        "arc_challenge": {
+            "acc": {
+                "value": 0.3242320819112628,
+                "floor_pct": 0.04,
+                "ceil_pct": 1.0,
+                "metric_key": None,
+            },
+            "acc_norm": {
+                "value": 0.3515358361774744,
+                "floor_pct": 0.04,
+                "ceil_pct": 1.0,
+                "metric_key": None,
+            },
+        },
     }
     assert test_case._task_chat_template == {
         "gsm8k_platinum_cot": True,
         "arc_challenge": True,
     }
     assert test_case._task_evalution_batch_size == {
-        "gsm8k_platinum_cot": 8,
-        "arc_challenge": 8,
+        "gsm8k_platinum_cot": "auto",
+        "arc_challenge": None,
+    }
+    assert test_case._task_evalution_use_model_path == {
+        "gsm8k_platinum_cot": True,
+        "arc_challenge": False,
+    }
+    assert test_case._task_evalution_model_args == {
+        "gsm8k_platinum_cot": {
+            "dtype": "bfloat16",
+            "attn_implementation": "paged|flash_attention_2",
+            "device": "cuda:0",
+        },
+        "arc_challenge": {},
+    }
+    assert test_case._task_evalution_suite_kwargs == {
+        "gsm8k_platinum_cot": {
+            "batch_size": 32,
+            "max_new_tokens": 256,
+            "stream": True,
+        },
+        "arc_challenge": {},
     }
     assert TestCohereCompass.MODEL_COMPAT_FAST_LAYER_COUNT == 4

--- a/tests/models/test_cohere_compass.py
+++ b/tests/models/test_cohere_compass.py
@@ -1,0 +1,417 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+import os.path
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+from model_test import ModelTest
+from PIL import Image
+from torch import nn
+from transformers import AutoConfig, AutoModelForImageTextToText, AutoProcessor
+
+from gptqmodel.models import auto
+from gptqmodel.models.base import BaseQModel
+from gptqmodel.models.definitions.cohere_compass import CohereCompassQModel
+from gptqmodel.quantization.awq.quantize.scale import apply_scale
+
+
+MODEL_ID = "CohereLabs/North-Micro-Vision-Instruct"
+LOCAL_MODEL_PATH = os.environ.get("GPTQMODEL_COHERE_COMPASS_MODEL")
+
+
+def test_cohere_compass_model_type_selects_definition(monkeypatch):
+    fake_config = SimpleNamespace(model_type="cohere_compass")
+
+    monkeypatch.setattr(auto, "resolve_trust_remote_code", lambda path, trust_remote_code=False: trust_remote_code)
+    monkeypatch.setattr(auto.AutoConfig, "from_pretrained", lambda *args, **kwargs: fake_config)
+
+    assert auto.check_and_get_model_definition("/tmp/north-micro-vision") is CohereCompassQModel
+
+
+def test_cohere_compass_module_tree_matches_parallel_residual_decoder():
+    layer_modules = CohereCompassQModel.simple_layer_modules(
+        model_config=SimpleNamespace(),
+        quantize_config=SimpleNamespace(dynamic=None),
+    )
+
+    assert layer_modules == [
+        ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj"],
+        ["self_attn.o_proj"],
+        ["mlp.gate_proj", "mlp.up_proj"],
+        ["mlp.down_proj"],
+    ]
+    assert CohereCompassQModel.require_load_processor is True
+    assert CohereCompassQModel.require_trust_remote_code is False
+    assert CohereCompassQModel.require_pkgs == ["transformers>=5.16.0.dev0"]
+    assert CohereCompassQModel.pre_lm_head_norm_module == "model.language_model.norm"
+    assert CohereCompassQModel.rotary_embedding == "model.language_model.rotary_emb"
+    assert CohereCompassQModel.extract_layers_node() == ["model.language_model.layers"]
+
+
+def test_cohere_compass_base_modules_include_visual_and_language_roots():
+    class _LanguageModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embed_tokens = nn.Embedding(4, 4)
+            self.layers = nn.ModuleList([nn.Identity()])
+            self.norm = nn.LayerNorm(4)
+            self.rotary_emb = nn.Identity()
+
+    class _CoreModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.visual = nn.Identity()
+            self.language_model = _LanguageModel()
+
+    class _Wrapper(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = _CoreModel()
+
+    base_modules = set(CohereCompassQModel.get_base_modules(_Wrapper()))
+
+    assert base_modules == {
+        "model.visual",
+        "model.language_model.embed_tokens",
+        "model.language_model.norm",
+        "model.language_model.rotary_emb",
+    }
+
+
+def test_cohere_compass_pre_quantize_hook_materializes_multimodal_roots():
+    model = nn.Module()
+    model.model = nn.Module()
+    model.model.language_model = nn.Module()
+    model.model.language_model.embed_tokens = nn.Embedding(4, 4)
+    model.model.language_model.norm = nn.LayerNorm(4)
+    model.model.language_model.rotary_emb = nn.Identity()
+    model.model.visual = nn.Linear(4, 4)
+
+    qmodel = object.__new__(CohereCompassQModel)
+    nn.Module.__init__(qmodel)
+    qmodel.model = model
+    qmodel.quantize_config = SimpleNamespace(device=torch.device("cpu"))
+    materialized = []
+
+    def shell_module_materialize(module, device):
+        materialized.append((module, device))
+        return module
+
+    qmodel.shell_module_materialize = shell_module_materialize
+    qmodel.pre_quantize_generate_hook_start()
+
+    assert materialized == [
+        (model.model.language_model.embed_tokens, torch.device("cpu")),
+        (model.model.language_model.norm, torch.device("cpu")),
+        (model.model.language_model.rotary_emb, torch.device("cpu")),
+        (model.model.visual, torch.device("cpu")),
+    ]
+    qmodel._stop_outer_input_capture()
+
+
+def test_cohere_compass_replay_kwargs_follow_layer_attention_type(monkeypatch):
+    model = nn.Module()
+    model.config = SimpleNamespace(
+        text_config=SimpleNamespace(
+            layer_types=["sliding_attention", "full_attention"],
+            rope_parameters={
+                "sliding_attention": {"rope_type": "default"},
+                "full_attention": None,
+            },
+        )
+    )
+    qmodel = object.__new__(CohereCompassQModel)
+    nn.Module.__init__(qmodel)
+    qmodel.model = model
+
+    sliding_layer = SimpleNamespace(self_attn=SimpleNamespace(layer_idx=0))
+    full_layer = SimpleNamespace(self_attn=SimpleNamespace(layer_idx=1))
+    captured_position_embeddings = (torch.randn(1, 4, 2), torch.randn(1, 4, 2))
+
+    sliding_kwargs = qmodel.prepare_layer_replay_kwargs(
+        layer=sliding_layer,
+        layer_input=[torch.randn(1, 4, 8)],
+        additional_inputs={"position_embeddings": captured_position_embeddings},
+        target_device=torch.device("cpu"),
+    )
+    full_kwargs = qmodel.prepare_layer_replay_kwargs(
+        layer=full_layer,
+        layer_input=[torch.randn(1, 4, 8)],
+        additional_inputs={"position_embeddings": captured_position_embeddings},
+        target_device=torch.device("cpu"),
+    )
+
+    assert sliding_kwargs["position_embeddings"] is captured_position_embeddings
+    assert full_kwargs["position_embeddings"] is None
+
+    monkeypatch.setattr(
+        BaseQModel,
+        "awq_get_modules_for_scaling",
+        lambda self, module, input_feat, module_kwargs: module_kwargs,
+    )
+    awq_kwargs = qmodel.awq_get_modules_for_scaling(
+        full_layer,
+        input_feat={"self_attn.q_proj": torch.randn(1, 4, 8)},
+        module_kwargs={
+            "position_embeddings": captured_position_embeddings,
+            "_awq_feature_kwargs": {
+                "self_attn.q_proj": {"position_embeddings": captured_position_embeddings},
+                "mlp.gate_proj": {},
+            },
+        },
+    )
+
+    assert awq_kwargs["position_embeddings"] is None
+    assert awq_kwargs["_awq_feature_kwargs"]["self_attn.q_proj"]["position_embeddings"] is None
+    assert awq_kwargs["_awq_feature_kwargs"]["mlp.gate_proj"]["position_embeddings"] is None
+
+
+def test_cohere_compass_isolated_replay_matches_outer_text_loop():
+    from transformers.models.cohere_compass.configuration_cohere_compass import CohereCompassTextConfig
+    from transformers.models.cohere_compass.modeling_cohere_compass import CohereCompassTextModel
+
+    config = CohereCompassTextConfig(
+        vocab_size=32,
+        hidden_size=12,
+        intermediate_size=24,
+        num_hidden_layers=4,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        max_position_embeddings=32,
+        sliding_window=2,
+        layer_types=["sliding_attention", "sliding_attention", "sliding_attention", "full_attention"],
+        rope_parameters={
+            "full_attention": None,
+            "sliding_attention": {
+                "rope_type": "default",
+                "rope_theta": 50_000,
+                "mrope_interleaved": True,
+                "mrope_section": [1, 1, 1],
+            },
+        },
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+        tie_word_embeddings=False,
+    )
+    config._attn_implementation = "eager"
+    language_model = CohereCompassTextModel(config).eval()
+
+    wrapper = nn.Module()
+    wrapper.config = SimpleNamespace(text_config=config)
+    wrapper.model = nn.Module()
+    wrapper.model.language_model = language_model
+    qmodel = object.__new__(CohereCompassQModel)
+    nn.Module.__init__(qmodel)
+    qmodel.model = wrapper
+
+    torch.manual_seed(0)
+    inputs_embeds = torch.randn(1, 5, config.hidden_size)
+    attention_mask = torch.ones(1, 5, dtype=torch.long)
+    position_ids = torch.arange(5, dtype=torch.long).view(1, 1, 5).expand(4, 1, -1)
+    visual_pos_masks = torch.tensor([[False, True, False, True, False]])
+    deepstack_visual_embeds = [torch.randn(2, config.hidden_size) for _ in range(3)]
+
+    native_layer_inputs = []
+    native_layer_kwargs = []
+    handles = []
+    for layer in language_model.layers:
+        def capture_layer_inputs(module, args, kwargs, *, _layer=layer):
+            del module, _layer
+            native_layer_inputs.append(args[0].detach().clone())
+            native_layer_kwargs.append(dict(kwargs))
+
+        handles.append(layer.register_forward_pre_hook(capture_layer_inputs, with_kwargs=True))
+
+    qmodel._start_outer_input_capture()
+    try:
+        with torch.no_grad():
+            native_output = language_model(
+                inputs_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                use_cache=False,
+                visual_pos_masks=visual_pos_masks,
+                deepstack_visual_embeds=deepstack_visual_embeds,
+            ).last_hidden_state
+        captured_outer_kwargs = qmodel.capture_first_layer_input_kwargs(
+            args=(),
+            kwargs={},
+            batch_device=torch.device("cpu"),
+            layer_input_kwargs={},
+        )
+    finally:
+        qmodel._stop_outer_input_capture()
+        for handle in handles:
+            handle.remove()
+
+    replay_cache = dict(captured_outer_kwargs)
+    replay_cache["attention_mask"] = native_layer_kwargs[0]["attention_mask"]
+    replay_cache["position_embeddings"] = native_layer_kwargs[0]["position_embeddings"]
+    replay_cache["use_cache"] = False
+
+    hidden_states = native_layer_inputs[0].clone()
+    with torch.no_grad():
+        for layer_index, layer in enumerate(language_model.layers):
+            replay_kwargs = qmodel.prepare_layer_replay_kwargs(
+                layer=layer,
+                layer_input=[hidden_states],
+                additional_inputs=dict(replay_cache),
+                target_device=torch.device("cpu"),
+            )
+
+            native_position_embeddings = native_layer_kwargs[layer_index]["position_embeddings"]
+            if native_position_embeddings is None:
+                assert replay_kwargs["position_embeddings"] is None
+            else:
+                torch.testing.assert_close(
+                    replay_kwargs["position_embeddings"][0],
+                    native_position_embeddings[0],
+                )
+                torch.testing.assert_close(
+                    replay_kwargs["position_embeddings"][1],
+                    native_position_embeddings[1],
+                )
+            torch.testing.assert_close(
+                replay_kwargs["attention_mask"],
+                native_layer_kwargs[layer_index]["attention_mask"],
+            )
+
+            hidden_states = layer(hidden_states, **replay_kwargs)
+            qmodel.update_layer_replay_kwargs_from_output(
+                layer=layer,
+                layer_output=hidden_states,
+                layer_input_kwargs=replay_cache,
+                target_device=torch.device("cpu"),
+            )
+            if layer_index + 1 < len(language_model.layers):
+                torch.testing.assert_close(hidden_states, native_layer_inputs[layer_index + 1])
+
+        torch.testing.assert_close(language_model.norm(hidden_states), native_output)
+
+
+def test_cohere_compass_layer_norm_supports_awq_scale_equivalence():
+    from transformers.models.cohere_compass.modeling_cohere_compass import CohereCompassLayerNorm
+
+    module = nn.Module()
+    module.input_layernorm = CohereCompassLayerNorm(4)
+    module.self_attn = nn.Module()
+    module.self_attn.q_proj = nn.Linear(4, 4, bias=False)
+    hidden_states = torch.randn(2, 3, 4)
+    scales = torch.tensor([0.5, 0.75, 1.25, 2.0])
+
+    reference = module.self_attn.q_proj(module.input_layernorm(hidden_states))
+    apply_scale(
+        module,
+        [("input_layernorm", ["self_attn.q_proj"], scales, 0.0)],
+    )
+    scaled = module.self_attn.q_proj(module.input_layernorm(hidden_states))
+
+    torch.testing.assert_close(scaled, reference, rtol=1e-5, atol=1e-6)
+    assert torch.isfinite(module.input_layernorm.weight).all()
+    assert torch.isfinite(module.self_attn.q_proj.weight).all()
+
+
+@pytest.mark.skipif(LOCAL_MODEL_PATH is None, reason="Set GPTQMODEL_COHERE_COMPASS_MODEL to run this integration test")
+def test_cohere_compass_native_shell_and_processor_match_definition():
+    from accelerate import init_empty_weights
+
+    config = AutoConfig.from_pretrained(LOCAL_MODEL_PATH, trust_remote_code=False)
+    with init_empty_weights(include_buffers=True):
+        shell = AutoModelForImageTextToText.from_config(config, trust_remote_code=False)
+
+    layer = shell.model.language_model.layers[0]
+
+    assert config.model_type == "cohere_compass"
+    assert auto.check_and_get_model_definition(LOCAL_MODEL_PATH) is CohereCompassQModel
+    assert hasattr(shell.model, "visual")
+    assert hasattr(shell.model, "language_model")
+    assert hasattr(layer, "input_layernorm")
+    assert hasattr(layer.self_attn, "q_proj")
+    assert hasattr(layer.self_attn, "k_proj")
+    assert hasattr(layer.self_attn, "v_proj")
+    assert hasattr(layer.self_attn, "o_proj")
+    assert hasattr(layer.mlp, "gate_proj")
+    assert hasattr(layer.mlp, "up_proj")
+    assert hasattr(layer.mlp, "down_proj")
+
+    processor = AutoProcessor.from_pretrained(LOCAL_MODEL_PATH, trust_remote_code=False)
+    image = Image.open(Path(__file__).parent / "ovis" / "10016.jpg").convert("RGB")
+    conversations = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": image},
+                {"type": "text", "text": "What do you see?"},
+            ],
+        }
+    ]
+    inputs = CohereCompassQModel.prepare_inputs_for_conversations(processor, conversations)
+
+    assert set(inputs) == {
+        "input_ids",
+        "attention_mask",
+        "mm_token_type_ids",
+        "pixel_values",
+        "image_grid_thw",
+    }
+    assert inputs.input_ids.shape[0] == 1
+    assert inputs.pixel_values.ndim == 2
+    assert inputs.image_grid_thw.shape == (1, 3)
+
+
+class TestCohereCompass(ModelTest):
+    NATIVE_MODEL_ID = LOCAL_MODEL_PATH or MODEL_ID
+    TRUST_REMOTE_CODE = False
+    USE_FLASH_ATTN = False
+    OFFLOAD_TO_DISK = False
+    EVAL_BATCH_SIZE = 1
+    MODEL_COMPAT_FAST_LAYER_POSITION = "first"
+
+    def test_cohere_compass(self):
+        with self.model_compat_test_context():
+            model, _tokenizer, processor = self.quantModel(
+                self.NATIVE_MODEL_ID,
+                trust_remote_code=self.TRUST_REMOTE_CODE,
+                dtype=self.TORCH_DTYPE,
+                batch_size=1,
+                call_perform_post_quant_validation=False,
+            )
+
+        image_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ovis/10016.jpg")
+        image = Image.open(image_path).convert("RGB")
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": image},
+                    {"type": "text", "text": "What do you see?"},
+                ],
+            }
+        ]
+
+        inputs = processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=True,
+            return_tensors="pt",
+            return_dict=True,
+        ).to(model.device)
+        outputs = model.generate(**inputs, max_new_tokens=64, do_sample=False)
+        generated_ids = [
+            output_ids[len(input_ids) :]
+            for input_ids, output_ids in zip(inputs.input_ids, outputs)
+        ]
+        response = processor.batch_decode(
+            generated_ids,
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        )[0]
+
+        self.assertTrue(response.strip())
+        self.check_kernel(model, self.KERNEL_INFERENCE)

--- a/tests/models/test_cohere_compass.py
+++ b/tests/models/test_cohere_compass.py
@@ -20,7 +20,7 @@ from gptqmodel.models.definitions.cohere_compass import CohereCompassQModel
 from gptqmodel.quantization.awq.quantize.scale import apply_scale
 
 
-MODEL_ID = "CohereLabs/North-Micro-Vision-Instruct"
+MODEL_ID = "/monster/data/model/North-Micro-Vision-Instruct"
 LOCAL_MODEL_PATH = os.environ.get("GPTQMODEL_COHERE_COMPASS_MODEL")
 
 
@@ -377,14 +377,6 @@ class TestCohereCompass(ModelTest):
     EVAL_TASKS_SLOW = {
         "gsm8k_platinum_cot": {
             "chat_template": True,
-        },
-        "arc_challenge": {
-            "chat_template": True,
-        },
-    }
-    EVAL_TASKS_FAST = {
-        "gsm8k_platinum_cot": {
-            "chat_template": True,
             "evalution_use_model_path": True,
             "evalution_batch_size": "auto",
             "evalution_model_args": {
@@ -417,6 +409,7 @@ class TestCohereCompass(ModelTest):
             },
         },
     }
+    EVAL_TASKS_FAST = ModelTest.derive_fast_eval_tasks(EVAL_TASKS_SLOW)
 
     def test_cohere_compass(self):
         with self.model_compat_test_context():
@@ -476,62 +469,3 @@ class TestCohereCompass(ModelTest):
             self.check_results(task_results)
         finally:
             self._cleanup_quantized_model(model, enabled=self.DELETE_QUANTIZED_MODEL)
-
-
-def test_cohere_compass_eval_configuration(monkeypatch):
-    monkeypatch.setenv(ModelTest.MODEL_TEST_MODE_ENV, ModelTest.MODEL_TEST_MODE_FAST)
-    test_case = TestCohereCompass(methodName="test_cohere_compass")
-
-    assert test_case.get_eval_tasks() == {
-        "gsm8k_platinum_cot": {
-            "acc,num": {
-                "value": 0.47229114971050457,
-                "floor_pct": 0.04,
-                "ceil_pct": 1.0,
-                "metric_key": None,
-            },
-        },
-        "arc_challenge": {
-            "acc": {
-                "value": 0.3242320819112628,
-                "floor_pct": 0.04,
-                "ceil_pct": 1.0,
-                "metric_key": None,
-            },
-            "acc_norm": {
-                "value": 0.3515358361774744,
-                "floor_pct": 0.04,
-                "ceil_pct": 1.0,
-                "metric_key": None,
-            },
-        },
-    }
-    assert test_case._task_chat_template == {
-        "gsm8k_platinum_cot": True,
-        "arc_challenge": True,
-    }
-    assert test_case._task_evalution_batch_size == {
-        "gsm8k_platinum_cot": "auto",
-        "arc_challenge": None,
-    }
-    assert test_case._task_evalution_use_model_path == {
-        "gsm8k_platinum_cot": True,
-        "arc_challenge": False,
-    }
-    assert test_case._task_evalution_model_args == {
-        "gsm8k_platinum_cot": {
-            "dtype": "bfloat16",
-            "attn_implementation": "paged|flash_attention_2",
-            "device": "cuda:0",
-        },
-        "arc_challenge": {},
-    }
-    assert test_case._task_evalution_suite_kwargs == {
-        "gsm8k_platinum_cot": {
-            "batch_size": 32,
-            "max_new_tokens": 256,
-            "stream": True,
-        },
-        "arc_challenge": {},
-    }
-    assert TestCohereCompass.MODEL_COMPAT_FAST_LAYER_COUNT == 4

--- a/tests/models/test_cohere_compass.py
+++ b/tests/models/test_cohere_compass.py
@@ -21,7 +21,6 @@ from gptqmodel.quantization.awq.quantize.scale import apply_scale
 
 
 MODEL_ID = "/monster/data/model/North-Micro-Vision-Instruct"
-LOCAL_MODEL_PATH = os.environ.get("GPTQMODEL_COHERE_COMPASS_MODEL")
 
 
 def test_cohere_compass_model_type_selects_definition(monkeypatch):
@@ -318,18 +317,17 @@ def test_cohere_compass_layer_norm_supports_awq_scale_equivalence():
     assert torch.isfinite(module.self_attn.q_proj.weight).all()
 
 
-@pytest.mark.skipif(LOCAL_MODEL_PATH is None, reason="Set GPTQMODEL_COHERE_COMPASS_MODEL to run this integration test")
 def test_cohere_compass_native_shell_and_processor_match_definition():
     from accelerate import init_empty_weights
 
-    config = AutoConfig.from_pretrained(LOCAL_MODEL_PATH, trust_remote_code=False)
+    config = AutoConfig.from_pretrained(MODEL_ID, trust_remote_code=False)
     with init_empty_weights(include_buffers=True):
         shell = AutoModelForImageTextToText.from_config(config, trust_remote_code=False)
 
     layer = shell.model.language_model.layers[0]
 
     assert config.model_type == "cohere_compass"
-    assert auto.check_and_get_model_definition(LOCAL_MODEL_PATH) is CohereCompassQModel
+    assert auto.check_and_get_model_definition(MODEL_ID) is CohereCompassQModel
     assert hasattr(shell.model, "visual")
     assert hasattr(shell.model, "language_model")
     assert hasattr(layer, "input_layernorm")
@@ -341,7 +339,7 @@ def test_cohere_compass_native_shell_and_processor_match_definition():
     assert hasattr(layer.mlp, "up_proj")
     assert hasattr(layer.mlp, "down_proj")
 
-    processor = AutoProcessor.from_pretrained(LOCAL_MODEL_PATH, trust_remote_code=False)
+    processor = AutoProcessor.from_pretrained(MODEL_ID, trust_remote_code=False)
     image = Image.open(Path(__file__).parent / "ovis" / "10016.jpg").convert("RGB")
     conversations = [
         {
@@ -367,7 +365,7 @@ def test_cohere_compass_native_shell_and_processor_match_definition():
 
 
 class TestCohereCompass(ModelTest):
-    NATIVE_MODEL_ID = LOCAL_MODEL_PATH or MODEL_ID
+    NATIVE_MODEL_ID = MODEL_ID
     TRUST_REMOTE_CODE = False
     USE_FLASH_ATTN = False
     OFFLOAD_TO_DISK = False

--- a/tests/models/test_cohere_compass.py
+++ b/tests/models/test_cohere_compass.py
@@ -50,6 +50,7 @@ def test_cohere_compass_module_tree_matches_parallel_residual_decoder():
     assert CohereCompassQModel.require_pkgs == ["transformers>=5.16.0.dev0"]
     assert CohereCompassQModel.pre_lm_head_norm_module == "model.language_model.norm"
     assert CohereCompassQModel.rotary_embedding == "model.language_model.rotary_emb"
+    assert CohereCompassQModel.awq_preserve_explicit_position_embeddings is True
     assert CohereCompassQModel.extract_layers_node() == ["model.language_model.layers"]
 
 
@@ -370,8 +371,34 @@ class TestCohereCompass(ModelTest):
     TRUST_REMOTE_CODE = False
     USE_FLASH_ATTN = False
     OFFLOAD_TO_DISK = False
-    EVAL_BATCH_SIZE = 1
+    EVAL_BATCH_SIZE = 8
+    MODEL_COMPAT_FAST_LAYER_COUNT = 4
     MODEL_COMPAT_FAST_LAYER_POSITION = "first"
+    # Exercise both benchmarks without inventing score thresholds; the test below
+    # still requires each task and its expected metrics to be returned.
+    EVAL_TASKS_SLOW = {
+        "gsm8k_platinum_cot": {
+            "chat_template": True,
+        },
+        "arc_challenge": {
+            "chat_template": True,
+        },
+    }
+    EVAL_TASKS_FAST = {
+        "gsm8k_platinum_cot": {
+            "chat_template": True,
+            "evalution_batch_size": 8,
+            "evalution_suite_kwargs": {
+                "batch_size": 8,
+                "max_new_tokens": 256,
+                "stream": True,
+            },
+        },
+        "arc_challenge": {
+            "chat_template": True,
+            "evalution_batch_size": 8,
+        },
+    }
 
     def test_cohere_compass(self):
         with self.model_compat_test_context():
@@ -380,38 +407,73 @@ class TestCohereCompass(ModelTest):
                 trust_remote_code=self.TRUST_REMOTE_CODE,
                 dtype=self.TORCH_DTYPE,
                 batch_size=1,
-                call_perform_post_quant_validation=False,
             )
 
-        image_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ovis/10016.jpg")
-        image = Image.open(image_path).convert("RGB")
-        messages = [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "image", "image": image},
-                    {"type": "text", "text": "What do you see?"},
-                ],
+        try:
+            image_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ovis/10016.jpg")
+            image = Image.open(image_path).convert("RGB")
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image", "image": image},
+                        {"type": "text", "text": "What do you see?"},
+                    ],
+                }
+            ]
+
+            inputs = processor.apply_chat_template(
+                messages,
+                tokenize=True,
+                add_generation_prompt=True,
+                return_tensors="pt",
+                return_dict=True,
+            ).to(model.device)
+            outputs = model.generate(**inputs, max_new_tokens=64, do_sample=False)
+            generated_ids = [
+                output_ids[len(input_ids) :]
+                for input_ids, output_ids in zip(inputs.input_ids, outputs)
+            ]
+            response = processor.batch_decode(
+                generated_ids,
+                skip_special_tokens=True,
+                clean_up_tokenization_spaces=False,
+            )[0]
+
+            self.assertTrue(response.strip())
+            self.check_kernel(model, self.KERNEL_INFERENCE)
+            task_results = self._post_quant_eval_records.get(self._current_load_backend())
+            self.assertIsNotNone(task_results)
+            expected_metrics = {
+                "gsm8k_platinum_cot": ("acc,num",),
+                "arc_challenge": ("acc", "acc_norm"),
             }
-        ]
+            for task_name, metric_names in expected_metrics.items():
+                self.assertIn(task_name, task_results)
+                for metric_name in metric_names:
+                    self.assertIsNotNone(
+                        self._resolve_metric_key(metric_name, task_results[task_name]),
+                        f"Metric `{metric_name}` missing from task `{task_name}`",
+                    )
+            self.check_results(task_results)
+        finally:
+            self._cleanup_quantized_model(model, enabled=self.DELETE_QUANTIZED_MODEL)
 
-        inputs = processor.apply_chat_template(
-            messages,
-            tokenize=True,
-            add_generation_prompt=True,
-            return_tensors="pt",
-            return_dict=True,
-        ).to(model.device)
-        outputs = model.generate(**inputs, max_new_tokens=64, do_sample=False)
-        generated_ids = [
-            output_ids[len(input_ids) :]
-            for input_ids, output_ids in zip(inputs.input_ids, outputs)
-        ]
-        response = processor.batch_decode(
-            generated_ids,
-            skip_special_tokens=True,
-            clean_up_tokenization_spaces=False,
-        )[0]
 
-        self.assertTrue(response.strip())
-        self.check_kernel(model, self.KERNEL_INFERENCE)
+def test_cohere_compass_eval_configuration(monkeypatch):
+    monkeypatch.setenv(ModelTest.MODEL_TEST_MODE_ENV, ModelTest.MODEL_TEST_MODE_FAST)
+    test_case = TestCohereCompass(methodName="test_cohere_compass")
+
+    assert test_case.get_eval_tasks() == {
+        "gsm8k_platinum_cot": {},
+        "arc_challenge": {},
+    }
+    assert test_case._task_chat_template == {
+        "gsm8k_platinum_cot": True,
+        "arc_challenge": True,
+    }
+    assert test_case._task_evalution_batch_size == {
+        "gsm8k_platinum_cot": 8,
+        "arc_challenge": 8,
+    }
+    assert TestCohereCompass.MODEL_COMPAT_FAST_LAYER_COUNT == 4

--- a/tests/test_awq_rotary_device.py
+++ b/tests/test_awq_rotary_device.py
@@ -37,6 +37,18 @@ class _MetaSelfAttention(nn.Module):
         return x
 
 
+class _RecordingMetaSelfAttention(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.proj = nn.Linear(4, 4, bias=False, device="meta")
+        self.position_embeddings = "unset"
+
+    def forward(self, x, position_embeddings=None, position_ids=None):
+        self.position_embeddings = position_embeddings
+        assert position_ids is not None
+        return x
+
+
 def _make_processor(rotary: nn.Module) -> AWQProcessor:
     qcfg = QuantizeConfig(
         quant_method=METHOD.AWQ,
@@ -80,6 +92,24 @@ def test_module_forward_builds_rotary_embeddings_on_module_device():
     assert cached_rotary.calls == [
         (torch.device("meta"), torch.device("meta"), torch.device("meta"))
     ]
+
+
+def test_module_forward_preserves_explicit_none_position_embeddings():
+    rotary = _TrackingRotary()
+    processor = _make_processor(rotary)
+    attn = _RecordingMetaSelfAttention()
+    hidden_states = torch.empty(2, 3, 4, device="meta")
+
+    output = processor._module_forward(
+        hidden_states,
+        attn,
+        {"position_embeddings": None},
+    )
+
+    assert output.device == torch.device("meta")
+    assert attn.position_embeddings is None
+    assert rotary.calls == []
+    assert processor._rotary_cache == {}
 
 
 def test_refresh_forward_kwargs_uses_device_local_rotary_cache():

--- a/tests/test_awq_rotary_device.py
+++ b/tests/test_awq_rotary_device.py
@@ -49,7 +49,7 @@ class _RecordingMetaSelfAttention(nn.Module):
         return x
 
 
-def _make_processor(rotary: nn.Module) -> AWQProcessor:
+def _make_processor(rotary: nn.Module, *, preserve_explicit_position_embeddings: bool = False) -> AWQProcessor:
     qcfg = QuantizeConfig(
         quant_method=METHOD.AWQ,
         format=FORMAT.GEMM,
@@ -66,6 +66,7 @@ def _make_processor(rotary: nn.Module) -> AWQProcessor:
         batch_size=1,
         gptq_model=types.SimpleNamespace(
             rotary_embedding=None,
+            awq_preserve_explicit_position_embeddings=preserve_explicit_position_embeddings,
         ),
         model=model,
         require_fwd=True,
@@ -94,7 +95,7 @@ def test_module_forward_builds_rotary_embeddings_on_module_device():
     ]
 
 
-def test_module_forward_preserves_explicit_none_position_embeddings():
+def test_module_forward_rebuilds_explicit_position_embeddings_by_default():
     rotary = _TrackingRotary()
     processor = _make_processor(rotary)
     attn = _RecordingMetaSelfAttention()
@@ -107,7 +108,46 @@ def test_module_forward_preserves_explicit_none_position_embeddings():
     )
 
     assert output.device == torch.device("meta")
+    assert isinstance(attn.position_embeddings, tuple)
+    assert processor._rotary_cache["meta"].calls
+
+
+def test_module_forward_preserves_explicit_none_position_embeddings_when_model_opts_in():
+    rotary = _TrackingRotary()
+    processor = _make_processor(rotary, preserve_explicit_position_embeddings=True)
+    attn = _RecordingMetaSelfAttention()
+    hidden_states = torch.empty(2, 3, 4, device="meta")
+
+    output = processor._module_forward(
+        hidden_states,
+        attn,
+        {"position_embeddings": None},
+    )
+
+    assert output.device == torch.device("meta")
     assert attn.position_embeddings is None
+    assert rotary.calls == []
+    assert processor._rotary_cache == {}
+
+
+def test_module_forward_preserves_explicit_rotary_embeddings_when_model_opts_in():
+    rotary = _TrackingRotary()
+    processor = _make_processor(rotary, preserve_explicit_position_embeddings=True)
+    attn = _RecordingMetaSelfAttention()
+    hidden_states = torch.empty(1, 3, 4, device="meta")
+    position_embeddings = (
+        torch.empty(1, 3, 4, device="meta"),
+        torch.empty(1, 3, 4, device="meta"),
+    )
+
+    output = processor._module_forward(
+        hidden_states,
+        attn,
+        {"position_embeddings": position_embeddings},
+    )
+
+    assert output.device == torch.device("meta")
+    assert attn.position_embeddings is position_embeddings
     assert rotary.calls == []
     assert processor._rotary_cache == {}
 


### PR DESCRIPTION
## Summary

- add a `cohere_compass` model definition for CohereLabs/North-Micro-Vision-Instruct image-text calibration and text-decoder quantization
- preserve layer-specific sliding/full attention masks, MRoPE embeddings, and DeepStack visual residuals during isolated GPTQ and AWQ layer replay
- make AWQ preservation of adapter-supplied position embeddings an explicit model opt-in, retaining the existing rebuild behavior for other models
- extend AWQ handling for Cohere Compass layer normalization

## Validation

- `pytest -q tests/models/test_cohere_compass.py tests/test_awq_rotary_device.py -k 'not TestCohereCompass'` (14 passed, 1 deselected with the integration model available)
- `pytest -q tests/test_gemma4_support.py tests/test_gemma4_unified_support.py` (12 passed)
- focused Ruff checks for the changed adapter, AWQ, and test files
- `git diff --check`
- GPTQ and AWQ save/reload and image-generation smoke coverage
- the FAST ARC Challenge/GSM8K baselines use recorded scores
