### PR TITLE
Add LM-head and embedding quantization lifecycle

### DIFF
--- a/gptqmodel/__init__.py
+++ b/gptqmodel/__init__.py
@@ -302,6 +302,8 @@ from .quantization import (
     GPTAQConfig,
     GPTQConfig,
     QuantizeConfig,
+    QuantizeEmbed,
+    QuantizeEmbedConfig,
     RTNConfig,
     WeightOnlyConfig,
 )

--- a/gptqmodel/looper/weight_only_looper.py
+++ b/gptqmodel/looper/weight_only_looper.py
@@ -686,8 +686,27 @@ class WeightOnlyLooper:
         if self.embed_quant_mode is None:
             return []
 
+        input_name = self.gptq_model.get_input_embeddings_name()
+        input_module = self.gptq_model.get_input_embeddings()
+        output_name = self.gptq_model.get_output_embeddings_name()
+        output_module = self.gptq_model.get_output_embeddings()
+        input_weight = getattr(input_module, "weight", None)
+        output_weight = getattr(output_module, "weight", None)
+        if (
+            input_name is not None
+            and output_name is not None
+            and input_name != output_name
+            and input_weight is not None
+            and input_weight is output_weight
+        ):
+            raise NotImplementedError(
+                "Embedding quantization does not support distinct input and output modules with a shared weight "
+                "parameter. Untie the model weights before quantization."
+            )
+
         targets: List[Tuple[str, torch.nn.Module, str]] = []
         seen_names = set()
+        seen_weight_parameters = set()
 
         def append_target(name: Optional[str], module: Optional[torch.nn.Module], label: str) -> None:
             if module is None or name is None:
@@ -697,20 +716,25 @@ class WeightOnlyLooper:
                     f"This type({type(module)}) of {label} embeddings quantization is currently not supported. "
                     f"SUPPORTS_MODULE_TYPES is {SUPPORTS_MODULE_TYPES}"
                 )
-            if name not in seen_names:
-                seen_names.add(name)
-                targets.append((name, module, label))
+            weight = getattr(module, "weight", None)
+            weight_parameter_id = id(weight) if weight is not None else None
+            if name in seen_names or weight_parameter_id in seen_weight_parameters:
+                return
+            seen_names.add(name)
+            if weight_parameter_id is not None:
+                seen_weight_parameters.add(weight_parameter_id)
+            targets.append((name, module, label))
 
         if self.embed_quant_mode in (QuantizeEmbed.INPUT, QuantizeEmbed.BOTH):
             append_target(
-                self.gptq_model.get_input_embeddings_name(),
-                self.gptq_model.get_input_embeddings(),
+                input_name,
+                input_module,
                 "input",
             )
         if self.embed_quant_mode in (QuantizeEmbed.OUTPUT, QuantizeEmbed.BOTH):
             append_target(
-                self.gptq_model.get_output_embeddings_name(),
-                self.gptq_model.get_output_embeddings(),
+                output_name,
+                output_module,
                 "output",
             )
         return targets

--- a/gptqmodel/looper/weight_only_looper.py
+++ b/gptqmodel/looper/weight_only_looper.py
@@ -650,7 +650,7 @@ class WeightOnlyLooper:
         if isinstance(resolved, NamedModule):
             return resolved
 
-        layer_name = self.gptq_model.lm_head if is_lm_head_module else f"{layer_path}.{module_name}"
+        layer_name = module_name if is_lm_head_module else f"{layer_path}.{module_name}"
         named = NamedModule(
             resolved,
             name=module_name,
@@ -790,18 +790,19 @@ class WeightOnlyLooper:
 
         self._configure_embedding_dynamic_defaults(embedding_targets)
         embedding_target_names = {name for name, _module, _label in embedding_targets}
-        if not embed_only and quant_config.lm_head and self.gptq_model.lm_head not in embedding_target_names:
+        lm_head_name = self.gptq_model.get_output_embeddings_name() or self.gptq_model.lm_head
+        if not embed_only and quant_config.lm_head and lm_head_name not in embedding_target_names:
             if self.gptq_model.model.config.tie_word_embeddings and hasattr(self.gptq_model.model.model, "_tied_weights_keys"):
                 tied_keys = self.gptq_model.model._tied_weights_keys
                 for item in tied_keys:
-                    if self.gptq_model.lm_head in item:
+                    if lm_head_name in item:
                         raise NotImplementedError(
                             "quantization of `lm_head` layer with `tied_weights=True` model state is not supported. Please check model has `tied_weights=False`."
                         )
 
-            lm_head_module = get_module(self.gptq_model.model, key=self.gptq_model.lm_head)
+            lm_head_module = get_module(self.gptq_model.model, key=lm_head_name)
             if lm_head_module is None:
-                raise ValueError(f"could not find layer {self.gptq_model.lm_head} in the model, exit...")
+                raise ValueError(f"could not find layer {lm_head_name} in the model, exit...")
             if not isinstance(lm_head_module, tuple(SUPPORTS_MODULE_TYPES)):
                 raise NotImplementedError(
                     f"This type({type(lm_head_module)}) of lm_head quantization is currently not supported. SUPPORTS_MODULE_TYPES is {SUPPORTS_MODULE_TYPES}"
@@ -859,7 +860,7 @@ class WeightOnlyLooper:
 
         layer_count = len(layers)
         quant_lm_head_in_loop = bool(
-            not embed_only and quant_config.lm_head and self.gptq_model.lm_head not in embedding_target_names
+            not embed_only and quant_config.lm_head and lm_head_name not in embedding_target_names
         )
         total_layers = (
             len(embedding_targets)
@@ -924,8 +925,8 @@ class WeightOnlyLooper:
                 # Transformer blocks and lm_head follow the same weight-only
                 # lifecycle, but lm_head is resolved from the root model.
                 if is_lm_head_module:
-                    module = get_module(self.gptq_model.model, key=self.gptq_model.lm_head)
-                    subsets = [[self.gptq_model.lm_head]]
+                    module = get_module(self.gptq_model.model, key=lm_head_name)
+                    subsets = [[lm_head_name]]
                 else:
                     module = layers[layer_index]
                     subsets = layer_modules
@@ -956,7 +957,7 @@ class WeightOnlyLooper:
                 # Resolve concrete submodules after any pre-quantization
                 # transforms so quantization targets the final layer layout.
                 materialize_model(module)
-                full = find_modules(module, name=self.gptq_model.lm_head if is_lm_head_module else "")
+                full = find_modules(module, name=lm_head_name if is_lm_head_module else "")
                 layer_strategy_modules = None if is_lm_head_module else planning_layer_modules
                 layer_strategy_device_map = self._build_layer_strategy_device_map(
                     full=full,

--- a/gptqmodel/looper/weight_only_looper.py
+++ b/gptqmodel/looper/weight_only_looper.py
@@ -30,7 +30,15 @@ from ..looper.named_module import NamedModule
 from ..models import BaseQModel
 from ..models._const import CPU, SUPPORTS_MODULE_TYPES
 from ..nn_modules.converter import MODULE_CONVERTER_MAP
-from ..quantization.config import BitsAndBytesConfig, FP8Config, GGUFConfig, RTNConfig, VramStrategy
+from ..quantization.config import (
+    BitsAndBytesConfig,
+    FP8Config,
+    GGUFConfig,
+    QuantizeEmbed,
+    QuantizeEmbedConfig,
+    RTNConfig,
+    VramStrategy,
+)
 from ..utils import has_gil_disabled
 from ..utils.device import get_device
 from ..utils.device_telemetry import emit_device_telemetry
@@ -59,11 +67,18 @@ log = setup_logger()
 class WeightOnlyLooper:
     """Run the simplified per-layer lifecycle for weight-only quantization."""
 
-    def __init__(self, model: BaseQModel, processor: WeightOnlyProcessor):
+    def __init__(
+        self,
+        model: BaseQModel,
+        processor: WeightOnlyProcessor,
+        embed_quant_config: Optional[QuantizeEmbedConfig] = None,
+    ):
         """Initializes the looper with the model being quantized and its processor."""
 
         self.gptq_model = model
         self.processor = processor
+        self.embed_quant_mode = embed_quant_config.embed_quant_mode if embed_quant_config else None
+        self.embed_only = embed_quant_config.embed_only if embed_quant_config else None
         self._quant_devices = self._resolve_quant_devices()
         self._quant_device_rr = 0
         self._module_device_map: Dict[str, torch.device] = {}
@@ -666,6 +681,69 @@ class WeightOnlyLooper:
             disk_path=offload_path,
         )
 
+    def _embedding_quant_targets(self) -> List[Tuple[str, torch.nn.Module, str]]:
+        """Return requested embedding modules as name, module, and display label tuples."""
+        if self.embed_quant_mode is None:
+            return []
+
+        targets: List[Tuple[str, torch.nn.Module, str]] = []
+        seen_names = set()
+
+        def append_target(name: Optional[str], module: Optional[torch.nn.Module], label: str) -> None:
+            if module is None or name is None:
+                raise ValueError(f"could not find {label} embeddings module in the model, exit...")
+            if not isinstance(module, tuple(SUPPORTS_MODULE_TYPES)):
+                raise NotImplementedError(
+                    f"This type({type(module)}) of {label} embeddings quantization is currently not supported. "
+                    f"SUPPORTS_MODULE_TYPES is {SUPPORTS_MODULE_TYPES}"
+                )
+            if name not in seen_names:
+                seen_names.add(name)
+                targets.append((name, module, label))
+
+        if self.embed_quant_mode in (QuantizeEmbed.INPUT, QuantizeEmbed.BOTH):
+            append_target(
+                self.gptq_model.get_input_embeddings_name(),
+                self.gptq_model.get_input_embeddings(),
+                "input",
+            )
+        if self.embed_quant_mode in (QuantizeEmbed.OUTPUT, QuantizeEmbed.BOTH):
+            append_target(
+                self.gptq_model.get_output_embeddings_name(),
+                self.gptq_model.get_output_embeddings(),
+                "output",
+            )
+        return targets
+
+    def _configure_embedding_dynamic_defaults(self, targets: List[Tuple[str, torch.nn.Module, str]]) -> None:
+        if not targets:
+            return
+        quant_config = self.gptq_model.quantize_config
+        if quant_config.dynamic is None:
+            quant_config.dynamic = {}
+        for module_name, _module, _label in targets:
+            if quant_config.dynamic_get(module_name, default=None) is None:
+                quant_config.dynamic[module_name] = {"bits": 8, "group_size": 32}
+
+    def _quantize_embedding_targets(self, targets, *, layer_count: int, pb) -> set[str]:
+        quantized_names: set[str] = set()
+        for target_index, (module_name, module, label) in enumerate(targets):
+            if pb is not None:
+                pb.current_iter_step = target_index
+                pb.title(f"Weight-only quantizing {label} embeddings").subtitle(module_name).draw()
+            named = NamedModule(module, name=module_name, full_name=module_name, layer_index=None)
+            self._finalize_subset_modules(self._quantize_subset_modules([named]))
+            prefixes = set(getattr(self.gptq_model, "_embedding_replacement_prefixes", set()))
+            prefixes.add(module_name)
+            self.gptq_model._embedding_replacement_prefixes = prefixes
+            quantized_names.add(module_name)
+            if pb is not None:
+                pb.current_iter_step = target_index + 1
+                pb.draw()
+        if targets:
+            self.processor.layer_count = layer_count
+        return quantized_names
+
     def loop(self, **kwargs):
         """Quantize layers directly from weights without calibration forwards."""
         quant_config = self.gptq_model.quantize_config
@@ -675,7 +753,20 @@ class WeightOnlyLooper:
                 "`FP8Config`, and `BitsAndBytesConfig` today."
             )
 
-        if quant_config.lm_head:
+        embedding_targets = self._embedding_quant_targets()
+        if embedding_targets and not isinstance(quant_config, RTNConfig):
+            raise NotImplementedError(
+                "Weight-only input/output embeddings fast quantization currently supports RTNConfig only."
+            )
+        embed_only = bool(embedding_targets) and self.embed_only
+        self.gptq_model._model_free_weight_only_embeddings_only = False
+        if embed_only:
+            quant_config.offload_to_disk = False
+            log.info("`embed_only` does not support `offload_to_disk=True`; setting `offload_to_disk` to `False`.")
+
+        self._configure_embedding_dynamic_defaults(embedding_targets)
+        embedding_target_names = {name for name, _module, _label in embedding_targets}
+        if not embed_only and quant_config.lm_head and self.gptq_model.lm_head not in embedding_target_names:
             if self.gptq_model.model.config.tie_word_embeddings and hasattr(self.gptq_model.model.model, "_tied_weights_keys"):
                 tied_keys = self.gptq_model.model._tied_weights_keys
                 for item in tied_keys:
@@ -743,7 +834,14 @@ class WeightOnlyLooper:
             layer_modules = [sum(layer_modules, [])]
 
         layer_count = len(layers)
-        total_layers = layer_count + (1 if quant_config.lm_head else 0)
+        quant_lm_head_in_loop = bool(
+            not embed_only and quant_config.lm_head and self.gptq_model.lm_head not in embedding_target_names
+        )
+        total_layers = (
+            len(embedding_targets)
+            if embed_only
+            else layer_count + len(embedding_targets) + (1 if quant_lm_head_in_loop else 0)
+        )
         pb = log.pb(range(total_layers)).manual().set(show_left_steps=1)
         pb.title(f"Weight-only quantization ({total_layers} layers)")
         self.processor.layer_count = layer_count
@@ -762,6 +860,14 @@ class WeightOnlyLooper:
             )
 
         try:
+            self._quantize_embedding_targets(embedding_targets, layer_count=layer_count, pb=pb)
+            if embed_only:
+                total_log = {self.processor.name(): self.processor.log}
+                self.gptq_model.quant_log = self.processor.log
+                self.processor.finalize(model=self.gptq_model)
+                self.gptq_model._model_free_weight_only_embeddings_only = True
+                return total_log
+
             # Trailing layers whose tracked modules are all dynamically excluded never
             # need another forward or finalize pass, so the loop can stop once the
             # final eligible layer has been processed.
@@ -772,7 +878,8 @@ class WeightOnlyLooper:
                 layer_count=layer_count,
             )
 
-            for layer_index in range(total_layers):
+            for progress_index in range(len(embedding_targets), total_layers):
+                layer_index = progress_index - len(embedding_targets)
                 is_lm_head_module = layer_index >= layer_count
 
                 if (
@@ -809,7 +916,7 @@ class WeightOnlyLooper:
                         if is_lm_head_module
                         else f"Weight-only quantizing layer {layer_index} of {layer_count - 1}"
                     )
-                    pb.current_iter_step = layer_index
+                    pb.current_iter_step = progress_index
                     pb.title(layer_title).subtitle("").draw()
 
                 module = self.gptq_model.pre_quantize(module)
@@ -890,7 +997,7 @@ class WeightOnlyLooper:
                 else:
                     layers[layer_index] = self.gptq_model.post_quantize(module)
                 if pb is not None:
-                    pb.current_iter_step = layer_index + 1
+                    pb.current_iter_step = progress_index + 1
                     pb.draw()
         finally:
             if pb is not None:

--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -50,6 +50,8 @@ from ..quantization.config import (
     AutoModuleDecoderConfig,
     BaseQuantizeConfig,
     GcMode,
+    QuantizeEmbed,
+    QuantizeEmbedConfig,
     VramStrategy,
     dynamic_get,
     resolve_quant_format,
@@ -76,6 +78,7 @@ from ..utils.model import (
     find_modules,
     get_module,
     get_module_by_name_prefix,
+    get_module_name,
     move_to,
 )
 from ..utils.model_dequant import infer_block_shape
@@ -816,11 +819,18 @@ class BaseQModel(nn.Module):
         # minimum length of calibration data, default is 10
         calibration_data_min_length: int = 10,
         calibration_concat_separator: Optional[str] = None,
+        embed_quant_config: Optional[Union[QuantizeEmbedConfig, QuantizeEmbed]] = None,
+        embed_quant_mode: Optional[QuantizeEmbed] = None,
     ) -> Dict[str, List[Dict[str, str]]]:
+        embed_quant_config = self._normalize_embed_quant_config(
+            embed_quant_config=embed_quant_config,
+            embed_quant_mode=embed_quant_mode,
+        )
+
         if self.quantize_config is None or not isinstance(self.quantize_config, BaseQuantizeConfig):
             raise AttributeError("`quantize_config` must be not None")
 
-        if self.quantized:
+        if self.quantized and embed_quant_config is None:
             raise EnvironmentError("quantize() is called a model that is already quantized")
 
         timer = getattr(self, "quant_region_timer", None)
@@ -1021,6 +1031,7 @@ class BaseQModel(nn.Module):
                 batch_size=batch_size,
                 backend=backend,
                 calibration_concat_separator=calibration_concat_separator,
+                embed_quant_config=embed_quant_config,
             )
         else:
             if calibration is None:
@@ -1043,6 +1054,60 @@ class BaseQModel(nn.Module):
 
         _setup_rotation_online_had(self.model, self.quantize_config.rotation)
         return result
+
+    @staticmethod
+    def _normalize_embed_quant_config(
+        embed_quant_config: Optional[Union[QuantizeEmbedConfig, QuantizeEmbed]],
+        embed_quant_mode: Optional[QuantizeEmbed],
+    ) -> Optional[QuantizeEmbedConfig]:
+        """Normalize the embedding quantization API and its compatibility argument."""
+        if embed_quant_config is not None and embed_quant_mode is not None:
+            raise ValueError("Pass only one of `embed_quant_config` or `embed_quant_mode`.")
+        if isinstance(embed_quant_config, QuantizeEmbed):
+            return QuantizeEmbedConfig(embed_quant_mode=embed_quant_config)
+        if embed_quant_config is not None:
+            if not isinstance(embed_quant_config, QuantizeEmbedConfig):
+                raise TypeError("`embed_quant_config` must be a `QuantizeEmbedConfig` or `QuantizeEmbed` instance.")
+            return embed_quant_config
+        if embed_quant_mode is not None:
+            if not isinstance(embed_quant_mode, QuantizeEmbed):
+                raise TypeError("`embed_quant_mode` must be a `QuantizeEmbed` instance.")
+            return QuantizeEmbedConfig(embed_quant_mode=embed_quant_mode)
+        return None
+
+    def requantize(
+        self,
+        calibration: Union[List[Dict[str, Union[List[int], torch.LongTensor]]], List[str], List[int]],
+        embed_quant_config: Optional[Union[QuantizeEmbedConfig, QuantizeEmbed]] = None,
+        calibration_concat_size: Optional[int] = None,
+        calibration_sort: Optional[str] = "desc",
+        batch_size: int = 1,
+        tokenizer: Optional[PreTrainedTokenizerBase] = None,
+        backend: Optional[BACKEND] = BACKEND.AUTO,
+        adapter: Adapter = None,
+        adapter_calibration_dataset: Union[List[Dict[str, Union[List[int], torch.LongTensor]]], List[str], List[int]] = None,
+        calibration_data_min_length: int = 10,
+        calibration_concat_separator: Optional[str] = None,
+        embed_quant_mode: Optional[QuantizeEmbed] = None,
+    ) -> Dict[str, List[Dict[str, str]]]:
+        if not self.quantized:
+            raise EnvironmentError("requantize() must be called on a model that has already been quantized.")
+        embed_quant_config = self._normalize_embed_quant_config(embed_quant_config, embed_quant_mode)
+        if embed_quant_config is None:
+            raise ValueError("`requantize()` requires `embed_quant_config` or `embed_quant_mode`.")
+        return self.quantize(
+            calibration=calibration,
+            calibration_concat_size=calibration_concat_size,
+            calibration_sort=calibration_sort,
+            batch_size=batch_size,
+            tokenizer=tokenizer,
+            backend=backend,
+            adapter=adapter,
+            adapter_calibration_dataset=adapter_calibration_dataset,
+            calibration_data_min_length=calibration_data_min_length,
+            calibration_concat_separator=calibration_concat_separator,
+            embed_quant_config=embed_quant_config,
+        )
 
     def _quantize_with_calibration(
         self,
@@ -1202,6 +1267,7 @@ class BaseQModel(nn.Module):
         batch_size: int,
         backend: Optional[BACKEND],
         calibration_concat_separator: Optional[str],
+        embed_quant_config: Optional[QuantizeEmbedConfig],
     ):
         del calibration_concat_size, calibration_sort, batch_size, calibration_concat_separator
 
@@ -1231,7 +1297,7 @@ class BaseQModel(nn.Module):
             tokenizer=self.tokenizer,
             qcfg=self.quantize_config,
         )
-        module_looper = WeightOnlyLooper(model=self, processor=processor)
+        module_looper = WeightOnlyLooper(model=self, processor=processor, embed_quant_config=embed_quant_config)
 
         gc_context = (
             DEVICE_THREAD_POOL.no_auto_gc()
@@ -1535,13 +1601,21 @@ class BaseQModel(nn.Module):
                 # Safetensors is unable to save tied weights, so we untie them here. Reference: https://github.com/huggingface/safetensors/issues/202
                 #untie_weights(self.model)
 
-                self.save_quantized(
-                    save_dir=save_dir,
-                    safetensors_metadata=safetensors_metadata,
-                    max_shard_size=max_shard_size,
-                    meta_quantizer=meta_quantizer,
-                    eora_path=eora_path,
-                    split_by=split_by)
+                if getattr(self, "_model_free_weight_only_embeddings_only", False):
+                    self.save_quantized_embeddings(
+                        save_dir=save_dir,
+                        safetensors_metadata=safetensors_metadata,
+                        max_shard_size=max_shard_size,
+                        meta_quantizer=meta_quantizer,
+                    )
+                else:
+                    self.save_quantized(
+                        save_dir=save_dir,
+                        safetensors_metadata=safetensors_metadata,
+                        max_shard_size=max_shard_size,
+                        meta_quantizer=meta_quantizer,
+                        eora_path=eora_path,
+                        split_by=split_by)
 
                 # overwrite quant_override_files
                 for name, value in self.quant_override_files.items():
@@ -3108,6 +3182,22 @@ class BaseQModel(nn.Module):
 
     def tied_word_embedding(self) -> bool:
         return getattr(self.model.config, "tie_word_embeddings", False)
+
+    def get_input_embeddings(self) -> Optional[nn.Module]:
+        getter = getattr(self.model, "get_input_embeddings", None)
+        return getter() if callable(getter) else None
+
+    def get_input_embeddings_name(self) -> Optional[str]:
+        module = self.get_input_embeddings()
+        return get_module_name(self.model, module) if module is not None else None
+
+    def get_output_embeddings(self) -> Optional[nn.Module]:
+        getter = getattr(self.model, "get_output_embeddings", None)
+        return getter() if callable(getter) else None
+
+    def get_output_embeddings_name(self) -> Optional[str]:
+        module = self.get_output_embeddings()
+        return get_module_name(self.model, module) if module is not None else None
 
     def __getattr__(self, item):
         try:

--- a/gptqmodel/models/writer.py
+++ b/gptqmodel/models/writer.py
@@ -201,6 +201,129 @@ def _materialize_meta_layers_from_turtle(model: torch.nn.Module, turtle_model) -
     return materialized
 
 
+def _checkpoint_prefixes_for_replacement(prefix: str, turtle_model) -> set[str]:
+    prefixes = {prefix}
+    resolver = getattr(turtle_model, "_resolve_checkpoint_module_path", None)
+    if callable(resolver):
+        resolved = resolver(prefix)
+        if resolved:
+            prefixes.add(resolved)
+    tensor_resolver = getattr(turtle_model, "_resolve_checkpoint_tensor_source", None)
+    if callable(tensor_resolver):
+        for leaf in ("weight", "bias"):
+            try:
+                checkpoint_name, _expert_index, _split_index, _split_dim = tensor_resolver(prefix, leaf)
+            except Exception:
+                checkpoint_name = None
+            if checkpoint_name:
+                prefixes.add(checkpoint_name[: -(len(leaf) + 1)] if checkpoint_name.endswith(f".{leaf}") else checkpoint_name)
+    return prefixes
+
+
+def _tensor_matches_prefixes(tensor_name: str, prefixes: set[str]) -> bool:
+    return tensor_name in prefixes or any(tensor_name.startswith(f"{prefix}.") for prefix in prefixes)
+
+
+def _save_embedding_replacement_safetensors(
+    model,
+    turtle_model,
+    embedding_prefixes: List[str],
+    *,
+    save_dir: str,
+    metadata: Dict[str, str],
+) -> tuple[List[str], Dict[str, str], int, List[str]]:
+    """Rewrite only checkpoint shards containing replaced embedding modules."""
+    if turtle_model is None or not hasattr(turtle_model, "_weight_map") or not hasattr(turtle_model, "model_local_path"):
+        raise ValueError("Embedding replacement save requires a LazyTurtle checkpoint source.")
+    prefixes = sorted({prefix for prefix in embedding_prefixes if isinstance(prefix, str) and prefix})
+    if not prefixes:
+        raise ValueError("Embedding replacement save requires at least one embedding prefix.")
+
+    index_path = os.path.join(save_dir, "model.safetensors.index.json")
+    existing_weight_map = {}
+    if os.path.exists(index_path):
+        with open(index_path, "r", encoding="utf-8") as handle:
+            existing_weight_map = json.load(handle).get("weight_map", {})
+
+    drop_by_shard: Dict[str, set[str]] = {}
+    replacements_by_shard: Dict[str, Dict[str, torch.Tensor]] = {}
+    removed_tensor_names: List[str] = []
+    for prefix in prefixes:
+        checkpoint_prefixes = _checkpoint_prefixes_for_replacement(prefix, turtle_model)
+        matched_shards = []
+        for tensor_name, shard_name in turtle_model._weight_map.items():
+            if _tensor_matches_prefixes(tensor_name, checkpoint_prefixes):
+                drop_by_shard.setdefault(shard_name, set()).add(tensor_name)
+                if tensor_name not in removed_tensor_names:
+                    removed_tensor_names.append(tensor_name)
+                if shard_name not in matched_shards:
+                    matched_shards.append(shard_name)
+        for leaf in ("weight", "bias"):
+            runtime_name = f"{prefix}.{leaf}"
+            runtime_shard = existing_weight_map.get(runtime_name)
+            if runtime_shard:
+                drop_by_shard.setdefault(runtime_shard, set()).add(runtime_name)
+                if runtime_name not in removed_tensor_names:
+                    removed_tensor_names.append(runtime_name)
+                if runtime_shard not in matched_shards:
+                    matched_shards.append(runtime_shard)
+        if not matched_shards:
+            raise ValueError(f"Could not find checkpoint tensor for embedding module `{prefix}`.")
+        try:
+            module = model.get_submodule(prefix)
+        except AttributeError as exc:
+            raise ValueError(f"Embedding replacement module `{prefix}` is not present in the model tree.") from exc
+        replacements = replacements_by_shard.setdefault(matched_shards[0], {})
+        for relative_name, tensor in module.state_dict().items():
+            replacements[f"{prefix}.{relative_name}" if relative_name else prefix] = tensor.detach().cpu()
+
+    rewritten_files = []
+    tensor_to_filename = {}
+    total_size_bytes = 0
+    for shard_name, dropped_names in drop_by_shard.items():
+        if not shard_name.endswith(".safetensors"):
+            raise NotImplementedError("Embedding-only replacement save currently supports safetensors checkpoints only.")
+        source_path = os.path.join(turtle_model.model_local_path, shard_name)
+        target_path = os.path.join(save_dir, shard_name)
+        os.makedirs(os.path.dirname(target_path), exist_ok=True)
+        read_path = target_path if os.path.exists(target_path) else source_path
+        tensors = {}
+        with safe_open(read_path, framework="pt", device="cpu") as handler:
+            for tensor_name in handler.keys():
+                if tensor_name not in dropped_names:
+                    tensors[tensor_name] = handler.get_tensor(tensor_name)
+                    tensor_to_filename[tensor_name] = shard_name
+        for tensor_name, tensor in replacements_by_shard.get(shard_name, {}).items():
+            tensors[tensor_name] = tensor
+            tensor_to_filename[tensor_name] = shard_name
+        save_file(tensors, target_path, metadata=metadata)
+        rewritten_files.append(shard_name)
+        total_size_bytes += os.path.getsize(target_path)
+    return rewritten_files, tensor_to_filename, total_size_bytes, removed_tensor_names
+
+
+def _copy_missing_checkpoint_files(source_dir: str, save_dir: str) -> List[str]:
+    source_root = os.path.realpath(source_dir)
+    save_root = os.path.realpath(save_dir)
+    if source_root == save_root:
+        return []
+    if os.path.commonpath([source_root, save_root]) == source_root:
+        raise ValueError("Embedding-only save destination must not be nested inside its checkpoint source.")
+    copied = []
+    for root, dirnames, filenames in os.walk(source_root):
+        dirnames.sort()
+        relative_root = os.path.relpath(root, source_root)
+        target_root = save_root if relative_root == "." else os.path.join(save_root, relative_root)
+        for filename in sorted(filenames):
+            target_path = os.path.join(target_root, filename)
+            if os.path.exists(target_path):
+                continue
+            os.makedirs(target_root, exist_ok=True)
+            shutil.copy2(os.path.join(root, filename), target_path)
+            copied.append(os.path.relpath(target_path, save_root))
+    return copied
+
+
 def _cleanup_saved_weight_files(
     save_dir: str,
     expected_files: List[str],
@@ -554,6 +677,87 @@ def ModelWriter(cls):
             del self.lora_results  # TODO REFRACTOR
 
     cls.eora_save = _eora_save
+
+    def save_quantized_embeddings(
+            self,
+            save_dir: str,
+            safetensors_metadata: Optional[Dict[str, str]] = None,
+            max_shard_size: Optional[Union[int, str]] = DEFAULT_MAX_SHARD_SIZE,
+            meta_quantizer: Optional[str] = None,
+    ):
+        """Save an embedding-only quantized model as a complete checkpoint."""
+        del max_shard_size
+        if not self.quantized:
+            raise ValueError("Save aborted as model is not quantized. Please call `quantize()` first.")
+        prefixes = sorted({
+            prefix for prefix in getattr(self, "_embedding_replacement_prefixes", set())
+            if isinstance(prefix, str) and prefix
+        })
+        if not prefixes:
+            raise ValueError("Embedding-only save requires quantized embedding replacement prefixes.")
+        checkpoint_source = self.turtle_model or getattr(self, "_embedding_replacement_source", None)
+        if checkpoint_source is None or not hasattr(checkpoint_source, "_weight_map") or not hasattr(checkpoint_source, "model_local_path"):
+            raise ValueError("Embedding-only save requires a LazyTurtle checkpoint source.")
+
+        os.makedirs(save_dir, exist_ok=True)
+        _copy_missing_checkpoint_files(checkpoint_source.model_local_path, save_dir)
+
+        quantizers = [f"{META_QUANTIZER_GPTQMODEL}:{__version__}"]
+        if meta_quantizer:
+            if len(meta_quantizer.split(":")) == 2:
+                quantizers.append(meta_quantizer.replace(" ", ""))
+            else:
+                log.warn(f"meta_quantizer: '{meta_quantizer}' format is invalid, expected: 'quantizer_name:version'")
+        self.quantize_config.meta_set_versionable(key=META_FIELD_QUANTIZER, value=quantizers)
+        self.quantize_config.meta_set(key=META_FIELD_URI, value=META_VALUE_URI)
+
+        metadata = {} if safetensors_metadata is None else {str(k): str(v) for k, v in safetensors_metadata.items()}
+        metadata["format"] = "pt"
+        rewritten_files, tensor_to_filename, _total_size, removed_names = _save_embedding_replacement_safetensors(
+            self.model,
+            checkpoint_source,
+            prefixes,
+            save_dir=save_dir,
+            metadata=metadata,
+        )
+        index_path = join(save_dir, "model.safetensors.index.json")
+        if os.path.exists(index_path):
+            with open(index_path, "r", encoding="utf-8") as handle:
+                index = json.load(handle)
+            weight_map = index.setdefault("weight_map", {})
+            for tensor_name in removed_names:
+                weight_map.pop(tensor_name, None)
+            weight_map.update(tensor_to_filename)
+            index.setdefault("metadata", {})["total_size"] = sum(
+                os.path.getsize(os.path.join(save_dir, filename))
+                for filename in set(weight_map.values())
+                if os.path.exists(os.path.join(save_dir, filename))
+            )
+            with open(index_path, "w", encoding="utf-8") as handle:
+                handle.write(json.dumps(index, indent=2, sort_keys=True) + "\n")
+        elif len(rewritten_files) > 1:
+            log.warn("Embedding save: no safetensors index found in `%s`; updated shards only.", save_dir)
+
+        serialized_config = copy.deepcopy(self.quantize_config)
+        serialized_config.save_pretrained(save_dir)
+        quant_config_path = os.path.join(save_dir, "quantize_config.json")
+        with open(quant_config_path, "r", encoding="utf-8") as handle:
+            quantization_config = json.load(handle)
+        config_path = os.path.join(save_dir, "config.json")
+        with open(config_path, "r", encoding="utf-8") as handle:
+            model_config = json.load(handle)
+        model_config["quantization_config"] = quantization_config
+        with open(config_path, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(model_config, indent=2, sort_keys=True) + "\n")
+
+        if self.trust_remote_code:
+            copy_py_files(save_dir, model_id_or_path=self.model_local_path)
+        if self.tokenizer:
+            self.tokenizer.save_pretrained(save_dir)
+        if hasattr(self, "processor") and isinstance(self.processor, ProcessorMixin):
+            self.processor.save_pretrained(save_dir)
+
+    cls.save_quantized_embeddings = save_quantized_embeddings
 
     def save_quantized(
             self,

--- a/gptqmodel/quantization/__init__.py
+++ b/gptqmodel/quantization/__init__.py
@@ -32,6 +32,8 @@ from .config import (
                      PreProcessorConfig,
                      QuantBits,
                      QuantizeConfig,
+                     QuantizeEmbed,
+                     QuantizeEmbedConfig,
                      RTNConfig,
                      SmootherConfig,
                      SmoothLog,

--- a/gptqmodel/quantization/config.py
+++ b/gptqmodel/quantization/config.py
@@ -148,6 +148,18 @@ class VramStrategy(str, Enum):
     BALANCED = "balanced"
 
 
+class QuantizeEmbed(str, Enum):
+    INPUT = "input"
+    OUTPUT = "output"
+    BOTH = "both"
+
+
+@dataclass
+class QuantizeEmbedConfig:
+    embed_quant_mode: QuantizeEmbed = QuantizeEmbed.OUTPUT
+    embed_only: bool = True
+
+
 class FallbackStrategy(str, Enum):
     """
     +-----------+----------------------+---------------------------+------------------------------+

--- a/tests/test_embed_quant_api.py
+++ b/tests/test_embed_quant_api.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from torch import nn
+
+from gptqmodel import QuantizeEmbed, QuantizeEmbedConfig
+from gptqmodel.models.base import BaseQModel
+from gptqmodel.quantization import QuantizeEmbedConfig as QuantizationEmbedConfig
+
+
+def _bare_model(*, quantized: bool):
+    model = BaseQModel.__new__(BaseQModel)
+    nn.Module.__init__(model)
+    model.quantized = quantized
+    return model
+
+
+def test_quantize_embed_config_is_exported_from_public_packages():
+    assert QuantizeEmbedConfig is QuantizationEmbedConfig
+
+
+def test_normalize_embed_quant_config_accepts_config_and_compatibility_mode():
+    config = QuantizeEmbedConfig(embed_quant_mode=QuantizeEmbed.INPUT, embed_only=False)
+    assert BaseQModel._normalize_embed_quant_config(config, None) is config
+    assert BaseQModel._normalize_embed_quant_config(QuantizeEmbed.BOTH, None) == QuantizeEmbedConfig(
+        embed_quant_mode=QuantizeEmbed.BOTH
+    )
+    assert BaseQModel._normalize_embed_quant_config(None, QuantizeEmbed.OUTPUT) == QuantizeEmbedConfig(
+        embed_quant_mode=QuantizeEmbed.OUTPUT
+    )
+
+
+def test_normalize_embed_quant_config_rejects_conflicting_arguments():
+    with pytest.raises(ValueError, match="Pass only one"):
+        BaseQModel._normalize_embed_quant_config(
+            QuantizeEmbedConfig(embed_quant_mode=QuantizeEmbed.INPUT),
+            QuantizeEmbed.OUTPUT,
+        )
+
+
+def test_requantize_forwards_canonical_embedding_config():
+    model = _bare_model(quantized=True)
+    captured = {}
+
+    def quantize(**kwargs):
+        captured.update(kwargs)
+        return {"ok": []}
+
+    model.quantize = quantize
+    config = QuantizeEmbedConfig(embed_quant_mode=QuantizeEmbed.BOTH, embed_only=False)
+    assert model.requantize(calibration=["sample"], embed_quant_config=config) == {"ok": []}
+    assert captured["embed_quant_config"] is config
+    assert "embed_quant_mode" not in captured
+
+
+def test_requantize_keeps_embedding_mode_compatibility():
+    model = _bare_model(quantized=True)
+    captured = {}
+    model.quantize = lambda **kwargs: captured.update(kwargs)
+
+    model.requantize(calibration=["sample"], embed_quant_mode=QuantizeEmbed.INPUT)
+
+    assert captured["embed_quant_config"] == QuantizeEmbedConfig(embed_quant_mode=QuantizeEmbed.INPUT)
+
+
+def test_requantize_requires_an_embedding_target():
+    model = _bare_model(quantized=True)
+    with pytest.raises(ValueError, match="requires"):
+        model.requantize(calibration=["sample"])

--- a/tests/test_embedding_save_lifecycle.py
+++ b/tests/test_embedding_save_lifecycle.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+from torch import nn
+
+from gptqmodel.models.base import BaseQModel
+from gptqmodel.models.writer import _save_embedding_replacement_safetensors
+
+
+def test_embedding_replacement_rewrites_only_affected_shard(tmp_path):
+    source = tmp_path / "source"
+    saved = tmp_path / "saved"
+    source.mkdir()
+    saved.mkdir()
+    save_file(
+        {"embed_tokens.weight": torch.ones(4, 3), "final_norm.weight": torch.ones(3)},
+        str(source / "model-00001-of-00002.safetensors"),
+    )
+    save_file(
+        {"layers.0.linear.weight": torch.full((3, 3), 2.0)},
+        str(source / "model-00002-of-00002.safetensors"),
+    )
+    model = nn.Module()
+    model.embed_tokens = nn.Module()
+    model.embed_tokens.register_buffer("qweight", torch.ones(2, 2, dtype=torch.int32))
+    turtle = SimpleNamespace(
+        model_local_path=str(source),
+        _weight_map={
+            "embed_tokens.weight": "model-00001-of-00002.safetensors",
+            "final_norm.weight": "model-00001-of-00002.safetensors",
+            "layers.0.linear.weight": "model-00002-of-00002.safetensors",
+        },
+    )
+
+    rewritten, weight_map, _size, removed = _save_embedding_replacement_safetensors(
+        model,
+        turtle,
+        ["embed_tokens"],
+        save_dir=str(saved),
+        metadata={"format": "pt"},
+    )
+
+    assert rewritten == ["model-00001-of-00002.safetensors"]
+    assert removed == ["embed_tokens.weight"]
+    assert weight_map["embed_tokens.qweight"] == "model-00001-of-00002.safetensors"
+    assert not (saved / "model-00002-of-00002.safetensors").exists()
+    with safe_open(str(saved / rewritten[0]), framework="pt", device="cpu") as handler:
+        assert set(handler.keys()) == {"embed_tokens.qweight", "final_norm.weight"}
+    with safe_open(str(source / rewritten[0]), framework="pt", device="cpu") as handler:
+        assert set(handler.keys()) == {"embed_tokens.weight", "final_norm.weight"}
+
+
+def test_model_save_routes_embedding_only_lifecycle_with_metadata(tmp_path):
+    model = BaseQModel.__new__(BaseQModel)
+    nn.Module.__init__(model)
+    model.quantized = True
+    model._model_free_weight_only_embeddings_only = True
+    model.quant_override_files = {}
+    model.quant_region_timer = None
+    captured = {}
+    model.save_quantized_embeddings = lambda **kwargs: captured.update(kwargs)
+    model.save_quantized = lambda **_kwargs: (_ for _ in ()).throw(
+        AssertionError("embedding-only lifecycle must not use the full save path")
+    )
+
+    model.save(str(tmp_path / "saved"), meta_quantizer="test-quantizer:1.0")
+
+    assert captured == {
+        "save_dir": str(tmp_path / "saved"),
+        "safetensors_metadata": None,
+        "max_shard_size": "4GB",
+        "meta_quantizer": "test-quantizer:1.0",
+    }

--- a/tests/test_weight_only_looper.py
+++ b/tests/test_weight_only_looper.py
@@ -6,6 +6,7 @@ from contextlib import nullcontext
 from types import SimpleNamespace
 
 import torch
+import pytest
 from torch import nn
 
 import gptqmodel.looper.weight_only_looper as weight_only_looper_module
@@ -285,6 +286,62 @@ def test_weight_only_looper_quantizes_input_and_lm_head_embeddings_only(monkeypa
     assert qcfg.offload_to_disk is False
     assert qcfg.dynamic["embed_tokens"] == {"bits": 8, "group_size": 32}
     assert qcfg.dynamic["lm_head"] == {"bits": 8, "group_size": 32}
+
+
+@pytest.mark.parametrize(
+    "embed_quant_config",
+    [
+        QuantizeEmbedConfig(embed_quant_mode=QuantizeEmbed.BOTH),
+        QuantizeEmbedConfig(),
+    ],
+)
+def test_weight_only_looper_rejects_tied_embedding_parameters_before_quantization(
+    monkeypatch,
+    embed_quant_config,
+):
+    qcfg = RTNConfig(bits=4, group_size=4, offload_to_disk=False, device="cpu")
+    qcfg.lm_head = False
+    processor = _FakeProcessor(qcfg)
+    model = _FakeQModel(qcfg)
+    model.model.lm_head.weight = model.model.embed_tokens.weight
+
+    monkeypatch.setattr(weight_only_looper_module, "log", _FakeLogger())
+
+    looper = WeightOnlyLooper(model=model, processor=processor, embed_quant_config=embed_quant_config)
+    with pytest.raises(NotImplementedError, match="shared weight parameter"):
+        looper.loop()
+
+    assert processor.quantized == []
+    assert processor.finalize_called is False
+    assert not hasattr(model, "_embedding_replacement_prefixes")
+    assert not hasattr(model, "_model_free_weight_only_embeddings_only")
+    assert qcfg.dynamic is None
+
+
+def test_weight_only_looper_deduplicates_same_embedding_parameter(monkeypatch):
+    qcfg = RTNConfig(bits=4, group_size=4, offload_to_disk=False, device="cpu")
+    qcfg.lm_head = False
+    processor = _FakeProcessor(qcfg)
+    model = _FakeQModel(qcfg)
+    model.get_output_embeddings_name = model.get_input_embeddings_name
+    model.get_output_embeddings = model.get_input_embeddings
+
+    monkeypatch.setattr(weight_only_looper_module, "log", _FakeLogger())
+    monkeypatch.setattr(
+        weight_only_looper_module,
+        "get_layers_with_prefixes",
+        lambda _model, _nodes: (list(model.model.layers), ["layers.0", "layers.1"]),
+    )
+
+    looper = WeightOnlyLooper(
+        model=model,
+        processor=processor,
+        embed_quant_config=QuantizeEmbedConfig(embed_quant_mode=QuantizeEmbed.BOTH),
+    )
+    looper.loop()
+
+    assert processor.quantized == ["embed_tokens"]
+    assert model._embedding_replacement_prefixes == {"embed_tokens"}
 
 
 def test_weight_only_looper_quantizes_embeddings_and_regular_modules(monkeypatch):

--- a/tests/test_weight_only_looper.py
+++ b/tests/test_weight_only_looper.py
@@ -9,10 +9,10 @@ import torch
 from torch import nn
 
 import gptqmodel.looper.weight_only_looper as weight_only_looper_module
+from gptqmodel.looper.named_module import NamedModule
 from gptqmodel.looper.weight_only_looper import WeightOnlyLooper
 from gptqmodel.looper.weight_only_processor import WeightOnlyProcessor
-from gptqmodel.looper.named_module import NamedModule
-from gptqmodel.quantization.config import RTNConfig, VramStrategy
+from gptqmodel.quantization.config import QuantizeEmbed, QuantizeEmbedConfig, RTNConfig, VramStrategy
 
 
 class _FakeProgress:
@@ -131,6 +131,8 @@ class _TinyModel(nn.Module):
             tie_word_embeddings=False,
         )
         self.layers = nn.ModuleList([_TinyLayer(), _TinyLayer()])
+        self.embed_tokens = nn.Embedding(8, 4)
+        self.lm_head = nn.Linear(4, 8, bias=False)
 
 
 class _FakeQModel:
@@ -156,6 +158,18 @@ class _FakeQModel:
 
     def post_quantize(self, module):
         return module
+
+    def get_input_embeddings_name(self):
+        return "embed_tokens"
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def get_output_embeddings_name(self):
+        return "lm_head"
+
+    def get_output_embeddings(self):
+        return self.model.lm_head
 
 
 class _FakeProcessor:
@@ -240,6 +254,63 @@ def test_weight_only_looper_reports_logbar_progress(monkeypatch):
     ]
     assert fake_logger.progresses[1].closed is True
     assert fake_logger.progresses[2].closed is True
+
+
+def test_weight_only_looper_quantizes_input_and_lm_head_embeddings_only(monkeypatch):
+    qcfg = RTNConfig(bits=4, group_size=4, offload_to_disk=True, device="cpu")
+    qcfg.lm_head = False
+    fake_logger = _FakeLogger()
+    processor = _FakeProcessor(qcfg)
+    model = _FakeQModel(qcfg)
+
+    monkeypatch.setattr(weight_only_looper_module, "log", fake_logger)
+    monkeypatch.setattr(
+        weight_only_looper_module,
+        "get_layers_with_prefixes",
+        lambda _model, _nodes: (list(model.model.layers), ["layers.0", "layers.1"]),
+    )
+
+    looper = WeightOnlyLooper(
+        model=model,
+        processor=processor,
+        embed_quant_config=QuantizeEmbedConfig(embed_quant_mode=QuantizeEmbed.BOTH),
+    )
+    total_log = looper.loop()
+
+    assert total_log == {"fake_weight_only": []}
+    assert processor.quantized == ["embed_tokens", "lm_head"]
+    assert processor.memory_calls == []
+    assert model._embedding_replacement_prefixes == {"embed_tokens", "lm_head"}
+    assert model._model_free_weight_only_embeddings_only is True
+    assert qcfg.offload_to_disk is False
+    assert qcfg.dynamic["embed_tokens"] == {"bits": 8, "group_size": 32}
+    assert qcfg.dynamic["lm_head"] == {"bits": 8, "group_size": 32}
+
+
+def test_weight_only_looper_quantizes_embeddings_and_regular_modules(monkeypatch):
+    qcfg = RTNConfig(bits=4, group_size=4, offload_to_disk=False, device="cpu")
+    qcfg.lm_head = False
+    fake_logger = _FakeLogger()
+    processor = _FakeProcessor(qcfg)
+    model = _FakeQModel(qcfg)
+
+    monkeypatch.setattr(weight_only_looper_module, "log", fake_logger)
+    monkeypatch.setattr(
+        weight_only_looper_module,
+        "get_layers_with_prefixes",
+        lambda _model, _nodes: (list(model.model.layers), ["layers.0", "layers.1"]),
+    )
+
+    looper = WeightOnlyLooper(
+        model=model,
+        processor=processor,
+        embed_quant_config=QuantizeEmbedConfig(embed_quant_mode=QuantizeEmbed.INPUT, embed_only=False),
+    )
+    looper.loop()
+
+    assert processor.quantized == ["embed_tokens", "layers.0.linear", "layers.1.linear"]
+    assert model._embedding_replacement_prefixes == {"embed_tokens"}
+    assert model._model_free_weight_only_embeddings_only is False
 
 
 def test_weight_only_processor_reports_dynamic_exclusions():

--- a/tests/test_weight_only_looper.py
+++ b/tests/test_weight_only_looper.py
@@ -344,6 +344,56 @@ def test_weight_only_looper_deduplicates_same_embedding_parameter(monkeypatch):
     assert model._embedding_replacement_prefixes == {"embed_tokens"}
 
 
+@pytest.mark.parametrize(
+    ("embed_quant_mode", "expected_quantized", "expected_progress"),
+    [
+        (
+            QuantizeEmbed.OUTPUT,
+            ["lm_head", "layers.0.linear", "layers.1.linear"],
+            [0, 1, 2],
+        ),
+        (
+            QuantizeEmbed.BOTH,
+            ["embed_tokens", "lm_head", "layers.0.linear", "layers.1.linear"],
+            [0, 1, 2, 3],
+        ),
+    ],
+)
+def test_weight_only_looper_does_not_requantize_lm_head_embedding_in_layer_loop(
+    monkeypatch,
+    embed_quant_mode,
+    expected_quantized,
+    expected_progress,
+):
+    qcfg = RTNConfig(bits=4, group_size=4, offload_to_disk=False, device="cpu")
+    qcfg.lm_head = True
+    fake_logger = _FakeLogger()
+    processor = _FakeProcessor(qcfg)
+    model = _FakeQModel(qcfg)
+    model.lm_head = model.model.lm_head
+
+    monkeypatch.setattr(weight_only_looper_module, "log", fake_logger)
+    monkeypatch.setattr(
+        weight_only_looper_module,
+        "get_layers_with_prefixes",
+        lambda _model, _nodes: (list(model.model.layers), ["layers.0", "layers.1"]),
+    )
+
+    looper = WeightOnlyLooper(
+        model=model,
+        processor=processor,
+        embed_quant_config=QuantizeEmbedConfig(embed_quant_mode=embed_quant_mode, embed_only=False),
+    )
+    looper.loop()
+
+    assert processor.quantized == expected_quantized
+    assert processor.quantized.count("lm_head") == 1
+    assert processor.memory_calls == [0, 1]
+    assert processor.finalize_called is True
+    assert fake_logger.iterable == expected_progress
+    assert all("quantizing lm_head" not in title for title in fake_logger.progress.titles)
+
+
 def test_weight_only_looper_quantizes_embeddings_and_regular_modules(monkeypatch):
     qcfg = RTNConfig(bits=4, group_size=4, offload_to_disk=False, device="cpu")
     qcfg.lm_head = False


### PR DESCRIPTION
## Summary

- add public input/output embedding quantization configuration
- support embedding requantization while preserving the compatibility argument
- route embedding-only quantization through complete checkpoint saves
- cover LM-head, input embedding, mixed-module, requantization, and save behavior

## Validation

- `pytest -q tests/test_embed_quant_api.py tests/test_embedding_save_lifecycle.py tests/test_weight_only_looper.py` — 22 passed
- `ruff check tests/test_embed_quant_api.py tests/test_embedding_save_lifecycle.py tests/test_weight_only_looper.py gptqmodel/looper/weight_only_looper.py gptqmodel/models/base.py gptqmodel/models/writer.py gptqmodel/quantization/config.py --output-format concise` — passed
- `git diff --check` — passed