### PR TITLE
[MODEL] Add `locateanything` quantization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Latest News 🗞️🚀
 
-* 08/26/2026 7.4.0-dev `main`: ✨ Added NVIDIA `LocateAnything-3B` multimodal perception and OCR quantization support.
+* 08/26/2026 7.4.0-dev `main`: ✨ Added NVIDIA `LocateAnything-3B` quantization support.
 * 08/25/2026 7.4.0-dev `main`: ✨ Added `lm_head` and embedding quantization lifecycle.
 * 08/24/2026 7.4.0-dev `main`: ✨ Added Baidu `Unlimited-OCR` quantization support.
 * 08/20/2026 7.4.0-dev `main`: ✨ Added `deepseek_v32` / DeepSeek V3.2; `muse_glimmer` / Muse Glimmer multimodal; `mage_vl` / Mage-VL; Cohere `North Micro Vision` (`cohere_compass`); `axk2` (A.X-K2) model support.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 ## Latest News 🗞️🚀
 
+* 08/26/2026 7.4.0-dev `main`: ✨ Added NVIDIA `LocateAnything-3B` multimodal perception and OCR quantization support.
 * 08/25/2026 7.4.0-dev `main`: ✨ Added `lm_head` and embedding quantization lifecycle.
 * 08/24/2026 7.4.0-dev `main`: ✨ Added Baidu `Unlimited-OCR` quantization support.
 * 08/20/2026 7.4.0-dev `main`: ✨ Added `deepseek_v32` / DeepSeek V3.2; `muse_glimmer` / Muse Glimmer multimodal; `mage_vl` / Mage-VL; Cohere `North Micro Vision` (`cohere_compass`); `axk2` (A.X-K2) model support.
@@ -269,7 +270,7 @@ Selected public references where teams or companies explicitly mention GPT-QMode
 | MiniMax M2/M3                 | ✅ | AfMoE                           | ✅ | Bailing-MoE                | ✅ | LFM2 / LFM2-VL / LFM2-MoE       | ✅ | Marin                  | ✅ |
 | InternVL Chat                 | ✅ | Laguna                          | ✅ | Mimo / Mimo V2             | ✅ | Zamba / Zamba2                  | ✅ | Intern S1 / S2 Preview             | ✅ |
 | HunYuan V1 Dense / MoE        | ✅ | HY-V3                           | ✅ | Inkling           | ✅ | Solar Open / Open 2                    | ✅ | North Micro Vision | ✅ |
-| Mage-VL                       | ✅ | Unlimited-OCR                   | ✅ |                            |    |                                 |    |                        |    |
+| Mage-VL                       | ✅ | Unlimited-OCR                   | ✅ | LocateAnything             | ✅ |                                 |    |                        |    |
 | Muse Glimmer                  | ✅ |                                 |    |                            |    |                                 |    |                        |    |
 | SmolLM3                       | ✅ |                                 |    |                            |    |                                 |    |                        |    |
 

--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -138,6 +138,7 @@ from .definitions.llama import LlamaQModel  # noqa: E402
 from .definitions.llama4 import Llama4QModel, Llama4TextQModel  # noqa: E402
 from .definitions.llava_qwen2 import LlavaQwen2QModel  # noqa: E402
 from .definitions.longcat_flash import LongCatFlashQModel  # noqa: E402
+from .definitions.locateanything import LocateAnythingQModel  # noqa: E402
 from .definitions.mage_vl import MageVLQModel  # noqa: E402
 from .definitions.mimo import MimoQModel  # noqa: E402
 from .definitions.mimo_v2 import MimoV2QModel  # noqa: E402
@@ -352,6 +353,7 @@ MODEL_MAP = {
     "solar_open2": SolarOpen2QModel,
     "gpt_oss": GPTOSSGPTQ,
     "longcat_flash": LongCatFlashQModel,
+    "locateanything": LocateAnythingQModel,
     "llava_qwen2": LlavaQwen2QModel,
     "nemotron_h": NemotronHQModel,
     "nemotron_h_puzzle": NemotronHPuzzleQModel,

--- a/gptqmodel/models/definitions/__init__.py
+++ b/gptqmodel/models/definitions/__init__.py
@@ -108,6 +108,7 @@ from .zamba import ZambaQModel
 from .zamba2 import Zamba2QModel
 from .pangu_alpha import PanguAlphaQModel
 from .longcat_flash import LongCatFlashQModel
+from .locateanything import LocateAnythingQModel
 from .apertus import ApertusQModel
 from .axk2 import AXK2QModel
 from .klear import KlearQModel

--- a/gptqmodel/models/definitions/locateanything.py
+++ b/gptqmodel/models/definitions/locateanything.py
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import torch
+from transformers import AutoModel, AutoProcessor
+
+from ...utils.calibration import batched
+from ...utils.model import MODALITY, move_to
+from ...utils.offload import offload_to_disk
+from .._const import CPU
+from ..base import BaseQModel
+
+
+class LocateAnythingQModel(BaseQModel):
+    """Quantize LocateAnything's Qwen decoder while keeping its vision path dense."""
+
+    loader = AutoModel
+
+    require_trust_remote_code = True
+    # Loading is on demand because Transformers 5 serializes this legacy
+    # processor into a shape that its own remote constructor cannot reload.
+    require_load_processor = False
+    support_batch_quantize = False
+    require_pkgs = ["peft", "decord", "lmdb"]
+
+    out_of_model_tensors = {
+        "files": [
+            "preprocessor_config.json",
+            "processor_config.json",
+            "chat_template.json",
+        ],
+    }
+
+    modality = [MODALITY.TEXT, MODALITY.IMAGE_TO_TEXT]
+
+    lm_head = "language_model.lm_head"
+    pre_lm_head_norm_module = "language_model.model.norm"
+
+    module_tree = [
+        "language_model",
+        "model",
+        "layers",
+        "#",
+        {
+            "input_layernorm": ("input_layernorm:!",),
+            "self_attn": ("q_proj:0", "k_proj:0", "v_proj:0", "o_proj:1"),
+            "post_attention_layernorm": ("post_attention_layernorm:!",),
+            "mlp": ("gate_proj:0", "up_proj:0", "down_proj:1"),
+        },
+    ]
+
+    @classmethod
+    def get_base_modules(cls, model):
+        base_modules = super().get_base_modules(model)
+        for name, _module in model.named_children():
+            if name != "language_model" and name not in base_modules:
+                base_modules.append(name)
+        return base_modules
+
+    def load_processor(self):
+        return AutoProcessor.from_pretrained(
+            self.model_local_path,
+            trust_remote_code=True,
+        )
+
+    def pre_quantize_generate_hook_start(self):
+        text_model = self.model.language_model.model
+        text_model.embed_tokens = self.pre_quantize(text_model.embed_tokens)
+        self.model.vision_model = self.pre_quantize(self.model.vision_model)
+        self.model.mlp1 = self.pre_quantize(self.model.mlp1)
+
+    def pre_quantize_generate_hook_end(self):
+        text_model = self.model.language_model.model
+        modules = (
+            (text_model, text_model.embed_tokens),
+            (self.model, self.model.vision_model),
+            (self.model, self.model.mlp1),
+        )
+        if self.quantize_config.offload_to_disk:
+            for parent, module in modules:
+                offload_to_disk(
+                    model=parent,
+                    module=module,
+                    disk_path=self.quantize_config.offload_to_disk_path,
+                )
+            return
+
+        text_model.embed_tokens = move_to(text_model.embed_tokens, device=CPU)
+        self.model.vision_model = move_to(self.model.vision_model, device=CPU)
+        self.model.mlp1 = move_to(self.model.mlp1, device=CPU)
+
+    def prepare_dataset(
+        self,
+        calibration_dataset,
+        batch_size: int = 1,
+        **kwargs,
+    ) -> list[Dict[str, Any]]:
+        del batch_size, kwargs
+        processor = self.load_processor()
+        calibration_data = []
+        for batch in batched(calibration_dataset, 1):
+            messages = batch[0]
+            text = processor.py_apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=False,
+            )
+            images, videos = processor.process_vision_info(messages)
+            calibration_data.append(
+                processor(
+                    text=[text],
+                    images=images,
+                    videos=videos,
+                    return_tensors="pt",
+                )
+            )
+        del processor
+        return calibration_data
+
+    def move_input_capture_example(
+        self,
+        example: Dict[str, Any],
+        data_device: torch.device,
+    ) -> Dict[str, Any]:
+        example = super().move_input_capture_example(example, data_device)
+        pixel_values = example.get("pixel_values")
+        if not torch.is_tensor(pixel_values):
+            return example
+
+        vision_model = self.model.vision_model
+        first_parameter = next(vision_model.parameters(), None)
+        vision_device = getattr(first_parameter, "device", pixel_values.device)
+        vision_dtype = getattr(vision_model, "dtype", None)
+        if not isinstance(vision_dtype, torch.dtype):
+            vision_dtype = getattr(first_parameter, "dtype", None)
+        if isinstance(vision_dtype, torch.dtype):
+            example["pixel_values"] = pixel_values.to(
+                device=vision_device,
+                dtype=vision_dtype,
+            )
+        image_grid_hws = example.get("image_grid_hws")
+        if image_grid_hws is not None:
+            example["image_grid_hws"] = torch.as_tensor(
+                image_grid_hws,
+                device=vision_device,
+                dtype=torch.int32,
+            )
+        return example
+
+    def run_input_capture(
+        self,
+        example: Dict[str, Any],
+        use_cache: bool,
+        data_device: torch.device,
+    ):
+        del data_device
+        input_ids = example["input_ids"]
+        vit_embeds = self.model.extract_feature(
+            example["pixel_values"],
+            example["image_grid_hws"],
+        )
+        visual_features = None
+        if vit_embeds:
+            visual_features = self.model.mlp1(torch.cat(vit_embeds, dim=0))
+
+        # The outer remote-code forward replaces image-token embeddings and
+        # then calls the Qwen decoder with only inputs_embeds. Its SDPA mask
+        # path nevertheless indexes input_ids. The bundled decoder already
+        # exposes the equivalent visual_features path, which preserves
+        # input_ids and avoids that remote-code inconsistency during capture.
+        return self.model.language_model(
+            input_ids=input_ids,
+            visual_features=visual_features,
+            image_token_index=self.model.image_token_index,
+            attention_mask=example.get("attention_mask"),
+            labels=example.get("labels"),
+            use_cache=use_cache,
+        )
+
+    @staticmethod
+    def _has_visual_inputs(inputs: Any, kwargs: Dict[str, Any]) -> bool:
+        if kwargs.get("pixel_values") is not None:
+            return True
+        return bool(
+            hasattr(inputs, "get")
+            and inputs.get("pixel_values") is not None
+        )
+
+    def forward(self, *args, **kwargs):
+        # The checkpoint's multimodal wrapper requires pixel_values even for a
+        # text-only call. Language evaluations should exercise the same
+        # quantized Qwen decoder directly when no visual input is supplied.
+        if not self._has_visual_inputs(None, kwargs):
+            return self.model.language_model(*args, **kwargs)
+        return self.model(*args, **kwargs)
+
+    def generate(self, inputs=None, **kwargs):
+        if self._has_visual_inputs(inputs, kwargs):
+            return super().generate(inputs=inputs, **kwargs)
+
+        with torch.inference_mode():
+            if kwargs.get("pad_token_id") is None and self.tokenizer is not None:
+                kwargs["pad_token_id"] = self.tokenizer.pad_token_id
+
+            if isinstance(inputs, str) or (
+                isinstance(inputs, list) and all(isinstance(item, str) for item in inputs)
+            ):
+                inputs = self.tokenizer(
+                    inputs,
+                    return_tensors="pt",
+                    padding=True,
+                    padding_side="left",
+                ).to(self.model.language_model.device)
+
+            if hasattr(inputs, "get") and not torch.is_tensor(inputs):
+                return self.model.language_model.generate(**inputs, **kwargs)
+            return self.model.language_model.generate(inputs=inputs, **kwargs)
+
+
+__all__ = ["LocateAnythingQModel"]

--- a/gptqmodel/utils/hf.py
+++ b/gptqmodel/utils/hf.py
@@ -1295,6 +1295,18 @@ def _normalize_remote_code_config_compat(config: Any) -> None:
         if not hasattr(config, "sliding_window") and hasattr(config, "sliding_window_size"):
             config.sliding_window = config.sliding_window_size
 
+    if model_type_lower == "locateanything":
+        # Transformers 5 migrates Qwen2's legacy rope_theta field into
+        # rope_parameters, while LocateAnything's bundled Qwen2 implementation
+        # still reads config.rope_theta directly.
+        text_config = getattr(config, "text_config", None)
+        if text_config is not None and not hasattr(text_config, "rope_theta"):
+            rope_parameters = getattr(text_config, "rope_parameters", None)
+            if isinstance(rope_parameters, dict):
+                rope_theta = rope_parameters.get("rope_theta")
+                if rope_theta is not None:
+                    text_config.rope_theta = rope_theta
+
     if model_type_lower == "hymba":
         # hymba uses Flex by default;
         # however, `modeling_hymba` has not yet been adapted to support the latest version of PyTorch Flex.
@@ -1458,6 +1470,8 @@ def prepare_remote_model_init_compat(model_id_or_path: Optional[str], config: An
 
     auto_map = getattr(config, "auto_map", None) or {}
     class_ref = auto_map.get("AutoModelForCausalLM")
+    if not isinstance(class_ref, str) and getattr(config, "model_type", None) == "locateanything":
+        class_ref = auto_map.get("AutoModel")
     if not isinstance(class_ref, str):
         return
 
@@ -1480,6 +1494,25 @@ def prepare_remote_model_init_compat(model_id_or_path: Optional[str], config: An
     with _MONKEY_PATCH_LOCK:
         if outer_model_cls is not None:
             try_patch_legacy_flash_attn_flag(outer_model_cls)
+
+        if getattr(config, "model_type", None) == "locateanything":
+            # LocateAnything bundles a second remote Qwen model class. Patch
+            # both the outer wrapper and nested decoder bases before either is
+            # instantiated by AutoModel.from_config/from_pretrained.
+            try_patch_legacy_attn_adjust_kwargs(outer_model_cls)
+            for module_name, module in list(sys.modules.items()):
+                if not (
+                    module_name == module_root
+                    or module_name.startswith(f"{module_root}.")
+                ):
+                    continue
+                for candidate in vars(module).values():
+                    if (
+                        isinstance(candidate, type)
+                        and candidate.__module__.startswith(module_root)
+                    ):
+                        try_patch_legacy_flash_attn_flag(candidate)
+                        try_patch_legacy_attn_adjust_kwargs(candidate)
 
         if getattr(config, "model_type", None) == "internvl_chat" and intern_vit_module is not None:
             encoder_cls = getattr(intern_vit_module, "InternVisionEncoder", None)
@@ -1780,6 +1813,65 @@ def try_patch_legacy_flash_attn_flag(model_cls):
 
         flash_attn_2_val = base_with_flag.__dict__["_supports_flash_attn_2"]
         setattr(base_with_flag, "_supports_flash_attn", bool(flash_attn_2_val))
+
+def try_patch_legacy_attn_adjust_kwargs(model_cls):
+    with _MONKEY_PATCH_LOCK:
+        if model_cls is None or not isinstance(model_cls, type):
+            return
+        if model_cls.__dict__.get("_gptqmodel_attn_adjust_kwargs_patch", False):
+            return
+
+        attn_adjust = getattr(model_cls, "_check_and_adjust_attn_implementation", None)
+        if not callable(attn_adjust):
+            return
+
+        try:
+            attn_adjust_sig = inspect.signature(attn_adjust)
+        except (TypeError, ValueError):
+            return
+
+        params = attn_adjust_sig.parameters.values()
+        accepts_kwargs = any(param.kind == inspect.Parameter.VAR_KEYWORD for param in params)
+        if accepts_kwargs or "allow_all_kernels" in attn_adjust_sig.parameters:
+            return
+
+        original_attn_adjust = attn_adjust
+
+        def attn_adjust_compat(self, *args, **kwargs):
+            kwargs.pop("allow_all_kernels", None)
+            from transformers import utils as transformers_utils
+
+            config = getattr(self, "config", None)
+            is_locateanything = getattr(config, "model_type", None) == "locateanything"
+            flash_available = transformers_utils.is_flash_attn_2_available()
+            if is_locateanything:
+                if args and args[0] not in ("magi", "sdpa"):
+                    args = ("sdpa", *args[1:])
+                elif kwargs.get("attn_implementation") not in (None, "magi", "sdpa"):
+                    kwargs["attn_implementation"] = "sdpa"
+            elif not flash_available:
+                if args and args[0] == "flash_attention_2":
+                    args = ("sdpa", *args[1:])
+                elif kwargs.get("attn_implementation") == "flash_attention_2":
+                    kwargs["attn_implementation"] = "sdpa"
+
+            if is_locateanything:
+                # Transformers recursively propagates the top-level Flash
+                # override to composite sub-configs. MoonViT does not support
+                # it, and LocateAnything's bundled Qwen forward only implements
+                # its mask path for `magi` and `sdpa` despite registering Flash
+                # attention layers. Keep the complete checkpoint on SDPA.
+                for sub_config_name in ("vision_config", "text_config"):
+                    sub_config = getattr(config, sub_config_name, None)
+                    if sub_config is not None:
+                        sub_config._attn_implementation = "sdpa"
+
+            adjusted = original_attn_adjust(self, *args, **kwargs)
+
+            return adjusted
+
+        model_cls._check_and_adjust_attn_implementation = attn_adjust_compat
+        model_cls._gptqmodel_attn_adjust_kwargs_patch = True
 
 
 def load_tokenizer(tokenizer_or_path, *, model_config: Any = None, **kwargs):

--- a/tests/models/ovis/image_to_test_dataset.py
+++ b/tests/models/ovis/image_to_test_dataset.py
@@ -4,14 +4,15 @@
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 from gptqmodel.models.definitions.base_qwen2_5_omni import BaseQwen2_5_OmniGPTQ
 from gptqmodel.models.definitions.base_qwen2_vl import BaseQwen2VLGPTQ
+from gptqmodel.models.definitions.base_qwen3_vl import BaseQwen3VLGPTQ
 from gptqmodel.models.definitions.cohere_compass import CohereCompassQModel
 from gptqmodel.models.definitions.deepseek_ocr2 import DeepSeekOCR2QModel
 from gptqmodel.models.definitions.deepseek_vl import DeepSeekVLQModel
 from gptqmodel.models.definitions.deepseek_vl_v2 import DeepSeekVLV2QModel
 from gptqmodel.models.definitions.ernie4_5_vl_moe import Ernie4_5_VLMoeQModel
 from gptqmodel.models.definitions.hunyuan_vl import HunYuanVLQModel
-from gptqmodel.models.definitions.intern_s2_preview import InternS2PreviewQModel
 from gptqmodel.models.definitions.inkling import InklingMMQModel
+from gptqmodel.models.definitions.intern_s2_preview import InternS2PreviewQModel
 from gptqmodel.models.definitions.interns1 import InternS1QModel
 from gptqmodel.models.definitions.internvl_chat import InternVLChatQModel
 from gptqmodel.models.definitions.lfm2_vl import LFM2VLQModel
@@ -25,7 +26,6 @@ from gptqmodel.models.definitions.ovis2 import Ovis2QModel
 from gptqmodel.models.definitions.ovis2_5 import Ovis2_5QModel
 from gptqmodel.models.definitions.ovis2_6_moe import Ovis2_6_MoeQModel
 from gptqmodel.models.definitions.unlimited_ocr import UnlimitedOCRQModel
-from gptqmodel.models.definitions.base_qwen3_vl import BaseQwen3VLGPTQ
 
 
 def format_ovis_dataset(image, assistant):

--- a/tests/models/ovis/image_to_test_dataset.py
+++ b/tests/models/ovis/image_to_test_dataset.py
@@ -14,6 +14,7 @@ from gptqmodel.models.definitions.inkling import InklingMMQModel
 from gptqmodel.models.definitions.interns1 import InternS1QModel
 from gptqmodel.models.definitions.internvl_chat import InternVLChatQModel
 from gptqmodel.models.definitions.lfm2_vl import LFM2VLQModel
+from gptqmodel.models.definitions.locateanything import LocateAnythingQModel
 from gptqmodel.models.definitions.minicpm_o import MiniCPMOQModel
 from gptqmodel.models.definitions.minicpmv import MiniCPMVQModel
 from gptqmodel.models.definitions.minicpmv_4_6 import MiniCPMV4_6QModel
@@ -112,6 +113,19 @@ def format_unlimited_ocr_dataset(image, assistant):
     }
 
 
+def format_locateanything_dataset(image, assistant):
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": image},
+                {"type": "text", "text": "Describe this image and transcribe any visible text."},
+            ],
+        },
+        {"role": "assistant", "content": assistant},
+    ]
+
+
 def format_qwen2_5_omni_dataset(image, assistant):
     return [
         {
@@ -160,6 +174,10 @@ def prepare_unlimited_ocr_dataset(n_sample: int = 20) -> list[dict]:
     return prepare_dataset(format_unlimited_ocr_dataset, n_sample=n_sample)
 
 
+def prepare_locateanything_dataset(n_sample: int = 20) -> list[list[dict]]:
+    return prepare_dataset(format_locateanything_dataset, n_sample=n_sample)
+
+
 def get_calib_dataset(model):
     if isinstance(model, OvisQModel):
         return prepare_dataset(format_ovis_dataset, n_sample=20)
@@ -203,5 +221,8 @@ def get_calib_dataset(model):
 
     if isinstance(model, UnlimitedOCRQModel):
         return prepare_unlimited_ocr_dataset(n_sample=20)
+
+    if isinstance(model, LocateAnythingQModel):
+        return prepare_locateanything_dataset(n_sample=20)
 
     raise NotImplementedError(f"Unsupported MODEL: {model.__class__}")

--- a/tests/models/test_locateanything.py
+++ b/tests/models/test_locateanything.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from model_test import ModelTest
+from ovis import image_to_test_dataset
+
+
+def test_prepare_locateanything_dataset_reuses_shared_dataset(monkeypatch):
+    calls = {}
+
+    def fake_prepare_dataset(format_func, n_sample):
+        calls["format_func"] = format_func
+        calls["n_sample"] = n_sample
+        return [format_func("image-url", "caption")]
+
+    monkeypatch.setattr(image_to_test_dataset, "prepare_dataset", fake_prepare_dataset)
+
+    dataset = image_to_test_dataset.prepare_locateanything_dataset(n_sample=3)
+
+    assert calls == {
+        "format_func": image_to_test_dataset.format_locateanything_dataset,
+        "n_sample": 3,
+    }
+    assert dataset == [
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": "image-url"},
+                    {
+                        "type": "text",
+                        "text": "Describe this image and transcribe any visible text.",
+                    },
+                ],
+            },
+            {"role": "assistant", "content": "caption"},
+        ]
+    ]
+
+
+class TestLocateAnything(ModelTest):
+    NATIVE_MODEL_ID = "/monster/data/model/LocateAnything-3B"  # nvidia/LocateAnything-3B
+    TRUST_REMOTE_CODE = True
+    # The bundled Qwen forward implements its mask path for SDPA (and Magi),
+    # but rejects both eager and FlashAttention 2. The compatibility shim maps
+    # ModelTest's eager request to SDPA for this checkpoint.
+    USE_FLASH_ATTN = False
+    EVAL_BATCH_SIZE = 16
+    EVAL_TASKS_SLOW = {
+        "arc_challenge": {
+            "chat_template": False,
+            "acc": {"value": 0.2099, "floor_pct": 0.04},
+            "acc_norm": {"value": 0.2688, "floor_pct": 0.04},
+        },
+    }
+    EVAL_TASKS_FAST = ModelTest.derive_fast_eval_tasks(EVAL_TASKS_SLOW)
+
+    def test_locateanything(self):
+        self.quantize_and_evaluate()

--- a/tests/test_locateanything_support.py
+++ b/tests/test_locateanything_support.py
@@ -1,0 +1,293 @@
+import sys
+from types import ModuleType, SimpleNamespace
+
+import torch
+import transformers
+from torch import nn
+from transformers import AutoModel
+
+from gptqmodel.models import auto
+from gptqmodel.models.definitions.locateanything import LocateAnythingQModel
+from gptqmodel.quantization import QuantizeConfig
+from gptqmodel.utils.hf import normalize_hf_config_compat, prepare_remote_model_init_compat
+from gptqmodel.utils.model import MODALITY
+
+
+def test_locateanything_model_type_selects_definition(monkeypatch):
+    fake_config = SimpleNamespace(model_type="locateanything")
+    monkeypatch.setattr(auto, "resolve_trust_remote_code", lambda path, trust_remote_code: True)
+    monkeypatch.setattr(auto, "patch_remote_code_before_config_load", lambda path: None)
+    monkeypatch.setattr(auto.AutoConfig, "from_pretrained", lambda *args, **kwargs: fake_config)
+
+    assert (
+        auto.check_and_get_model_definition(
+            "/tmp/LocateAnything-3B",
+            trust_remote_code=True,
+        )
+        is LocateAnythingQModel
+    )
+
+
+def test_locateanything_definition_contract():
+    assert LocateAnythingQModel.loader is AutoModel
+    assert LocateAnythingQModel.require_trust_remote_code is True
+    assert LocateAnythingQModel.require_load_processor is False
+    assert LocateAnythingQModel.out_of_model_tensors == {
+        "files": [
+            "preprocessor_config.json",
+            "processor_config.json",
+            "chat_template.json",
+        ],
+    }
+    assert LocateAnythingQModel.support_batch_quantize is False
+    assert LocateAnythingQModel.modality == [MODALITY.TEXT, MODALITY.IMAGE_TO_TEXT]
+    assert LocateAnythingQModel.lm_head == "language_model.lm_head"
+    assert LocateAnythingQModel.pre_lm_head_norm_module == "language_model.model.norm"
+    assert LocateAnythingQModel.extract_layers_node() == ["language_model.model.layers"]
+    assert LocateAnythingQModel.simple_layer_modules(
+        model_config=SimpleNamespace(),
+        quantize_config=QuantizeConfig(),
+    ) == [
+        ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj"],
+        ["self_attn.o_proj"],
+        ["mlp.gate_proj", "mlp.up_proj"],
+        ["mlp.down_proj"],
+    ]
+
+
+def test_locateanything_config_restores_remote_qwen_rope_theta():
+    text_config = SimpleNamespace(
+        rope_parameters={"rope_type": "default", "rope_theta": 1_000_000.0},
+    )
+    config = SimpleNamespace(
+        model_type="locateanything",
+        text_config=text_config,
+        rope_parameters={"rope_type": "default", "rope_theta": 10_000.0},
+    )
+
+    normalize_hf_config_compat(config, trust_remote_code=True)
+
+    assert text_config.rope_theta == 1_000_000.0
+
+
+def test_locateanything_remote_attention_compat(monkeypatch):
+    calls = []
+    module_root = "transformers_modules.fake_locateanything"
+    outer_module = ModuleType(f"{module_root}.modeling_locateanything")
+    qwen_module = ModuleType(f"{module_root}.modeling_qwen2")
+
+    class DummyOuterModel:
+        _supports_flash_attn_2 = True
+
+        def __init__(self):
+            self.config = SimpleNamespace(
+                model_type="locateanything",
+                vision_config=SimpleNamespace(_attn_implementation="eager"),
+                text_config=SimpleNamespace(_attn_implementation="eager"),
+            )
+
+        def _check_and_adjust_attn_implementation(self, implementation, is_init_check=False):
+            calls.append((implementation, is_init_check))
+            return implementation
+
+    class DummyQwenBase:
+        _supports_flash_attn_2 = True
+
+    class DummyQwenForCausalLM(DummyQwenBase):
+        pass
+
+    DummyOuterModel.__module__ = outer_module.__name__
+    DummyQwenBase.__module__ = qwen_module.__name__
+    DummyQwenForCausalLM.__module__ = qwen_module.__name__
+    outer_module.DummyOuterModel = DummyOuterModel
+    qwen_module.DummyQwenBase = DummyQwenBase
+    qwen_module.DummyQwenForCausalLM = DummyQwenForCausalLM
+
+    monkeypatch.setitem(sys.modules, outer_module.__name__, outer_module)
+    monkeypatch.setitem(sys.modules, qwen_module.__name__, qwen_module)
+    monkeypatch.setattr(transformers.utils, "is_flash_attn_2_available", lambda: True)
+    monkeypatch.setattr(
+        "transformers.dynamic_module_utils.get_class_from_dynamic_module",
+        lambda class_ref, model_id_or_path, **kwargs: DummyOuterModel,
+    )
+    config = SimpleNamespace(
+        model_type="locateanything",
+        auto_map={"AutoModel": "modeling_locateanything.DummyOuterModel"},
+    )
+
+    prepare_remote_model_init_compat("/tmp/LocateAnything-3B", config)
+    model = DummyOuterModel()
+    results = [
+        model._check_and_adjust_attn_implementation(
+            requested,
+            is_init_check=True,
+            allow_all_kernels=False,
+        )
+        for requested in ("eager", "flash_attention_2")
+    ]
+
+    assert results == ["sdpa", "sdpa"]
+    assert calls == [("sdpa", True), ("sdpa", True)]
+    assert model.config.vision_config._attn_implementation == "sdpa"
+    assert model.config.text_config._attn_implementation == "sdpa"
+    assert DummyOuterModel._supports_flash_attn is True
+    assert DummyQwenBase._supports_flash_attn is True
+    assert DummyQwenForCausalLM._supports_flash_attn is True
+    assert getattr(DummyOuterModel, "_gptqmodel_attn_adjust_kwargs_patch", False) is True
+
+
+def _fake_model_tree():
+    text_model = nn.Module()
+    text_model.embed_tokens = nn.Embedding(8, 4)
+    text_model.layers = nn.ModuleList([nn.Linear(4, 4)])
+    text_model.norm = nn.LayerNorm(4)
+
+    language_model = nn.Module()
+    language_model.model = text_model
+    language_model.lm_head = nn.Linear(4, 8, bias=False)
+
+    model = nn.Module()
+    model.language_model = language_model
+    model.vision_model = nn.Linear(4, 4)
+    model.mlp1 = nn.Sequential(nn.Linear(4, 4))
+    return model
+
+
+def test_locateanything_keeps_multimodal_modules_in_base_dtype():
+    model = _fake_model_tree()
+
+    assert set(LocateAnythingQModel.get_base_modules(model)) == {
+        "language_model.lm_head",
+        "language_model.model.embed_tokens",
+        "language_model.model.norm",
+        "vision_model",
+        "mlp1",
+    }
+
+
+def test_locateanything_prepare_dataset_uses_remote_processor(monkeypatch):
+    calls = []
+
+    class FakeProcessor:
+        def py_apply_chat_template(self, messages, **kwargs):
+            calls.append(("template", messages, kwargs))
+            return "rendered prompt"
+
+        def process_vision_info(self, messages):
+            calls.append(("vision", messages))
+            return ["image"], []
+
+        def __call__(self, **kwargs):
+            calls.append(("processor", kwargs))
+            return {"input_ids": torch.tensor([[1, 2]])}
+
+    qmodel = object.__new__(LocateAnythingQModel)
+    monkeypatch.setattr(qmodel, "load_processor", lambda: FakeProcessor())
+    messages = [{"role": "user", "content": [{"type": "image", "image": "url"}]}]
+
+    result = qmodel.prepare_dataset([messages], batch_size=8)
+
+    assert result[0]["input_ids"].tolist() == [[1, 2]]
+    assert calls == [
+        (
+            "template",
+            messages,
+            {"tokenize": False, "add_generation_prompt": False},
+        ),
+        ("vision", messages),
+        (
+            "processor",
+            {
+                "text": ["rendered prompt"],
+                "images": ["image"],
+                "videos": [],
+                "return_tensors": "pt",
+            },
+        ),
+    ]
+
+
+def test_locateanything_text_forward_bypasses_visual_wrapper():
+    class LanguageModel(nn.Module):
+        def forward(self, input_ids=None, **kwargs):
+            return ("text", input_ids, kwargs)
+
+    class OuterModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.language_model = LanguageModel()
+
+        def forward(self, *args, **kwargs):
+            return ("visual", args, kwargs)
+
+    qmodel = object.__new__(LocateAnythingQModel)
+    nn.Module.__init__(qmodel)
+    qmodel.model = OuterModel()
+
+    input_ids = torch.tensor([[1, 2]])
+    assert qmodel(input_ids=input_ids)[0] == "text"
+    assert qmodel(input_ids)[0] == "text"
+    assert qmodel(pixel_values=torch.ones(1), input_ids=input_ids)[0] == "visual"
+
+
+def test_locateanything_move_input_capture_casts_pixels_to_vision_dtype():
+    qmodel = object.__new__(LocateAnythingQModel)
+    nn.Module.__init__(qmodel)
+    qmodel.model = SimpleNamespace(vision_model=nn.Linear(2, 2).to(dtype=torch.bfloat16))
+
+    result = qmodel.move_input_capture_example(
+        {
+            "pixel_values": torch.ones(1, 2, dtype=torch.float32),
+            "image_grid_hws": [[18, 26]],
+        },
+        torch.device("cpu"),
+    )
+
+    assert result["pixel_values"].dtype is torch.bfloat16
+    assert result["image_grid_hws"].dtype is torch.int32
+    assert result["image_grid_hws"].tolist() == [[18, 26]]
+
+
+def test_locateanything_input_capture_uses_decoder_visual_features_path():
+    calls = []
+
+    class LanguageModel(nn.Module):
+        def forward(self, **kwargs):
+            calls.append(kwargs)
+            return "captured"
+
+    class OuterModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.language_model = LanguageModel()
+            self.mlp1 = nn.Identity()
+            self.image_token_index = 42
+
+        def extract_feature(self, pixel_values, image_grid_hws):
+            assert pixel_values.shape == (1, 2)
+            assert image_grid_hws.tolist() == [[1, 2]]
+            return [torch.ones(2, 4)]
+
+    qmodel = object.__new__(LocateAnythingQModel)
+    nn.Module.__init__(qmodel)
+    qmodel.model = OuterModel()
+    input_ids = torch.tensor([[42, 42]])
+    attention_mask = torch.ones_like(input_ids)
+
+    result = qmodel.run_input_capture(
+        {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "pixel_values": torch.ones(1, 2),
+            "image_grid_hws": torch.tensor([[1, 2]], dtype=torch.int32),
+        },
+        use_cache=False,
+        data_device=torch.device("cpu"),
+    )
+
+    assert result == "captured"
+    assert calls[0]["input_ids"] is input_ids
+    assert calls[0]["attention_mask"] is attention_mask
+    assert calls[0]["visual_features"].shape == (2, 4)
+    assert calls[0]["image_token_index"] == 42
+    assert calls[0]["use_cache"] is False


### PR DESCRIPTION
## Summary
- register NVIDIA LocateAnything-3B and quantize its Qwen decoder while keeping the vision path dense
- add multimodal calibration capture, processor artifact preservation, and Transformers remote-code compatibility
- add ARC score regression coverage, focused model tests, and README support notes

## Validation
- ruff check on changed Python files
- pytest -q tests/test_locateanything_support.py
- pytest -q tests/models/test_locateanything.py -k prepare_locateanything
- git diff --check