### PR TITLE
[MODEL] add `Mage-VL`, `Muse Glimmer`, `OLMo 3`, `SmolLM3`, and `DeepSeek V3.2` quantization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 ## Latest News
 
+* 08/19/2026 7.4.0 `main`: ✨ Added `muse_glimmer` / Muse Glimmer multimodal model support.
 * 08/19/2026 7.4.0 `main`: ✨ Added `mage_vl` / Mage-VL model support
 * 08/18/2026 7.4.0 `main`: ✨ Added Cohere `North Micro Vision` (`cohere_compass`) model support
 * 08/04/2026 7.4.0 `main`: ✨ Added `axk2` (A.X-K2) model support
@@ -284,6 +285,7 @@ Selected public references where teams or companies explicitly mention GPT-QMode
 | InternVL Chat                 | ✅ | Laguna                          | ✅ | Mimo / Mimo V2             | ✅ | Zamba / Zamba2                  | ✅ | Intern S1 / S2 Preview             | ✅ |
 | HunYuan V1 Dense / MoE        | ✅ | HY-V3                           | ✅ | Inkling           | ✅ | Solar Open / Open 2                    | ✅ | North Micro Vision | ✅ |
 | Mage-VL                       | ✅ |                                 |    |                            |    |                                 |    |                        |    |
+| Muse Glimmer                  | ✅ |                                 |    |                            |    |                                 |    |                        |    |
 
 
 Prism Bonsai GGUF checkpoints are supported for inference only through GPT-QModel's native GGUF path and internal GGUF runtime. Bonsai checkpoints load through the normal model path or repo argument and do not require the external `gguf` package. Prism model quantization is not included.

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Selected public references where teams or companies explicitly mention GPT-QMode
 | HunYuan V1 Dense / MoE        | ✅ | HY-V3                           | ✅ | Inkling           | ✅ | Solar Open / Open 2                    | ✅ | North Micro Vision | ✅ |
 | Mage-VL                       | ✅ |                                 |    |                            |    |                                 |    |                        |    |
 | Muse Glimmer                  | ✅ |                                 |    |                            |    |                                 |    |                        |    |
+| SmolLM3                       | ✅ |                                 |    |                            |    |                                 |    |                        |    |
 
 
 Prism Bonsai GGUF checkpoints are supported for inference only through GPT-QModel's native GGUF path and internal GGUF runtime. Bonsai checkpoints load through the normal model path or repo argument and do not require the external `gguf` package. Prism model quantization is not included.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 ## Latest News
 
+* 08/19/2026 7.4.0 `main`: ✨ Added `mage_vl` / Mage-VL model support
 * 08/18/2026 7.4.0 `main`: ✨ Added Cohere `North Micro Vision` (`cohere_compass`) model support
 * 08/04/2026 7.4.0 `main`: ✨ Added `axk2` (A.X-K2) model support
 * 08/04/2026 7.4.0 `main`: 🚀🔥⚡ Added `Swordfish` Blackwell (>= sm100) GPTQ/AWQ kernel from [AlpinDale](https://x.com/AlpinDale): [Paper](https://blog.alpindale.net/posts/swordfish/).
@@ -282,6 +283,7 @@ Selected public references where teams or companies explicitly mention GPT-QMode
 | MiniMax M2/M3                 | ✅ | AfMoE                           | ✅ | Bailing-MoE                | ✅ | LFM2 / LFM2-VL / LFM2-MoE       | ✅ | Marin                  | ✅ |
 | InternVL Chat                 | ✅ | Laguna                          | ✅ | Mimo / Mimo V2             | ✅ | Zamba / Zamba2                  | ✅ | Intern S1 / S2 Preview             | ✅ |
 | HunYuan V1 Dense / MoE        | ✅ | HY-V3                           | ✅ | Inkling           | ✅ | Solar Open / Open 2                    | ✅ | North Micro Vision | ✅ |
+| Mage-VL                       | ✅ |                                 |    |                            |    |                                 |    |                        |    |
 
 
 Prism Bonsai GGUF checkpoints are supported for inference only through GPT-QModel's native GGUF path and internal GGUF runtime. Bonsai checkpoints load through the normal model path or repo argument and do not require the external `gguf` package. Prism model quantization is not included.

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Selected public references where teams or companies explicitly mention GPT-QMode
 | Cohere 1-2 / 2 MoE            | ✅ | GPT-Neo / NeoX                  | ✅ | Llama 1-3.3                | ✅ | Nemotron H / H Puzzle / Omni    | ✅ | StarCoder2             | ✅ |
 | DBRX Converted                | ✅ | GPT-2                           | ✅ | Llama 3.2 VL               | ✅ | Nemotron Ultra / Labs-Diffusion | ✅ | TeleChat2              | ✅ |
 | Deci                          | ✅ | GPT-J                           | ✅ | Llama 4                    | ✅ | OPT                             | ✅ | Trinity                | ✅ |
-| DeepSeek-V2/V3/V4/R1          | ✅ | GPT-OSS                         | ✅ | LongCat Flash              | ✅ | OLMo2 / LLaDA2                  | ✅ | Yi                     | ✅ |
+| DeepSeek-V2/V3/V4/R1          | ✅ | GPT-OSS                         | ✅ | LongCat Flash              | ✅ | OLMo2/3 / LLaDA2                | ✅ | Yi                     | ✅ |
 | DeepSeek-V2 Lite / VL / VL2 / OCR2 | ✅ | Granite / Granite MoE           | ✅ | LongLLaMA                  | ✅ | Ovis 1.6/2/2.5/2.6 MoE/2.6 Next | ✅ | Seed-OSS               | ✅ |
 | Dream                         | ✅ | GRIN-MoE                        | ✅ | Instella                   | ✅ | Phi 1-4                         | ✅ | Voxtral                | ✅ |
 | ERNIE 4.5 / MoE / VL MoE      | ✅ | GLM 4/4V/4.5V/4.6V/5/5.1/OCR/ASR | ✅ | GLM4 MoE / Lite / 4.5V MoE | ✅ | MiniCPM 3/O/V/V 4_6             | ✅ | PanGu-α                | ✅ |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 ## Latest News
 
+* 08/20/2026 7.4.0 `main`: ✨ Added `deepseek_v32` / DeepSeek V3.2 model support
 * 08/19/2026 7.4.0 `main`: ✨ Added `muse_glimmer` / Muse Glimmer multimodal model support.
 * 08/19/2026 7.4.0 `main`: ✨ Added `mage_vl` / Mage-VL model support
 * 08/18/2026 7.4.0 `main`: ✨ Added Cohere `North Micro Vision` (`cohere_compass`) model support
@@ -276,7 +277,7 @@ Selected public references where teams or companies explicitly mention GPT-QMode
 | Cohere 1-2 / 2 MoE            | ✅ | GPT-Neo / NeoX                  | ✅ | Llama 1-3.3                | ✅ | Nemotron H / H Puzzle / Omni    | ✅ | StarCoder2             | ✅ |
 | DBRX Converted                | ✅ | GPT-2                           | ✅ | Llama 3.2 VL               | ✅ | Nemotron Ultra / Labs-Diffusion | ✅ | TeleChat2              | ✅ |
 | Deci                          | ✅ | GPT-J                           | ✅ | Llama 4                    | ✅ | OPT                             | ✅ | Trinity                | ✅ |
-| DeepSeek-V2/V3/V4/R1          | ✅ | GPT-OSS                         | ✅ | LongCat Flash              | ✅ | OLMo2/3 / LLaDA2                | ✅ | Yi                     | ✅ |
+| DeepSeek-V2/V3/V3.2/V4/R1     | ✅ | GPT-OSS                         | ✅ | LongCat Flash              | ✅ | OLMo2/3 / LLaDA2                | ✅ | Yi                     | ✅ |
 | DeepSeek-V2 Lite / VL / VL2 / OCR2 | ✅ | Granite / Granite MoE           | ✅ | LongLLaMA                  | ✅ | Ovis 1.6/2/2.5/2.6 MoE/2.6 Next | ✅ | Seed-OSS               | ✅ |
 | Dream                         | ✅ | GRIN-MoE                        | ✅ | Instella                   | ✅ | Phi 1-4                         | ✅ | Voxtral                | ✅ |
 | ERNIE 4.5 / MoE / VL MoE      | ✅ | GLM 4/4V/4.5V/4.6V/5/5.1/OCR/ASR | ✅ | GLM4 MoE / Lite / 4.5V MoE | ✅ | MiniCPM 3/O/V/V 4_6             | ✅ | PanGu-α                | ✅ |

--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -154,6 +154,7 @@ from .definitions.mllama import MLlamaQModel, MLlamaTextQModel  # noqa: E402
 from .definitions.mobilellm import MobileLLMQModel  # noqa: E402
 from .definitions.moss import MossQModel  # noqa: E402
 from .definitions.mpt import MptQModel  # noqa: E402
+from .definitions.muse_glimmer import MuseGlimmerQModel  # noqa: E402
 from .definitions.nemotron_labs_diffusion import NemotronLabsDiffusionQModel  # noqa: E402
 from .definitions.nemotron_h import NemotronHQModel  # noqa: E402
 from .definitions.nemotron_h_puzzle import NemotronHPuzzleQModel  # noqa: E402
@@ -289,6 +290,7 @@ MODEL_MAP = {
     "minimax": MiniMaxM2GPTQ,
     "minimax_m2": MiniMaxM2GPTQ,
     "minimax_m3_vl": MiniMaxM3VLGPTQ,
+    "muse_glimmer": MuseGlimmerQModel,
     "ministral3": Ministral3GPTQ,
     "qwen2_moe": Qwen2MoeQModel,
     "qwen3_moe": Qwen3MoeQModel,

--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -80,6 +80,7 @@ from .definitions.dbrx_converted import DbrxConvertedQModel  # noqa: E402
 from .definitions.decilm import DeciLMQModel  # noqa: E402
 from .definitions.deepseek_v2 import DeepSeekV2QModel  # noqa: E402
 from .definitions.deepseek_v3 import DeepSeekV3QModel  # noqa: E402
+from .definitions.deepseek_v32 import DeepSeekV32QModel  # noqa: E402
 from .definitions.deepseek_v4 import DeepSeekV4QModel  # noqa: E402
 from .definitions.deepseek_ocr2 import DeepSeekOCR2QModel  # noqa: E402
 from .definitions.deepseek_vl import DeepSeekVLQModel  # noqa: E402
@@ -308,6 +309,7 @@ MODEL_MAP = {
     "dbrx_converted": DbrxConvertedQModel,
     "deepseek_v2": DeepSeekV2QModel,
     "deepseek_v3": DeepSeekV3QModel,
+    "deepseek_v32": DeepSeekV32QModel,
     "deepseek_v4": DeepSeekV4QModel,
     "deepseek_ocr2": DeepSeekOCR2QModel,
     "deepseek_vl": DeepSeekVLQModel,

--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -159,6 +159,7 @@ from .definitions.nemotron_labs_diffusion import NemotronLabsDiffusionQModel  # 
 from .definitions.nemotron_h import NemotronHQModel  # noqa: E402
 from .definitions.nemotron_h_puzzle import NemotronHPuzzleQModel  # noqa: E402
 from .definitions.nemotron_omni import NemotronOmniQModel  # noqa: E402
+from .definitions.olmo3 import Olmo3QModel  # noqa: E402
 from .definitions.opt import OptQModel  # noqa: E402
 from .definitions.ovis import OvisQModel  # noqa: E402
 from .definitions.ovis2 import Ovis2QModel  # noqa: E402
@@ -323,6 +324,7 @@ MODEL_MAP = {
     "mobilellm": MobileLLMQModel,
     "hymba": HymbaQModel,
     "olmo2": LlamaQModel, # 100% llama clone
+    "olmo3": Olmo3QModel,
     "ovis": OvisQModel,
     "ovis2": Ovis2QModel,
     "ovis2_5": Ovis2_5QModel,

--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -220,6 +220,7 @@ MODEL_MAP = {
     "gptj": GptJQModel,
     "gpt2": GPT2QModel,
     "llama": LlamaQModel,
+    "smollm3": LlamaQModel,  # llama-compatible quantization module tree
     "llama4": Llama4QModel,
     "llama4_text": Llama4TextQModel,
     "opt": OptQModel,

--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -137,6 +137,7 @@ from .definitions.llama import LlamaQModel  # noqa: E402
 from .definitions.llama4 import Llama4QModel, Llama4TextQModel  # noqa: E402
 from .definitions.llava_qwen2 import LlavaQwen2QModel  # noqa: E402
 from .definitions.longcat_flash import LongCatFlashQModel  # noqa: E402
+from .definitions.mage_vl import MageVLQModel  # noqa: E402
 from .definitions.mimo import MimoQModel  # noqa: E402
 from .definitions.mimo_v2 import MimoV2QModel  # noqa: E402
 from .definitions.minicpm import MiniCPMGPTQ  # noqa: E402
@@ -314,6 +315,7 @@ MODEL_MAP = {
     "mllama": MLlamaQModel,
     "mllama_text_model": MLlamaTextQModel,
     "marin": Qwen3QModel,
+    "mage_vl": MageVLQModel,
     "granite": LlamaQModel, # 100% llama clone
     "granitemoehybrid": GraniteMoeHybridQModel,
     "mobilellm": MobileLLMQModel,

--- a/gptqmodel/models/definitions/__init__.py
+++ b/gptqmodel/models/definitions/__init__.py
@@ -78,6 +78,7 @@ from .mpt import MptQModel
 from .muse_glimmer import MuseGlimmerQModel
 from .nemotron_labs_diffusion import NemotronLabsDiffusionQModel
 from .nemotron_h_puzzle import NemotronHPuzzleQModel
+from .olmo3 import Olmo3QModel
 from .opt import OptQModel
 from .ovis import OvisQModel
 from .ovis2_5 import Ovis2_5QModel

--- a/gptqmodel/models/definitions/__init__.py
+++ b/gptqmodel/models/definitions/__init__.py
@@ -59,6 +59,7 @@ from .intern_s2_preview import InternS2PreviewQModel
 from .interns1 import InternS1QModel
 from .internvl_chat import InternVLChatQModel
 from .lfm2_vl import LFM2VLQModel
+from .mage_vl import MageVLQModel
 from .llama4 import Llama4QModel, Llama4TextQModel
 from .mimo import MimoQModel
 from .minicpm3 import MiniCpm3QModel

--- a/gptqmodel/models/definitions/__init__.py
+++ b/gptqmodel/models/definitions/__init__.py
@@ -75,6 +75,7 @@ from .mllama import MLlamaQModel, MLlamaTextQModel
 from .mobilellm import MobileLLMQModel
 from .moss import MossQModel
 from .mpt import MptQModel
+from .muse_glimmer import MuseGlimmerQModel
 from .nemotron_labs_diffusion import NemotronLabsDiffusionQModel
 from .nemotron_h_puzzle import NemotronHPuzzleQModel
 from .opt import OptQModel

--- a/gptqmodel/models/definitions/__init__.py
+++ b/gptqmodel/models/definitions/__init__.py
@@ -20,6 +20,7 @@ from .dbrx_converted import DbrxConvertedQModel
 from .decilm import DeciLMQModel
 from .deepseek_v2 import DeepSeekV2QModel
 from .deepseek_v3 import DeepSeekV3QModel
+from .deepseek_v32 import DeepSeekV32QModel
 from .deepseek_v4 import DeepSeekV4QModel
 from .deepseek_ocr2 import DeepSeekOCR2QModel
 from .deepseek_vl import DeepSeekVLQModel

--- a/gptqmodel/models/definitions/deepseek_v32.py
+++ b/gptqmodel/models/definitions/deepseek_v32.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from ..base import BaseQModel
+from ..moe_lifecycle import GateUpDownMoELifecycleHooks
+
+
+class DeepSeekV32QModel(BaseQModel):
+    """DeepSeek-V3.2 MLA/DSA model with dense and routed/shared-MoE layers."""
+
+    require_trust_remote_code = False
+
+    dynamic_expert_index = "n_routed_experts"
+
+    pre_lm_head_norm_module = "model.norm"
+    rotary_embedding = "model.rotary_emb"
+
+    # The first three decoder layers are dense and the remaining layers are MoE.
+    layer_modules_strict = False
+
+    # Transformers intentionally ignores the checkpoint's auxiliary MTP layer.
+    # Preserve those tensors when saving a quantized checkpoint.
+    out_of_model_tensors = {"prefixes": ["model.layers.61"]}
+
+    moe_lifecycle_hooks = GateUpDownMoELifecycleHooks()
+
+    module_tree = [
+        "model",
+        "layers",
+        "#",
+        {
+            "input_layernorm": ("input_layernorm:!",),
+            "self_attn": (
+                "q_a_proj:0:q",
+                "kv_a_proj_with_mqa:0:k:v",
+                "indexer.wk:0",
+                # DSA accumulates this projection's scores in float32; leave its weights unquantized.
+                "indexer.weights_proj:0:!",
+                "q_b_proj:1:q",
+                "kv_b_proj:1:k:v",
+                "indexer.wq_b:1",
+                "o_proj:2",
+            ),
+            "post_attention_layernorm": ("post_attention_layernorm:!",),
+            "mlp:moe": {
+                # Dense fallback used by the first three decoder layers.
+                "": ("gate_proj:0:gate", "up_proj:0:up", "down_proj:1:down"),
+                "gate": ("gate:!", "e_score_correction_bias:!"),
+                "experts:routed:expert_activation=experts.act_fn": {
+                    "#": ("gate_proj:0:gate", "up_proj:0:up", "down_proj:1:down"),
+                },
+                "shared_experts:shared": (
+                    "gate_proj:0:gate",
+                    "up_proj:0:up",
+                    "down_proj:1:down",
+                ),
+            },
+        },
+    ]
+
+
+__all__ = ["DeepSeekV32QModel"]

--- a/gptqmodel/models/definitions/mage_vl.py
+++ b/gptqmodel/models/definitions/mage_vl.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from transformers import AutoProcessor
+
+from .base_qwen3_vl import BaseQwen3VLGPTQ
+
+
+class MageVLQModel(BaseQwen3VLGPTQ):
+    """Quantize Mage-VL's Qwen3 decoder while keeping the custom vision tower dense."""
+
+    pre_lm_head_norm_module = "model.language_model.norm"
+    rotary_embedding = "model.language_model.rotary_emb"
+
+    # Mage-VL's proactive gate is stored outside the main checkpoint index, and
+    # its custom processor does not inherit ProcessorMixin/save_pretrained.
+    # Preserve both when writing a quantized checkpoint.
+    out_of_model_tensors = {
+        "files": [
+            "streammind_gate.safetensors",
+            "preprocessor_config.json",
+            "video_preprocessor_config.json",
+            "chat_template.jinja",
+        ],
+    }
+
+    require_trust_remote_code = True
+
+    def load_processor(self):
+        return AutoProcessor.from_pretrained(
+            self.model_local_path,
+            trust_remote_code=self.require_trust_remote_code,
+        )
+
+
+__all__ = ["MageVLQModel"]

--- a/gptqmodel/models/definitions/muse_glimmer.py
+++ b/gptqmodel/models/definitions/muse_glimmer.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from typing import Dict
+
+import torch
+from transformers import AutoModelForImageTextToText, AutoProcessor, ProcessorMixin
+from transformers.masking_utils import create_causal_mask, create_sliding_window_causal_mask
+
+from ...utils.attn_mask import normalize_seq_mask
+from ...utils.calibration import batched
+from ...utils.model import MODALITY
+from ..base import BaseQModel
+
+
+class MuseGlimmerQModel(BaseQModel):
+    loader = AutoModelForImageTextToText
+
+    pre_lm_head_norm_module = "model.language_model.norm"
+    rotary_embedding = "model.language_model.rotary_emb"
+
+    # Muse Glimmer alternates sliding and full-attention layers. Keeping batches
+    # at one avoids padding-dependent mask reuse while decoder layers are replayed.
+    support_batch_quantize = False
+    require_load_processor = True
+    modality = [MODALITY.TEXT, MODALITY.IMAGE_TO_TEXT]
+
+    # The attention gate consumes the same hidden states as Q/K/V, while o_proj
+    # consumes the gated attention result. The vision tower intentionally stays
+    # outside this tree and remains in its original precision.
+    module_tree = [
+        "model",
+        "language_model",
+        "layers",
+        "#",
+        {
+            "input_layernorm": ("input_layernorm:!",),
+            "self_attn": (
+                "q_proj:0:q",
+                "k_proj:0:k",
+                "v_proj:0:v",
+                "gate_proj:0",
+                "o_proj:1",
+            ),
+            "post_attention_layernorm": ("post_attention_layernorm:!",),
+            "pre_feedforward_layernorm": ("pre_feedforward_layernorm:!",),
+            "mlp": ("gate_proj:0:gate", "up_proj:0:up", "down_proj:1:down"),
+            "post_feedforward_layernorm": ("post_feedforward_layernorm:!",),
+        },
+    ]
+
+    # Muse Glimmer uses GQA, so the attention output projection cannot reuse an
+    # AWQ scale unless its predecessor has the exact compatible shape.
+    awq_scale_optimize_shape_dependent_modules = ["self_attn.o_proj"]
+
+    def load_processor(self) -> ProcessorMixin:
+        return AutoProcessor.from_pretrained(self.model_local_path, trust_remote_code=False)
+
+    @classmethod
+    def prepare_inputs_for_conversations(
+        cls,
+        processor: ProcessorMixin,
+        conversations: list[dict] | list[list[dict]],
+    ):
+        return processor.apply_chat_template(
+            conversations,
+            tokenize=True,
+            add_generation_prompt=True,
+            return_dict=True,
+            return_tensors="pt",
+        )
+
+    def preprocess_dataset(self, sample: Dict) -> Dict:
+        return sample
+
+    def prepare_dataset(self, calibration_dataset, batch_size: int = 1, **kwargs):
+        del kwargs
+        processor = self.load_processor()
+        calibration_data = []
+        for batch in batched(calibration_dataset, batch_size, process_func=self.preprocess_dataset):
+            calibration_data.append(self.prepare_inputs_for_conversations(processor, batch))
+        del processor
+        return calibration_data
+
+    def prepare_layer_replay_kwargs(self, layer, layer_input, additional_inputs, target_device):
+        additional_inputs = super().prepare_layer_replay_kwargs(
+            layer,
+            layer_input,
+            additional_inputs,
+            target_device,
+        )
+        if not layer_input or not torch.is_tensor(layer_input[0]):
+            return additional_inputs
+
+        hidden_states = layer_input[0]
+        sequence_length = hidden_states.shape[1] if hidden_states.ndim >= 2 else hidden_states.shape[0]
+        batch_size = hidden_states.shape[0] if hidden_states.ndim >= 2 else 1
+
+        position_ids = additional_inputs.get("position_ids")
+        if position_ids is None or position_ids.shape[-1] != sequence_length:
+            position_ids = torch.arange(sequence_length, device=target_device, dtype=torch.long)
+            position_ids = position_ids.unsqueeze(0).expand(batch_size, -1)
+            additional_inputs["position_ids"] = position_ids
+
+        attention_mask = additional_inputs.get("attention_mask")
+        if torch.is_tensor(attention_mask):
+            attention_mask = normalize_seq_mask(attention_mask, seq_len=sequence_length)
+
+        self_attention = getattr(layer, "self_attn", None)
+        layer_config = getattr(layer, "config", None) or getattr(self_attention, "config", None)
+        if layer_config is None:
+            return additional_inputs
+
+        layer_index = getattr(self_attention, "layer_idx", None)
+        mask_factory = (
+            create_sliding_window_causal_mask
+            if getattr(self_attention, "is_local_attention", False)
+            else create_causal_mask
+        )
+        additional_inputs["attention_mask"] = mask_factory(
+            config=layer_config,
+            inputs_embeds=hidden_states,
+            attention_mask=attention_mask,
+            past_key_values=None,
+            position_ids=position_ids,
+            layer_idx=layer_index,
+        )
+
+        layer_rope_theta = getattr(layer_config, "layer_rope_theta", None)
+        if layer_rope_theta is not None and layer_index is not None and not layer_rope_theta[layer_index]:
+            additional_inputs["position_embeddings"] = None
+
+        return additional_inputs
+
+
+__all__ = ["MuseGlimmerQModel"]

--- a/gptqmodel/models/definitions/olmo3.py
+++ b/gptqmodel/models/definitions/olmo3.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+import torch
+
+from ...utils.device import get_device
+from ...utils.model import get_module_by_name_prefix, move_to, nested_move_to
+from ..base import BaseQModel
+
+
+def _prepare_olmo3_replay_kwargs(model_def, layer, layer_input, additional_inputs, target_device):
+    """Refresh the RoPE tuple for each OLMo 3 attention type during layer replay."""
+
+    rotary_path = getattr(model_def, "rotary_embedding", None)
+    if not rotary_path or not layer_input:
+        return additional_inputs
+
+    rotary, _ = get_module_by_name_prefix(model_def.model, [rotary_path])
+    if rotary is None:
+        return additional_inputs
+
+    attention_type = getattr(getattr(layer, "self_attn", None), "attention_type", None)
+    if attention_type is None:
+        return additional_inputs
+
+    hidden_states = layer_input[0]
+    seq_len = hidden_states.shape[1] if hidden_states.dim() >= 2 else hidden_states.shape[0]
+    batch_dim = hidden_states.shape[0] if hidden_states.dim() >= 2 else 1
+
+    position_ids = additional_inputs.get("position_ids")
+    if position_ids is None or position_ids.shape[-1] != seq_len:
+        position_ids = torch.arange(seq_len, device=target_device, dtype=torch.long).unsqueeze(0).expand(batch_dim, -1)
+        additional_inputs["position_ids"] = position_ids
+
+    try:
+        rotary_device = get_device(rotary)
+    except Exception:
+        rotary_device = position_ids.device
+
+    rotary_position_ids = move_to(position_ids, device=rotary_device)
+    rotary_input = torch.empty(1, device=rotary_device, dtype=hidden_states.dtype)
+    additional_inputs["position_embeddings"] = nested_move_to(
+        rotary(rotary_input, rotary_position_ids, attention_type),
+        device=target_device,
+    )
+
+    return additional_inputs
+
+
+class Olmo3QModel(BaseQModel):
+    pre_lm_head_norm_module = "model.norm"
+    rotary_embedding = "model.rotary_emb"
+
+    # The output projection only shares an AWQ scale when its input shape matches V.
+    awq_scale_optimize_shape_dependent_modules = ["self_attn.o_proj"]
+
+    module_tree = [
+        "model",
+        "layers",
+        "#",
+        {
+            "self_attn": (
+                "q_proj:0:q",
+                "q_norm:0:!",
+                "k_proj:0:k",
+                "k_norm:0:!",
+                "v_proj:0:v",
+                "o_proj:1",
+            ),
+            "post_attention_layernorm": ("post_attention_layernorm:!",),
+            "mlp": ("gate_proj:0:gate", "up_proj:0:up", "down_proj:1:down"),
+            "post_feedforward_layernorm": ("post_feedforward_layernorm:!",),
+        },
+    ]
+
+    def prepare_layer_replay_kwargs(self, layer, layer_input, additional_inputs, target_device):
+        return _prepare_olmo3_replay_kwargs(self, layer, layer_input, additional_inputs, target_device)
+
+
+__all__ = ["Olmo3QModel"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy==2.2.6; python_version < "3.14"
 numpy>=2.3.0; python_version >= "3.14"
 torch>=2.8.0
 safetensors>=0.7.0
-transformers>=5.4.0
+transformers>=5.14.0
 threadpoolctl>=3.6.0
 packaging>=24.2
 device-smi>=0.5.5
@@ -19,4 +19,4 @@ datasets>=3.6.0
 pyarrow>=21.0
 dill>=0.3.8
 torchao>=0.16.0
-defuser>=0.0.25
+defuser>=0.0.26

--- a/tests/models/model_test.py
+++ b/tests/models/model_test.py
@@ -1707,7 +1707,10 @@ class ModelTest(unittest.TestCase):
 
         else:
             if need_create_processor:
-                processor = AutoProcessor.from_pretrained(model_id_or_path)
+                processor = AutoProcessor.from_pretrained(
+                    model_id_or_path,
+                    trust_remote_code=trust_remote_code,
+                )
         if not is_quantized:
             del model
             torch_empty_cache()

--- a/tests/models/ovis/image_to_test_dataset.py
+++ b/tests/models/ovis/image_to_test_dataset.py
@@ -17,6 +17,7 @@ from gptqmodel.models.definitions.lfm2_vl import LFM2VLQModel
 from gptqmodel.models.definitions.minicpm_o import MiniCPMOQModel
 from gptqmodel.models.definitions.minicpmv import MiniCPMVQModel
 from gptqmodel.models.definitions.minicpmv_4_6 import MiniCPMV4_6QModel
+from gptqmodel.models.definitions.muse_glimmer import MuseGlimmerQModel
 from gptqmodel.models.definitions.ovis import OvisQModel
 from gptqmodel.models.definitions.ovis2 import Ovis2QModel
 from gptqmodel.models.definitions.ovis2_5 import Ovis2_5QModel
@@ -171,6 +172,7 @@ def get_calib_dataset(model):
         or isinstance(model, InklingMMQModel)
         or isinstance(model, Ernie4_5_VLMoeQModel)
         or isinstance(model, LFM2VLQModel)
+        or isinstance(model, MuseGlimmerQModel)
     ):
         return prepare_dataset(format_qwen2_vl_dataset, n_sample=20)
 

--- a/tests/models/ovis/image_to_test_dataset.py
+++ b/tests/models/ovis/image_to_test_dataset.py
@@ -21,7 +21,7 @@ from gptqmodel.models.definitions.ovis import OvisQModel
 from gptqmodel.models.definitions.ovis2 import Ovis2QModel
 from gptqmodel.models.definitions.ovis2_5 import Ovis2_5QModel
 from gptqmodel.models.definitions.ovis2_6_moe import Ovis2_6_MoeQModel
-from gptqmodel.models.definitions.qwen3_vl import Qwen3_VLQModel
+from gptqmodel.models.definitions.base_qwen3_vl import BaseQwen3VLGPTQ
 
 
 def format_ovis_dataset(image, assistant):
@@ -161,7 +161,7 @@ def get_calib_dataset(model):
 
     if (
         isinstance(model, BaseQwen2VLGPTQ)
-        or isinstance(model, Qwen3_VLQModel)
+        or isinstance(model, BaseQwen3VLGPTQ)
         or isinstance(model, MiniCPMOQModel)
         or isinstance(model, MiniCPMVQModel)
         or isinstance(model, MiniCPMV4_6QModel)

--- a/tests/models/test_deepseek_v32.py
+++ b/tests/models/test_deepseek_v32.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from model_test import ModelTest
+
+class TestDeepSeekV32(ModelTest):
+    NATIVE_MODEL_ID = "/monster/data/model/DeepSeek-V3.2-BF16"
+    TRUST_REMOTE_CODE = False
+    USE_FLASH_ATTN = False
+    EVAL_TASKS_SLOW = {
+        "arc_challenge": {
+            "acc": {"value": 0.6467576791808873, "floor_pct": 0.04},
+            "acc_norm": {"value": 0.6663822525597269, "floor_pct": 0.04},
+        },
+    }
+    EVAL_TASKS_FAST = ModelTest.derive_fast_eval_tasks(EVAL_TASKS_SLOW)
+    MODEL_COMPAT_FAST_LAYER_POSITION = "first"
+    EVAL_BATCH_SIZE = 32
+
+    def test_deepseek_v32(self):
+        self.quantize_and_evaluate()

--- a/tests/models/test_mage_vl.py
+++ b/tests/models/test_mage_vl.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from model_test import ModelTest
+from ovis import image_to_test_dataset
+from PIL import Image
+from transformers import AutoConfig, AutoModelForImageTextToText
+
+from gptqmodel.models import auto
+from gptqmodel.models.definitions import mage_vl
+from gptqmodel.models.definitions.mage_vl import MageVLQModel
+
+
+MODEL_PATH = Path("/monster/data/model/Mage-VL")
+
+
+def test_mage_vl_model_type_selects_definition(monkeypatch):
+    fake_config = SimpleNamespace(model_type="mage_vl")
+
+    monkeypatch.setattr(
+        auto,
+        "resolve_trust_remote_code",
+        lambda path, trust_remote_code=False: trust_remote_code,
+    )
+    monkeypatch.setattr(
+        auto.AutoConfig, "from_pretrained", lambda *args, **kwargs: fake_config
+    )
+
+    assert (
+        auto.check_and_get_model_definition("/tmp/mage-vl", trust_remote_code=True)
+        is MageVLQModel
+    )
+
+
+def test_mage_vl_definition_matches_qwen3_decoder_contract():
+    layer_modules = MageVLQModel.simple_layer_modules(
+        model_config=SimpleNamespace(),
+        quantize_config=SimpleNamespace(dynamic=None),
+    )
+
+    assert layer_modules == [
+        ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj"],
+        ["self_attn.o_proj"],
+        ["mlp.gate_proj", "mlp.up_proj"],
+        ["mlp.down_proj"],
+    ]
+    assert MageVLQModel.extract_layers_node() == [
+        "model.language_model.layers",
+        "language_model.layers",
+    ]
+    assert MageVLQModel.loader is AutoModelForImageTextToText
+    assert MageVLQModel.pre_lm_head_norm_module == "model.language_model.norm"
+    assert MageVLQModel.rotary_embedding == "model.language_model.rotary_emb"
+    assert MageVLQModel.out_of_model_tensors == {
+        "files": [
+            "streammind_gate.safetensors",
+            "preprocessor_config.json",
+            "video_preprocessor_config.json",
+            "chat_template.jinja",
+        ],
+    }
+    assert MageVLQModel.require_load_processor is True
+    assert MageVLQModel.require_trust_remote_code is True
+
+
+def test_mage_vl_processor_load_enables_remote_code(monkeypatch):
+    calls = {}
+    expected_processor = object()
+
+    def fake_from_pretrained(model_path, **kwargs):
+        calls["model_path"] = model_path
+        calls.update(kwargs)
+        return expected_processor
+
+    monkeypatch.setattr(mage_vl.AutoProcessor, "from_pretrained", fake_from_pretrained)
+
+    qmodel = object.__new__(MageVLQModel)
+    qmodel.model_local_path = "/tmp/mage-vl"
+
+    assert qmodel.load_processor() is expected_processor
+    assert calls == {
+        "model_path": "/tmp/mage-vl",
+        "trust_remote_code": True,
+    }
+
+
+def test_mage_vl_uses_qwen_style_image_calibration_dataset(monkeypatch):
+    calls = {}
+    expected_dataset = object()
+
+    def fake_prepare_dataset(format_func, n_sample):
+        calls["format_func"] = format_func
+        calls["n_sample"] = n_sample
+        return expected_dataset
+
+    monkeypatch.setattr(image_to_test_dataset, "prepare_dataset", fake_prepare_dataset)
+
+    qmodel = object.__new__(MageVLQModel)
+
+    assert image_to_test_dataset.get_calib_dataset(qmodel) is expected_dataset
+    assert calls == {
+        "format_func": image_to_test_dataset.format_qwen2_vl_dataset,
+        "n_sample": 20,
+    }
+
+
+@pytest.mark.skipif(not MODEL_PATH.exists(), reason="Mage-VL model not found")
+def test_mage_vl_processor_prepares_image_calibration_sample():
+    qmodel = object.__new__(MageVLQModel)
+    qmodel.model_local_path = str(MODEL_PATH)
+    image = Image.open(MODEL_PATH / "examples/dog.jpg").convert("RGB")
+    calibration_dataset = [
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": image},
+                    {"type": "text", "text": "Describe this image."},
+                ],
+            },
+            {"role": "assistant", "content": "A dog is running on grass."},
+        ],
+    ]
+
+    [inputs] = qmodel.prepare_dataset(calibration_dataset, batch_size=1)
+
+    image_token_count = int((inputs["input_ids"] == 151655).sum().item())
+    merged_patch_count = int((inputs["image_grid_thw"].prod(dim=-1) // 4).sum().item())
+    assert image_token_count == merged_patch_count
+    assert inputs["pixel_values"].shape[0] == int(
+        inputs["image_grid_thw"].prod(dim=-1).sum().item()
+    )
+    assert inputs["patch_positions"].shape == (inputs["pixel_values"].shape[0], 3)
+
+
+@pytest.mark.skipif(not MODEL_PATH.exists(), reason="Mage-VL model not found")
+def test_mage_vl_native_shell_matches_definition_tree():
+    from accelerate import init_empty_weights
+
+    config = AutoConfig.from_pretrained(MODEL_PATH, trust_remote_code=True)
+    with init_empty_weights(include_buffers=True):
+        shell = AutoModelForImageTextToText.from_config(config, trust_remote_code=True)
+
+    layer = shell.model.language_model.layers[0]
+
+    assert config.model_type == "mage_vl"
+    assert config.text_config.model_type == "qwen3"
+    assert (
+        auto.check_and_get_model_definition(MODEL_PATH, trust_remote_code=True)
+        is MageVLQModel
+    )
+    assert MageVLQModel.get_base_modules(shell) == ["model.visual"]
+    assert hasattr(shell.model, "visual")
+    assert hasattr(shell.model, "language_model")
+    assert hasattr(layer.self_attn, "q_proj")
+    assert hasattr(layer.self_attn, "k_proj")
+    assert hasattr(layer.self_attn, "v_proj")
+    assert hasattr(layer.self_attn, "o_proj")
+    assert hasattr(layer.self_attn, "q_norm")
+    assert hasattr(layer.self_attn, "k_norm")
+    assert hasattr(layer.mlp, "gate_proj")
+    assert hasattr(layer.mlp, "up_proj")
+    assert hasattr(layer.mlp, "down_proj")
+
+
+class TestMageVL(ModelTest):
+    NATIVE_MODEL_ID = "/monster/data/model/Mage-VL"
+    TRUST_REMOTE_CODE = True
+    USE_FLASH_ATTN = False
+    OFFLOAD_TO_DISK = False
+    EVAL_BATCH_SIZE = 1
+
+    def test_mage_vl(self):
+        with self.model_compat_test_context():
+            model, _tokenizer, processor = self.quantModel(
+                self.NATIVE_MODEL_ID,
+                trust_remote_code=self.TRUST_REMOTE_CODE,
+                dtype=self.TORCH_DTYPE,
+                batch_size=1,
+                call_perform_post_quant_validation=False,
+            )
+
+        image = Image.open(MODEL_PATH / "examples/dog.jpg").convert("RGB")
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "What animal is shown in this image?"},
+                ],
+            },
+        ]
+        text = processor.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        inputs = processor(
+            text=[text],
+            images=[image],
+            return_tensors="pt",
+        ).to(model.device)
+        inputs["pixel_values"] = inputs["pixel_values"].to(model.dtype)
+
+        output_ids = model.generate(**inputs, max_new_tokens=64, do_sample=False)
+        output = processor.decode(
+            output_ids[0, inputs["input_ids"].shape[1] :],
+            skip_special_tokens=True,
+        )
+        print("output:", output)
+
+        self.assertIn("dog", output.lower())
+        self.check_kernel(model, self.KERNEL_INFERENCE)

--- a/tests/models/test_muse_glimmer.py
+++ b/tests/models/test_muse_glimmer.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+import os.path
+from types import SimpleNamespace
+
+import pytest
+import torch
+from model_test import ModelTest
+from PIL import Image
+from torch import nn
+
+from gptqmodel import BACKEND
+from gptqmodel.models import auto
+from gptqmodel.models.definitions import muse_glimmer
+from gptqmodel.models.definitions.muse_glimmer import MuseGlimmerQModel
+from gptqmodel.utils.model import MODALITY
+
+
+def test_muse_glimmer_model_type_selects_definition(monkeypatch):
+    fake_config = SimpleNamespace(model_type="muse_glimmer")
+
+    monkeypatch.setattr(auto, "resolve_trust_remote_code", lambda path, trust_remote_code=False: trust_remote_code)
+    monkeypatch.setattr(auto, "patch_remote_code_before_config_load", lambda path: None)
+    monkeypatch.setattr(auto.AutoConfig, "from_pretrained", lambda *args, **kwargs: fake_config)
+
+    assert auto.check_and_get_model_definition("/tmp/muse-glimmer") is MuseGlimmerQModel
+
+
+def test_muse_glimmer_module_tree_matches_text_decoder_order():
+    layer_modules = MuseGlimmerQModel.simple_layer_modules(
+        model_config=SimpleNamespace(),
+        quantize_config=SimpleNamespace(dynamic=None),
+    )
+
+    assert layer_modules == [
+        ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj", "self_attn.gate_proj"],
+        ["self_attn.o_proj"],
+        ["mlp.gate_proj", "mlp.up_proj"],
+        ["mlp.down_proj"],
+    ]
+    assert MuseGlimmerQModel.extract_layers_node() == ["model.language_model.layers"]
+    assert MuseGlimmerQModel.pre_lm_head_norm_module == "model.language_model.norm"
+    assert MuseGlimmerQModel.rotary_embedding == "model.language_model.rotary_emb"
+    assert MuseGlimmerQModel.require_load_processor is True
+    assert MuseGlimmerQModel.support_batch_quantize is False
+    assert MuseGlimmerQModel.modality == [MODALITY.TEXT, MODALITY.IMAGE_TO_TEXT]
+
+
+@pytest.mark.parametrize(
+    ("layer_index", "is_local_attention", "expected_mask_factory", "expect_position_embeddings"),
+    [
+        (0, True, "sliding", True),
+        (3, False, "causal", False),
+    ],
+)
+def test_muse_glimmer_replay_rebuilds_layer_specific_mask_and_rope(
+    monkeypatch,
+    layer_index,
+    is_local_attention,
+    expected_mask_factory,
+    expect_position_embeddings,
+):
+    calls = []
+
+    def fake_mask_factory(name):
+        def create_mask(**kwargs):
+            calls.append((name, kwargs))
+            return f"{name}-mask"
+
+        return create_mask
+
+    monkeypatch.setattr(muse_glimmer, "create_causal_mask", fake_mask_factory("causal"))
+    monkeypatch.setattr(muse_glimmer, "create_sliding_window_causal_mask", fake_mask_factory("sliding"))
+
+    config = SimpleNamespace(layer_rope_theta=[500000.0, 500000.0, 500000.0, 0])
+    self_attention = SimpleNamespace(
+        config=config,
+        is_local_attention=is_local_attention,
+        layer_idx=layer_index,
+    )
+    layer = SimpleNamespace(config=config, self_attn=self_attention)
+    hidden_states = torch.zeros(1, 4, 8)
+    position_embeddings = (torch.ones(1, 4, 8), torch.zeros(1, 4, 8))
+    additional_inputs = {
+        "attention_mask": torch.ones(1, 4, dtype=torch.long),
+        "position_embeddings": position_embeddings,
+    }
+
+    qmodel = object.__new__(MuseGlimmerQModel)
+    nn.Module.__init__(qmodel)
+    result = qmodel.prepare_layer_replay_kwargs(
+        layer=layer,
+        layer_input=[hidden_states],
+        additional_inputs=additional_inputs,
+        target_device=torch.device("cpu"),
+    )
+
+    assert result["attention_mask"] == f"{expected_mask_factory}-mask"
+    assert result["position_ids"].tolist() == [[0, 1, 2, 3]]
+    if expect_position_embeddings:
+        assert result["position_embeddings"] is position_embeddings
+    else:
+        assert result["position_embeddings"] is None
+
+    assert len(calls) == 1
+    mask_name, mask_kwargs = calls[0]
+    assert mask_name == expected_mask_factory
+    assert mask_kwargs["attention_mask"].dtype == torch.bool
+    assert mask_kwargs["layer_idx"] == layer_index
+
+
+def test_muse_glimmer_replay_matches_dense_text_forward():
+    configuration = pytest.importorskip("transformers.models.muse_glimmer.configuration_muse_glimmer")
+    modeling = pytest.importorskip("transformers.models.muse_glimmer.modeling_muse_glimmer")
+
+    torch.manual_seed(0)
+    config = configuration.MuseGlimmerTextConfig(
+        vocab_size=64,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=4,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        layer_types=["sliding_attention", "sliding_attention", "sliding_attention", "full_attention"],
+        layer_rope_theta=[500000.0, 500000.0, 500000.0, 0],
+        sliding_window=2,
+        bos_token_id=1,
+        eos_token_id=2,
+    )
+    config._attn_implementation = "eager"
+    model = modeling.MuseGlimmerTextModel(config).eval()
+
+    input_ids = torch.tensor([[1, 3, 4, 5, 6]])
+    position_ids = torch.arange(input_ids.shape[1]).unsqueeze(0)
+    dense_output = model(input_ids=input_ids, use_cache=False).last_hidden_state
+
+    hidden_states = model.embed_tokens(input_ids)
+    position_embeddings = model.rotary_emb(hidden_states, position_ids)
+    qmodel = object.__new__(MuseGlimmerQModel)
+    nn.Module.__init__(qmodel)
+
+    for layer in model.layers:
+        replay_kwargs = qmodel.prepare_layer_replay_kwargs(
+            layer=layer,
+            layer_input=[hidden_states],
+            additional_inputs={
+                "attention_mask": None,
+                "position_ids": position_ids,
+                "position_embeddings": position_embeddings,
+            },
+            target_device=torch.device("cpu"),
+        )
+        hidden_states = layer(hidden_states, **replay_kwargs)
+
+    replay_output = model.norm(hidden_states)
+    torch.testing.assert_close(replay_output, dense_output, rtol=0, atol=0)
+
+
+class TestMuseGlimmer(ModelTest):
+    NATIVE_MODEL_ID = "/monster/data/model/Muse-Glimmer-30B"  # meta-models/Muse-Glimmer-30B
+    USE_FLASH_ATTN = False
+    TRUST_REMOTE_CODE = False
+    DELETE_QUANTIZED_MODEL = False
+    EVAL_BATCH_SIZE = 1
+    LOAD_BACKEND = BACKEND.AUTO
+    MODEL_COMPAT_FAST_LAYER_POSITION = "first"
+
+    def test_muse_glimmer(self):
+        with self.model_compat_test_context():
+            model, _tokenizer, processor = self.quantModel(
+                self.NATIVE_MODEL_ID,
+                trust_remote_code=self.TRUST_REMOTE_CODE,
+                dtype=self.TORCH_DTYPE,
+                batch_size=1,
+                need_eval=False,
+                call_perform_post_quant_validation=False,
+            )
+
+        image_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ovis/10016.jpg")
+        conversation = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": Image.open(image_path)},
+                    {"type": "text", "text": "What is in this image?"},
+                ],
+            },
+        ]
+        inputs = processor.apply_chat_template(
+            conversation,
+            add_generation_prompt=True,
+            return_tensors="pt",
+            return_dict=True,
+            tokenize=True,
+        ).to(model.device)
+
+        output_ids = model.generate(**inputs, max_new_tokens=128, do_sample=False)
+        generated_ids = output_ids[:, inputs["input_ids"].shape[1] :]
+        output = processor.batch_decode(
+            generated_ids,
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        )[0]
+        print(f"Output:\n{output}")
+
+        self.assertIn("snow", output.lower())

--- a/tests/models/test_olmo3.py
+++ b/tests/models/test_olmo3.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from gptqmodel import BACKEND
+from model_test import ModelTest
+
+
+class TestOlmo3(ModelTest):
+    NATIVE_MODEL_ID = "allenai/Olmo-3-1025-7B"
+    TRUST_REMOTE_CODE = False
+    DATASET_SIZE_FAST = 128
+    EVAL_BATCH_SIZE = 32
+    EVAL_TASKS_SLOW = {
+        "arc_challenge": {
+            "chat_template": False,
+            "acc": {
+                "value": 0.48293515358361777,
+                "floor_pct": 0.10,
+            },
+            "acc_norm": {
+                "value": 0.5196245733788396,
+                "floor_pct": 0.10,
+            },
+        },
+    }
+    EVAL_TASKS_FAST = {
+        "arc_challenge": {
+            "chat_template": False,
+            "acc": {
+                "value": 0.46875,
+                "floor_pct": 0.25,
+            },
+            "acc_norm": {
+                "value": 0.59375,
+                "floor_pct": 0.25,
+            },
+        },
+    }
+    LOAD_BACKEND = BACKEND.AUTO
+    USE_FLASH_ATTN = False
+    MODEL_COMPAT_FAST_LAYER_POSITION = "first"
+
+    def test_olmo3(self):
+        self.quantize_and_evaluate()

--- a/tests/models/test_smollm3.py
+++ b/tests/models/test_smollm3.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from gptqmodel import BACKEND
+from model_test import ModelTest
+
+
+class TestSmolLM3(ModelTest):
+    NATIVE_MODEL_ID = "HuggingFaceTB/SmolLM3-3B"
+    TRUST_REMOTE_CODE = False
+    DATASET_SIZE_FAST = 128
+    EVAL_BATCH_SIZE = 32
+    EVAL_TASKS_SLOW = {
+        "arc_challenge": {
+            "chat_template": False,
+            "acc_norm": {
+                "value": 0.538,
+                "floor_pct": 0.10,
+                "ceil_pct": 0.10,
+            },
+        },
+    }
+    EVAL_TASKS_FAST = {
+        "arc_challenge": {
+            "chat_template": False,
+            "acc": {
+                "value": 0.40625,
+                "floor_pct": 0.25,
+                "ceil_pct": 1.0,
+            },
+            "acc_norm": {
+                "value": 0.5,
+                "floor_pct": 0.25,
+                "ceil_pct": 1.0,
+            },
+        },
+    }
+    LOAD_BACKEND = BACKEND.AUTO
+    USE_FLASH_ATTN = False
+    MODEL_COMPAT_FAST_LAYER_POSITION = "first"
+
+    def test_smollm3(self):
+        self.quantize_and_evaluate()

--- a/tests/test_deepseek_v32_support.py
+++ b/tests/test_deepseek_v32_support.py
@@ -1,0 +1,129 @@
+from types import SimpleNamespace
+
+import defuser
+import torch
+from transformers import AutoModelForCausalLM
+from transformers.models.deepseek_v32.configuration_deepseek_v32 import (
+    DeepseekV32Config,
+)
+
+from gptqmodel.models import auto
+from gptqmodel.models.definitions.deepseek_v32 import DeepSeekV32QModel
+from gptqmodel.utils.model import find_modules
+
+
+def _tiny_config() -> DeepseekV32Config:
+    config = DeepseekV32Config(
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=64,
+        moe_intermediate_size=16,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        n_routed_experts=2,
+        n_shared_experts=1,
+        num_experts_per_tok=1,
+        q_lora_rank=16,
+        kv_lora_rank=8,
+        qk_nope_head_dim=8,
+        qk_rope_head_dim=4,
+        v_head_dim=8,
+        index_head_dim=8,
+        index_n_heads=2,
+        index_topk=4,
+        n_group=1,
+        topk_group=1,
+        max_position_embeddings=32,
+        mlp_layer_types=["dense", "dense", "dense", "sparse"],
+        bos_token_id=1,
+        eos_token_id=2,
+    )
+    config._attn_implementation = "eager"
+    return config
+
+
+def test_deepseek_v32_model_type_selects_definition(monkeypatch):
+    fake_config = SimpleNamespace(model_type="deepseek_v32")
+
+    monkeypatch.setattr(
+        auto,
+        "resolve_trust_remote_code",
+        lambda path, trust_remote_code=False: trust_remote_code,
+    )
+    monkeypatch.setattr(
+        auto.AutoConfig, "from_pretrained", lambda *args, **kwargs: fake_config
+    )
+
+    assert auto.check_and_get_model_definition("deepseek-v32-fixture") is DeepSeekV32QModel
+
+
+def test_deepseek_v32_module_tree_covers_dsa_dense_and_moe_paths():
+    config = _tiny_config()
+    layer_modules = DeepSeekV32QModel.simple_layer_modules(
+        model_config=config,
+        quantize_config=SimpleNamespace(dynamic=None),
+    )
+    flat_modules = {name for block in layer_modules for name in block}
+
+    assert {
+        "self_attn.q_a_proj",
+        "self_attn.q_b_proj",
+        "self_attn.kv_a_proj_with_mqa",
+        "self_attn.kv_b_proj",
+        "self_attn.indexer.wk",
+        "self_attn.indexer.wq_b",
+        "self_attn.o_proj",
+        "mlp.gate_proj",
+        "mlp.up_proj",
+        "mlp.down_proj",
+        "mlp.experts.0.gate_proj",
+        "mlp.experts.1.up_proj",
+        "mlp.shared_experts.down_proj",
+    } <= flat_modules
+    assert "self_attn.indexer.weights_proj" not in flat_modules
+
+    full_modules = {
+        name
+        for block in DeepSeekV32QModel.full_layer_modules(model_config=config)
+        for name in block
+    }
+    assert "self_attn.indexer.weights_proj:!" in full_modules
+    assert DeepSeekV32QModel.out_of_model_tensors == {"prefixes": ["model.layers.61"]}
+
+
+def test_deepseek_v32_defusion_preserves_forward_and_exposes_quantizable_experts():
+    torch.manual_seed(0)
+    config = _tiny_config()
+    model = AutoModelForCausalLM.from_config(
+        config, dtype=torch.float32, trust_remote_code=False
+    ).eval()
+    input_ids = torch.tensor([[1, 2, 3, 4]])
+
+    with torch.no_grad():
+        expected = model(input_ids=input_ids, use_cache=False).logits
+
+    assert defuser.convert_model(model, cleanup_original=False) is True
+
+    with torch.no_grad():
+        actual = model(input_ids=input_ids, use_cache=False).logits
+    torch.testing.assert_close(actual, expected)
+
+    modules = find_modules(model)
+    assert "model.layers.0.self_attn.indexer.weights_proj" in modules
+    assert "model.layers.3.mlp.experts.0.gate_proj" in modules
+    assert "model.layers.3.mlp.experts.0.up_proj" in modules
+    assert "model.layers.3.mlp.experts.0.down_proj" in modules
+    assert "model.layers.3.mlp.shared_experts.gate_proj" in modules
+
+    layer_modules = DeepSeekV32QModel.simple_layer_modules(
+        model_config=config,
+        quantize_config=SimpleNamespace(dynamic=None),
+    )
+    suffixes = {name for block in layer_modules for name in block}
+    matched = {
+        name for name in modules if any(name.endswith(suffix) for suffix in suffixes)
+    }
+    assert any(name.endswith("self_attn.indexer.wk") for name in matched)
+    assert any(name.endswith("mlp.experts.0.gate_proj") for name in matched)
+    assert not any(name.endswith("self_attn.indexer.weights_proj") for name in matched)

--- a/tests/test_model_test_helpers.py
+++ b/tests/test_model_test_helpers.py
@@ -269,6 +269,45 @@ def test_quantize_and_evaluate_runs_evalution_for_prequantized_model_without_cac
     }
 
 
+def test_quant_model_for_prequantized_vl_forwards_trust_remote_code_to_processor(monkeypatch):
+    tokenizer = SimpleNamespace(pad_token_id=1, eos_token_id=2)
+    prequantized_model = SimpleNamespace(
+        config=SimpleNamespace(model_type="mage_vl", pad_token_id=1, eos_token_id=2),
+        modality=[model_test_module.MODALITY.IMAGE_TO_TEXT],
+        quantized=True,
+        tokenizer=tokenizer,
+    )
+    processor = object()
+    processor_calls = []
+
+    class _Harness(ModelTest):
+        USE_FLASH_ATTN = False
+
+    helper = _Harness(methodName="runTest")
+    quantize_config = SimpleNamespace(requires_calibration_dataset=lambda: False)
+
+    monkeypatch.setattr(helper, "_build_quantize_config", lambda: quantize_config)
+    monkeypatch.setattr(helper, "_apply_model_compat_quant_overrides", lambda _model: None)
+    monkeypatch.setattr(model_test_module.GPTQModel, "load", lambda *args, **kwargs: prequantized_model)
+
+    def _load_processor(*args, **kwargs):
+        processor_calls.append((args, kwargs))
+        return processor
+
+    monkeypatch.setattr(model_test_module.AutoProcessor, "from_pretrained", _load_processor)
+
+    loaded_model, loaded_tokenizer, loaded_processor = helper.quantModel(
+        "/tmp/prequantized-vl",
+        trust_remote_code=True,
+        need_eval=False,
+    )
+
+    assert loaded_model is prequantized_model
+    assert loaded_tokenizer is tokenizer
+    assert loaded_processor is processor
+    assert processor_calls == [(("/tmp/prequantized-vl",), {"trust_remote_code": True})]
+
+
 def test_perform_post_quant_validation_retries_without_forced_cuda_map_after_oom(monkeypatch):
     class _LoadedModel:
         def __init__(self):

--- a/tests/test_olmo3_support.py
+++ b/tests/test_olmo3_support.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from types import SimpleNamespace
+
+import torch
+from transformers import Olmo3Config, Olmo3ForCausalLM
+
+from gptqmodel.models import auto
+from gptqmodel.models.definitions.olmo3 import Olmo3QModel, _prepare_olmo3_replay_kwargs
+
+
+def _tiny_olmo3_model():
+    config = Olmo3Config(
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+        sliding_window=16,
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+        rope_parameters={
+            "sliding_attention": {"rope_type": "default", "rope_theta": 10_000.0},
+            "full_attention": {
+                "rope_type": "linear",
+                "factor": 2.0,
+                "rope_theta": 10_000.0,
+            },
+        },
+    )
+    return Olmo3ForCausalLM(config)
+
+
+def test_olmo3_model_type_selects_definition(monkeypatch):
+    fake_config = SimpleNamespace(model_type="olmo3")
+
+    monkeypatch.setattr(
+        auto,
+        "resolve_trust_remote_code",
+        lambda path, trust_remote_code=False: trust_remote_code,
+    )
+    monkeypatch.setattr(
+        auto.AutoConfig, "from_pretrained", lambda *args, **kwargs: fake_config
+    )
+
+    assert auto.check_and_get_model_definition("/tmp/olmo3") is Olmo3QModel
+
+
+def test_olmo3_quantization_groups_match_forward_boundaries():
+    layer_modules = Olmo3QModel.simple_layer_modules(
+        model_config=SimpleNamespace(),
+        quantize_config=SimpleNamespace(dynamic=None),
+    )
+
+    assert layer_modules == [
+        ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj"],
+        ["self_attn.o_proj"],
+        ["mlp.gate_proj", "mlp.up_proj"],
+        ["mlp.down_proj"],
+    ]
+    role_flags = {}
+    for module_spec in Olmo3QModel.module_tree[-1]["self_attn"]:
+        name, flags = Olmo3QModel._parse_module_flags(module_spec)
+        role_flags[name] = frozenset(
+            flag for flag in flags if not flag.isdigit() and flag not in {"!", "?"}
+        )
+
+    assert role_flags["q_proj"] == frozenset({"q"})
+    assert role_flags["k_proj"] == frozenset({"k"})
+    assert role_flags["v_proj"] == frozenset({"v"})
+
+
+def test_olmo3_transformers_runtime_matches_explicit_module_tree():
+    model = _tiny_olmo3_model()
+    layer_modules = set(dict(model.model.layers[0].named_modules()))
+
+    assert Olmo3QModel.extract_layers_node() == ["model.layers"]
+    assert Olmo3QModel.pre_lm_head_norm_module == "model.norm"
+    assert Olmo3QModel.rotary_embedding == "model.rotary_emb"
+    assert "input_layernorm" not in layer_modules
+    assert {
+        "self_attn.q_proj",
+        "self_attn.q_norm",
+        "self_attn.k_proj",
+        "self_attn.k_norm",
+        "self_attn.v_proj",
+        "self_attn.o_proj",
+        "post_attention_layernorm",
+        "mlp.gate_proj",
+        "mlp.up_proj",
+        "mlp.down_proj",
+        "post_feedforward_layernorm",
+    } <= layer_modules
+
+
+def test_olmo3_replay_refreshes_rope_for_each_attention_type():
+    model = _tiny_olmo3_model()
+    model_def = SimpleNamespace(
+        model=model, rotary_embedding=Olmo3QModel.rotary_embedding
+    )
+    hidden_states = torch.zeros(1, 8, model.config.hidden_size)
+    position_ids = torch.arange(8).unsqueeze(0)
+
+    sliding_kwargs = _prepare_olmo3_replay_kwargs(
+        model_def,
+        model.model.layers[0],
+        [hidden_states],
+        {"position_ids": position_ids},
+        torch.device("cpu"),
+    )
+    full_kwargs = _prepare_olmo3_replay_kwargs(
+        model_def,
+        model.model.layers[3],
+        [hidden_states],
+        {"position_ids": position_ids},
+        torch.device("cpu"),
+    )
+
+    expected_full = model.model.rotary_emb(
+        hidden_states, position_ids, "full_attention"
+    )
+    assert all(
+        torch.equal(actual, expected)
+        for actual, expected in zip(full_kwargs["position_embeddings"], expected_full)
+    )
+    assert not torch.equal(
+        sliding_kwargs["position_embeddings"][0], full_kwargs["position_embeddings"][0]
+    )

--- a/tests/test_smollm3_support.py
+++ b/tests/test_smollm3_support.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+
+from transformers import SmolLM3Config, SmolLM3ForCausalLM
+
+from gptqmodel.models import auto
+from gptqmodel.models.definitions.llama import LlamaQModel
+
+
+def test_smollm3_model_type_selects_llama_definition(monkeypatch):
+    fake_config = SimpleNamespace(model_type="smollm3")
+
+    monkeypatch.setattr(auto, "resolve_trust_remote_code", lambda path, trust_remote_code=False: trust_remote_code)
+    monkeypatch.setattr(auto.AutoConfig, "from_pretrained", lambda *args, **kwargs: fake_config)
+
+    assert auto.check_and_get_model_definition("/tmp/smollm3") is LlamaQModel
+
+
+def test_smollm3_quantization_groups_match_runtime_projection_order():
+    layer_modules = LlamaQModel.simple_layer_modules(
+        model_config=SimpleNamespace(),
+        quantize_config=SimpleNamespace(dynamic=None),
+    )
+
+    assert layer_modules == [
+        ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj"],
+        ["self_attn.o_proj"],
+        ["mlp.gate_proj", "mlp.up_proj"],
+        ["mlp.down_proj"],
+    ]
+
+
+def test_smollm3_transformers_runtime_uses_llama_projection_paths():
+    config = SmolLM3Config(
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+    )
+    model = SmolLM3ForCausalLM(config)
+    layer_modules = set(dict(model.model.layers[0].named_modules()))
+
+    assert {
+        "input_layernorm",
+        "self_attn.q_proj",
+        "self_attn.k_proj",
+        "self_attn.v_proj",
+        "self_attn.o_proj",
+        "post_attention_layernorm",
+        "mlp.gate_proj",
+        "mlp.up_proj",
+        "mlp.down_proj",
+    } <= layer_modules
+    assert LlamaQModel.pre_lm_head_norm_module == "model.norm"


### PR DESCRIPTION
## Summary

Add quantization support for Mage-VL, Muse Glimmer, OLMo 3, SmolLM3, and DeepSeek V3.2.

## What Changed

- Add model definitions and registrations for Mage-VL, Muse Glimmer, OLMo 3, and DeepSeek V3.2.
- Register SmolLM3 with its Llama-compatible quantization module tree.
- Add multimodal processor and calibration handling for Mage-VL and Muse Glimmer.
- Handle OLMo 3 sliding/full-attention RoPE during layer replay.
- Cover DeepSeek V3.2 DSA, dense layers, routed/shared experts, and auxiliary checkpoint tensors.
- Update required Transformers and Defuser versions.
- Add targeted model-definition, runtime-layout, replay, and regression tests.

## Tests

- [x] I added a new simple/fast unit test for this change, or documented why that is not applicable.
- [x] I ran the new targeted test locally before opening this PR.
- [x] I ran any other directly relevant local tests.

Paste the exact test commands and results here:

```bash
pytest -q \
  tests/models/test_mage_vl.py::test_mage_vl_model_type_selects_definition \
  tests/models/test_mage_vl.py::test_mage_vl_definition_matches_qwen3_decoder_contract \
  tests/models/test_mage_vl.py::test_mage_vl_processor_load_enables_remote_code \
  tests/models/test_mage_vl.py::test_mage_vl_uses_qwen_style_image_calibration_dataset \
  tests/models/test_muse_glimmer.py::test_muse_glimmer_model_type_selects_definition \
  tests/models/test_muse_glimmer.py::test_muse_glimmer_module_tree_matches_text_decoder_order \
  tests/models/test_muse_glimmer.py::test_muse_glimmer_replay_rebuilds_layer_specific_mask_and_rope \
  tests/models/test_muse_glimmer.py::test_muse_glimmer_replay_matches_dense_text_forward \
  tests/test_model_test_helpers.py \
  tests/test_olmo3_support.py \
  tests/test_smollm3_support.py \
  tests/test_deepseek_v32_support.py
# 30 passed

ruff check \
  gptqmodel/models/definitions/deepseek_v32.py \
  gptqmodel/models/definitions/mage_vl.py \
  gptqmodel/models/definitions/muse_glimmer.py \
  gptqmodel/models/definitions/olmo3.py \
  tests/models/model_test.py \
  tests/models/ovis/image_to_test_dataset.py \
  tests/models/test_deepseek_v32.py \
  tests/models/test_mage_vl.py \
  tests/models/test_muse_glimmer.py \
  tests/models/test_olmo3.py \
  tests/models/test_smollm3.py \
  tests/test_deepseek_v32_support.py \
  tests/test_model_test_helpers.py \
  tests/test_olmo3_support.py \
  tests/test_smollm3_support.py
# All checks passed!

pytest --collect-only -q \
  tests/models/test_mage_vl.py \
  tests/models/test_muse_glimmer.py \
  tests/models/test_olmo3.py \
  tests/models/test_smollm3.py \
  tests/models/test_deepseek_v32.py \
  tests/test_deepseek_v32_support.py \
  tests/test_olmo3_support.py \
  tests/test_smollm3_support.py
# 26 tests collected
```

## Review Requirements

AI-assisted code is welcome.

Every changed file must still be properly reviewed by a human before the PR is opened as ready for review.

- [ ] I personally reviewed every file in this diff.
- [ ] I checked that the code matches existing project structure, APIs, and conventions.
- [ ] I avoided unnecessary monkeypatching and used the project's normal extension points where possible.

## Notes

Real-checkpoint quantization and evaluation tests were not executed in the current no-CUDA environment; their test modules collect successfully.
