### PR TITLE
feat: support tile-misaligned 4-bit AWQ Marlin shapes

### DIFF
--- a/gptqmodel/nn_modules/qlinear/marlin_awq.py
+++ b/gptqmodel/nn_modules/qlinear/marlin_awq.py
@@ -18,11 +18,18 @@ from ...utils.backend import BACKEND
 from ...utils.logger import setup_logger
 from ...utils.marlin import (
     apply_awq_marlin_linear,
+    apply_awq_marlin_linear_padded,
     awq_marlin_repack,
     awq_to_marlin_zero_points,
     marlin_import_exception,
+    marlin_is_tile_aligned,
     marlin_make_empty_g_idx,
     marlin_make_workspace_new,
+    marlin_pad_awq_qweight,
+    marlin_pad_awq_qzeros,
+    marlin_pad_dim,
+    marlin_pad_scales,
+    marlin_padded_nk,
     marlin_permute_bias,
     marlin_permute_scales,
     marlin_runtime_available,
@@ -48,7 +55,7 @@ class AwqMarlinLinear(AWQuantLinear):
     SUPPORTS_TRAINING = False
     SUPPORTS_AUTO_PADDING = False
     SUPPORTS_IN_FEATURES_DIVISIBLE_BY = [1]
-    SUPPORTS_OUT_FEATURES_DIVISIBLE_BY = [64]
+    SUPPORTS_OUT_FEATURES_DIVISIBLE_BY = [1]
 
     SUPPORTS_DEVICES = [DEVICE.CUDA]
     SUPPORTS_PLATFORM = [PLATFORM.LINUX]
@@ -83,6 +90,17 @@ class AwqMarlinLinear(AWQuantLinear):
         self.max_par = 8  # partitioning for large inputs
         self.compute_dtype = kwargs.get("dtype") or torch.float16
 
+        selected_backend = kwargs.pop("backend", BACKEND.AWQ_MARLIN)
+        # Keep runtime padding opt-in until tail-shape performance is measured.
+        if selected_backend in (BACKEND.AUTO, BACKEND.AUTO_TRAINABLE) and not marlin_is_tile_aligned(
+            out_features, in_features
+        ):
+            raise NotImplementedError(
+                "Automatic AWQ Marlin selection keeps tile-misaligned shapes "
+                "on the next compatible backend; request AWQ_MARLIN explicitly "
+                "to enable runtime tile padding."
+            )
+
         super().__init__(
             bits=bits,
             group_size=group_size,
@@ -92,7 +110,7 @@ class AwqMarlinLinear(AWQuantLinear):
             out_features=out_features,
             bias=bias,
             pack_dtype=pack_dtype,
-            backend=kwargs.pop("backend", BACKEND.AWQ_MARLIN),
+            backend=selected_backend,
             adapter=adapter,
             register_buffers=False,
             **kwargs)
@@ -170,6 +188,37 @@ class AwqMarlinLinear(AWQuantLinear):
         return True, None
 
     @classmethod
+    def _validate(cls, **args) -> Tuple[bool, Optional[Exception]]:
+        ok, err = super()._validate(**args)
+        if not ok:
+            return ok, err
+
+        bits = args.get("bits", 4)
+        in_features = args.get("in_features")
+        out_features = args.get("out_features")
+        if out_features is None:
+            return True, None
+
+        # AWQ packs N into int32 words; padding cannot repair a partial word.
+        pack_factor = 32 // bits
+        if out_features % pack_factor != 0:
+            return False, NotImplementedError(
+                "AWQ Marlin out_features must be divisible by "
+                f"pack_factor={pack_factor}; got N={out_features}."
+            )
+
+        # Keep uint8 tails on fallback until zero-point thread configs are validated.
+        if bits != 4 and in_features is not None and not marlin_is_tile_aligned(
+            out_features, in_features
+        ):
+            return False, NotImplementedError(
+                "AWQ Marlin runtime tile padding is enabled only for 4-bit "
+                f"weights; got bits={bits}."
+            )
+
+        return True, None
+
+    @classmethod
     def validate_device(cls, device: DEVICE):
         super().validate_device(device)
         CUDA_VISIBLE_DEVICES = os.environ.get("CUDA_VISIBLE_DEVICES")
@@ -197,28 +246,71 @@ class AwqMarlinLinear(AWQuantLinear):
         # Allocate marlin workspace
         self.workspace = marlin_make_workspace_new(device)
 
-        # Repack weights from AWQ format to marlin format.
-        marlin_qweight = awq_marlin_repack(
-            self.qweight,
-            self.in_features,
+        # group_size=K and group_size=-1 both mean one channelwise group.
+        marlin_group_size = (
+            -1
+            if self.requested_group_size == self.in_features
+            else self.requested_group_size
+        )
+        padded_n, padded_k = marlin_padded_nk(
             self.out_features,
+            self.in_features,
+            marlin_group_size,
+        )
+        self._marlin_tile_padding = (
+            None
+            if (padded_n, padded_k) == (self.out_features, self.in_features)
+            else (padded_n, padded_k)
+        )
+
+        # Repack weights from AWQ format to marlin format.
+        padded_qweight = marlin_pad_awq_qweight(
+            self.qweight.contiguous(),
+            self.out_features,
+            self.in_features,
+            padded_n,
+            padded_k,
+            self.bits,
+        )
+        marlin_qweight = awq_marlin_repack(
+            padded_qweight,
+            padded_k,
+            padded_n,
             self.bits,
             dtype=self.compute_dtype)
         replace_parameter(self, "qweight", marlin_qweight)
 
         # Permute scales from AWQ format to marlin format.
+        padded_scales = marlin_pad_scales(
+            self.scales.contiguous(),
+            self.out_features,
+            self.in_features,
+            padded_n,
+            padded_k,
+            marlin_group_size,
+        )
         marlin_scales = marlin_permute_scales(
-            self.scales,
-            size_k=self.in_features,
-            size_n=self.out_features,
-            group_size=self.group_size)
+            padded_scales,
+            size_k=padded_k,
+            size_n=padded_n,
+            group_size=marlin_group_size)
         replace_parameter(self, "scales", marlin_scales)
 
         # Permute zero-points from AWQ format to marlin format.
+        padded_qzeros = marlin_pad_awq_qzeros(
+            self.qzeros.contiguous(),
+            self.out_features,
+            self.in_features,
+            padded_n,
+            padded_k,
+            marlin_group_size,
+            self.bits,
+        )
+        padded_groups = 1 if marlin_group_size == -1 else padded_k // marlin_group_size
         marlin_zp = awq_to_marlin_zero_points(
-            self.qzeros,
-            size_k=self.in_features // self.group_size,
-            size_n=self.out_features,
+            padded_qzeros,
+            size_k=padded_groups,
+            size_n=padded_n,
             num_bits=self.bits)
         replace_parameter(self, "qzeros", marlin_zp)
 
@@ -227,7 +319,9 @@ class AwqMarlinLinear(AWQuantLinear):
         self.g_idx_sort_indices = marlin_make_empty_g_idx(device)
 
         if hasattr(self, "bias") and self.bias is not None:
-            self.bias.data = marlin_permute_bias(self.bias)
+            self.bias.data = marlin_permute_bias(
+                marlin_pad_dim(self.bias, self.out_features, padded_n)
+            )
 
         super().post_init()
 
@@ -255,19 +349,36 @@ class AwqMarlinLinear(AWQuantLinear):
         if self.bias is not None and self.bias.dtype != x.dtype:
             self.bias.data = self.bias.data.to(x.dtype)
 
-        out = apply_awq_marlin_linear(
-            input=x,
-            weight=self.qweight,
-            weight_scale=self.scales,
-            weight_zp=self.qzeros,
-            g_idx=self.g_idx,
-            g_idx_sort_indices=self.g_idx_sort_indices,
-            workspace=self.workspace,
-            quant_type=self.weight_type,
-            output_size_per_partition=self.out_features,
-            input_size_per_partition=self.in_features,
-            bias=self.bias,
-        )
+        # Aligned layers retain the original decode-sensitive call path.
+        if self._marlin_tile_padding is None:
+            out = apply_awq_marlin_linear(
+                input=x,
+                weight=self.qweight,
+                weight_scale=self.scales,
+                weight_zp=self.qzeros,
+                g_idx=self.g_idx,
+                g_idx_sort_indices=self.g_idx_sort_indices,
+                workspace=self.workspace,
+                quant_type=self.weight_type,
+                output_size_per_partition=self.out_features,
+                input_size_per_partition=self.in_features,
+                bias=self.bias,
+            )
+        else:
+            out = apply_awq_marlin_linear_padded(
+                tile_padding=self._marlin_tile_padding,
+                input=x,
+                weight=self.qweight,
+                weight_scale=self.scales,
+                weight_zp=self.qzeros,
+                g_idx=self.g_idx,
+                g_idx_sort_indices=self.g_idx_sort_indices,
+                workspace=self.workspace,
+                quant_type=self.weight_type,
+                output_size_per_partition=self.out_features,
+                input_size_per_partition=self.in_features,
+                bias=self.bias,
+            )
 
         if self.adapter:
             out = self.adapter.apply(x=x, out=out)

--- a/gptqmodel/utils/marlin.py
+++ b/gptqmodel/utils/marlin.py
@@ -370,6 +370,44 @@ def marlin_pad_qweight(qweight: torch.Tensor, size_n: int, size_k: int,
     )
 
 
+def marlin_pad_awq_qweight(qweight: torch.Tensor, size_n: int, size_k: int,
+                           padded_n: int, padded_k: int,
+                           num_bits: int) -> torch.Tensor:
+    """Zero-pad an AWQ-layout packed weight before Marlin repacking."""
+    pack_factor = 32 // num_bits
+    expected_shape = (size_k, size_n // pack_factor)
+    if tuple(qweight.shape) != expected_shape:
+        raise ValueError(
+            f"AWQ qweight shape must be {expected_shape}, got {tuple(qweight.shape)}."
+        )
+    if (padded_n, padded_k) == (size_n, size_k):
+        return qweight
+    return torch.nn.functional.pad(
+        qweight,
+        (0, (padded_n - size_n) // pack_factor, 0, padded_k - size_k),
+    )
+
+
+def marlin_pad_awq_qzeros(qzeros: torch.Tensor, size_n: int, size_k: int,
+                          padded_n: int, padded_k: int, group_size: int,
+                          num_bits: int) -> torch.Tensor:
+    """Zero-pad AWQ packed zero-points to the padded group and N extents."""
+    pack_factor = 32 // num_bits
+    groups = size_k // group_size if group_size > 0 else 1
+    padded_groups = padded_k // group_size if group_size > 0 else 1
+    expected_shape = (groups, size_n // pack_factor)
+    if tuple(qzeros.shape) != expected_shape:
+        raise ValueError(
+            f"AWQ qzeros shape must be {expected_shape}, got {tuple(qzeros.shape)}."
+        )
+    if (padded_n, padded_k) == (size_n, size_k):
+        return qzeros
+    return torch.nn.functional.pad(
+        qzeros,
+        (0, (padded_n - size_n) // pack_factor, 0, padded_groups - groups),
+    )
+
+
 def marlin_pad_scales(scales: torch.Tensor, size_n: int, size_k: int,
                       padded_n: int, padded_k: int,
                       group_size: int) -> torch.Tensor:
@@ -678,6 +716,42 @@ def apply_awq_marlin_linear(
                               is_zp_float=False)
 
     return output.reshape(out_shape)
+
+
+def apply_awq_marlin_linear_padded(
+        *,
+        tile_padding: Tuple[int, int],
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        weight_scale: torch.Tensor,
+        weight_zp: torch.Tensor,
+        g_idx: torch.Tensor,
+        g_idx_sort_indices: torch.Tensor,
+        workspace: torch.Tensor,
+        quant_type: ScalarType,
+        output_size_per_partition: int,
+        input_size_per_partition: int,
+        bias: Optional[torch.Tensor] = None,
+        use_fp32_reduce: bool = True,
+) -> torch.Tensor:
+    """Pad one AWQ GEMM around the unchanged Marlin call path."""
+    padded_n, padded_k = tile_padding
+    padded_input = marlin_pad_dim(input, input_size_per_partition, padded_k)
+    output = apply_awq_marlin_linear(
+        input=padded_input,
+        weight=weight,
+        weight_scale=weight_scale,
+        weight_zp=weight_zp,
+        g_idx=g_idx,
+        g_idx_sort_indices=g_idx_sort_indices,
+        workspace=workspace,
+        quant_type=quant_type,
+        output_size_per_partition=padded_n,
+        input_size_per_partition=padded_k,
+        bias=bias,
+        use_fp32_reduce=use_fp32_reduce,
+    )
+    return marlin_unpad_output(output, output_size_per_partition, padded_n)
 
 
 def gptq_marlin_gemm(a: torch.Tensor,

--- a/tests/kernels/test_awq_machete_marlin.py
+++ b/tests/kernels/test_awq_machete_marlin.py
@@ -75,6 +75,7 @@ def _build_awq_module(
     qzeros: torch.Tensor,
     scales: torch.Tensor,
     bias: torch.Tensor,
+    dtype: torch.dtype = torch.float16,
 ):
     module = module_cls(
         bits=bits,
@@ -85,13 +86,14 @@ def _build_awq_module(
         out_features=out_features,
         bias=True,
         register_buffers=True,
+        dtype=dtype,
     ).to(device)
 
     with torch.no_grad():
         module.qweight.copy_(qweight.to(device))
         module.qzeros.copy_(qzeros.to(device))
-        module.scales.copy_(scales.to(torch.float16).to(device))
-        module.bias.copy_(bias.to(torch.float16).to(device))
+        module.scales.copy_(scales.to(dtype=dtype, device=device))
+        module.bias.copy_(bias.to(dtype=dtype, device=device))
 
     module.post_init()
     module.eval()
@@ -172,6 +174,86 @@ def test_awq_marlin_cuda_zero_points_match_torch_awq():
         atol=8e-3,
         rtol=8e-3,
     )
+
+
+@pytest.mark.cuda
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "rows,in_features,out_features,group_size",
+    [
+        (1, 256, 200, 32),  # N tail during decode
+        (17, 208, 256, -1),  # K tail with channelwise scales
+        (8, 208, 256, 208),  # Explicit K-sized channelwise group
+        (33, 288, 200, 32),  # N and K tails
+    ],
+)
+def test_awq_marlin_cuda_padded_shape_matches_dense_reference(
+    dtype, rows, in_features, out_features, group_size
+):
+    capability = torch.cuda.get_device_capability()
+    if capability[0] < 8 and dtype == torch.bfloat16:
+        pytest.skip("AWQ Marlin BF16 requires compute capability >= 8.0")
+    if marlin_import_exception is not None:
+        pytest.skip(f"AWQ Marlin kernel unavailable: {marlin_import_exception}")
+    if not marlin_runtime_available(dtype):
+        pytest.skip(marlin_runtime_error(dtype))
+
+    torch.manual_seed(23)
+    device = torch.device("cuda:0")
+    bits = 4
+    effective_group_size = in_features if group_size == -1 else group_size
+    groups = in_features // effective_group_size
+    maxq = (1 << bits) - 1
+
+    codes = torch.randint(
+        0,
+        maxq + 1,
+        (in_features, out_features),
+        dtype=torch.int32,
+    )
+    zero_points = torch.randint(
+        0,
+        maxq + 1,
+        (groups, out_features),
+        dtype=torch.int32,
+    )
+    scales = (torch.rand((groups, out_features)) * 0.01 + 0.001).to(dtype)
+    bias = (torch.randn(out_features) * 0.01).to(dtype)
+    qweight = _pack_awq_tensor(codes, bits)
+    qzeros = _pack_awq_tensor(zero_points, bits)
+
+    module = _build_awq_module(
+        AwqMarlinLinear,
+        device=device,
+        bits=bits,
+        group_size=group_size,
+        in_features=in_features,
+        out_features=out_features,
+        qweight=qweight,
+        qzeros=qzeros,
+        scales=scales,
+        bias=bias,
+        dtype=dtype,
+    )
+
+    group_indices = torch.arange(in_features) // effective_group_size
+    dense_weight = (
+        codes - zero_points.index_select(0, group_indices)
+    ).to(dtype) * scales.index_select(0, group_indices)
+    dense_weight = dense_weight.to(device)
+    x = torch.randn((rows, in_features), device=device, dtype=dtype) / in_features**0.5
+    expected = x @ dense_weight + bias.to(device)
+    with torch.inference_mode():
+        actual = module(x)
+        repeated = module(x)
+    torch.cuda.synchronize(device)
+
+    assert module._marlin_tile_padding is not None
+    assert actual.shape == (rows, out_features)
+    assert actual.dtype == dtype
+    torch.testing.assert_close(actual, expected, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(repeated, expected, atol=5e-2, rtol=5e-2)
 
 
 @pytest.mark.cuda

--- a/tests/test_marlin_jit.py
+++ b/tests/test_marlin_jit.py
@@ -358,6 +358,113 @@ def test_marlin_auto_selection_keeps_tile_padding_opt_in(monkeypatch):
     assert aligned.out_features == 64
 
 
+@pytest.mark.parametrize("group_size", [32, -1])
+def test_awq_marlin_tile_padding_helpers_preserve_packed_values(group_size):
+    size_n, size_k, bits = 200, 288, 4
+    padded_n, padded_k = marlin_utils.marlin_padded_nk(
+        size_n, size_k, group_size
+    )
+    pack_factor = 32 // bits
+    groups = size_k // group_size if group_size > 0 else 1
+    padded_groups = padded_k // group_size if group_size > 0 else 1
+
+    qweight = torch.ones((size_k, size_n // pack_factor), dtype=torch.int32)
+    padded_qweight = marlin_utils.marlin_pad_awq_qweight(
+        qweight, size_n, size_k, padded_n, padded_k, bits
+    )
+    assert padded_qweight.shape == (padded_k, padded_n // pack_factor)
+    assert torch.equal(padded_qweight[:size_k, : qweight.size(1)], qweight)
+    assert torch.count_nonzero(padded_qweight[:, qweight.size(1) :]) == 0
+    assert torch.count_nonzero(padded_qweight[size_k:, :]) == 0
+
+    qzeros = torch.ones((groups, size_n // pack_factor), dtype=torch.int32)
+    padded_qzeros = marlin_utils.marlin_pad_awq_qzeros(
+        qzeros,
+        size_n,
+        size_k,
+        padded_n,
+        padded_k,
+        group_size,
+        bits,
+    )
+    assert padded_qzeros.shape == (padded_groups, padded_n // pack_factor)
+    assert torch.equal(padded_qzeros[:groups, : qzeros.size(1)], qzeros)
+    assert torch.count_nonzero(padded_qzeros[:, qzeros.size(1) :]) == 0
+    assert torch.count_nonzero(padded_qzeros[groups:, :]) == 0
+
+
+def test_awq_marlin_quant_linear_validation_accepts_packable_tile_tails(monkeypatch):
+    monkeypatch.setattr(marlin_awq_qlinear_module, "marlin_import_exception", None)
+    common = {
+        "bits": 4,
+        "group_size": 32,
+        "sym": False,
+        "desc_act": False,
+        "in_features": 288,
+        "out_features": 200,
+        "pack_dtype": torch.int32,
+        "dtype": torch.float16,
+        "dynamic": None,
+        "device": None,
+        "trainable": False,
+        "adapter": None,
+    }
+
+    ok, err = marlin_awq_qlinear_module.AwqMarlinLinear._validate(**common)
+    assert ok is True
+    assert err is None
+
+    ok, err = marlin_awq_qlinear_module.AwqMarlinLinear._validate(
+        **dict(common, out_features=202)
+    )
+    assert ok is False
+    assert "pack_factor=8" in str(err)
+
+    ok, err = marlin_awq_qlinear_module.AwqMarlinLinear._validate(
+        **dict(common, in_features=208, out_features=256, group_size=208)
+    )
+    assert ok is True
+    assert err is None
+
+    ok, err = marlin_awq_qlinear_module.AwqMarlinLinear._validate(
+        **dict(common, bits=8)
+    )
+    assert ok is False
+    assert "enabled only for 4-bit weights" in str(err)
+
+
+def test_awq_marlin_auto_selection_keeps_tile_padding_opt_in(monkeypatch):
+    monkeypatch.setattr(marlin_awq_qlinear_module, "marlin_import_exception", None)
+    kwargs = {
+        "bits": 4,
+        "group_size": 32,
+        "desc_act": False,
+        "sym": False,
+        "in_features": 288,
+        "out_features": 200,
+        "bias": False,
+        "dtype": torch.float16,
+    }
+
+    with pytest.raises(NotImplementedError, match="request AWQ_MARLIN explicitly"):
+        marlin_awq_qlinear_module.AwqMarlinLinear(
+            **kwargs, backend=BACKEND.AUTO
+        )
+
+    explicit = marlin_awq_qlinear_module.AwqMarlinLinear(
+        **kwargs, backend=BACKEND.AWQ_MARLIN
+    )
+    assert explicit.in_features == 288
+    assert explicit.out_features == 200
+
+    aligned = marlin_awq_qlinear_module.AwqMarlinLinear(
+        **dict(kwargs, in_features=256, out_features=128),
+        backend=BACKEND.AUTO,
+    )
+    assert aligned.in_features == 256
+    assert aligned.out_features == 128
+
+
 def test_marlin_quant_linear_validate_device_allows_sm75(monkeypatch):
     monkeypatch.setattr(marlin_qlinear_module, "IS_ROCM", False)
     monkeypatch.setattr(torch.cuda, "device_count", lambda: 2)
@@ -651,6 +758,149 @@ def test_apply_gptq_marlin_linear_pads_input_and_slices_output(monkeypatch):
         output_size_per_partition=200,
         input_size_per_partition=288,
         is_k_full=True,
+        bias=torch.zeros(256, dtype=torch.float16),
+        tile_padding=(256, 320),
+    )
+
+    assert captured == {
+        "input_shape": (6, 320),
+        "bias_shape": (256,),
+        "size_m": 6,
+        "size_n": 256,
+        "size_k": 320,
+    }
+    assert output.shape == (2, 3, 200)
+    assert output.is_contiguous()
+
+
+def test_awq_marlin_quant_linear_post_init_pads_packed_tensors(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(marlin_awq_qlinear_module, "marlin_import_exception", None)
+    monkeypatch.setattr(
+        marlin_awq_qlinear_module, "marlin_runtime_available", lambda dtype: True
+    )
+    monkeypatch.setattr(
+        marlin_awq_qlinear_module, "marlin_runtime_error", lambda dtype: ""
+    )
+    monkeypatch.setattr(
+        marlin_awq_qlinear_module,
+        "marlin_make_workspace_new",
+        lambda device: torch.zeros(128, dtype=torch.int32, device=device),
+    )
+    monkeypatch.setattr(
+        marlin_awq_qlinear_module,
+        "marlin_make_empty_g_idx",
+        lambda device: torch.empty(0, dtype=torch.int32, device=device),
+    )
+
+    def fake_repack(qweight, size_k, size_n, num_bits, dtype=None):
+        captured["qweight"] = (
+            tuple(qweight.shape),
+            size_k,
+            size_n,
+            num_bits,
+            dtype,
+        )
+        pack_factor = 32 // num_bits
+        return torch.zeros(
+            (size_k // 16, size_n * 16 // pack_factor),
+            dtype=torch.int32,
+            device=qweight.device,
+        )
+
+    def fake_permute_scales(scales, size_k, size_n, group_size):
+        captured["scales"] = (
+            tuple(scales.shape),
+            size_k,
+            size_n,
+            group_size,
+        )
+        return scales
+
+    def fake_zero_points(qzeros, size_k, size_n, num_bits):
+        captured["qzeros"] = (
+            tuple(qzeros.shape),
+            size_k,
+            size_n,
+            num_bits,
+        )
+        return qzeros
+
+    monkeypatch.setattr(
+        marlin_awq_qlinear_module, "awq_marlin_repack", fake_repack
+    )
+    monkeypatch.setattr(
+        marlin_awq_qlinear_module, "marlin_permute_scales", fake_permute_scales
+    )
+    monkeypatch.setattr(
+        marlin_awq_qlinear_module,
+        "awq_to_marlin_zero_points",
+        fake_zero_points,
+    )
+    monkeypatch.setattr(
+        marlin_awq_qlinear_module, "marlin_permute_bias", lambda bias: bias
+    )
+
+    module = marlin_awq_qlinear_module.AwqMarlinLinear(
+        bits=4,
+        group_size=32,
+        desc_act=False,
+        sym=False,
+        in_features=288,
+        out_features=200,
+        bias=True,
+        dtype=torch.float16,
+        register_buffers=True,
+    )
+    module.post_init()
+
+    assert module.in_features == 288
+    assert module.out_features == 200
+    assert module.qweight.shape == (20, 512)
+    assert module.scales.shape == (10, 256)
+    assert module.qzeros.shape == (10, 32)
+    assert module.bias.shape == (256,)
+    assert module._marlin_tile_padding == (256, 320)
+    assert captured == {
+        "qweight": ((320, 32), 320, 256, 4, torch.float16),
+        "scales": ((10, 256), 320, 256, 32),
+        "qzeros": ((10, 32), 10, 256, 4),
+    }
+
+
+def test_apply_awq_marlin_linear_pads_input_and_slices_output(monkeypatch):
+    captured = {}
+
+    def fake_gemm(a, _c, _weight, bias, _scales, _global_scale,
+                  _weight_zp, _g_idx, _sort_indices, _workspace, _wtype,
+                  **kwargs):
+        captured.update(
+            {
+                "input_shape": tuple(a.shape),
+                "bias_shape": tuple(bias.shape),
+                "size_m": kwargs["size_m"],
+                "size_n": kwargs["size_n"],
+                "size_k": kwargs["size_k"],
+            }
+        )
+        return torch.ones(
+            (kwargs["size_m"], kwargs["size_n"]), dtype=a.dtype
+        )
+
+    monkeypatch.setattr(marlin_utils, "gptq_marlin_gemm", fake_gemm)
+
+    output = marlin_utils.apply_awq_marlin_linear_padded(
+        input=torch.randn(2, 3, 288, dtype=torch.float16),
+        weight=torch.zeros((20, 512), dtype=torch.int32),
+        weight_scale=torch.ones((10, 256), dtype=torch.float16),
+        weight_zp=torch.zeros((10, 32), dtype=torch.int32),
+        g_idx=torch.empty(0, dtype=torch.int32),
+        g_idx_sort_indices=torch.empty(0, dtype=torch.int32),
+        workspace=torch.zeros(128, dtype=torch.int32),
+        quant_type=scalar_types.uint4,
+        output_size_per_partition=200,
+        input_size_per_partition=288,
         bias=torch.zeros(256, dtype=torch.float16),
         tile_padding=(256, 320),
     )


### PR DESCRIPTION
## Summary

- pad packed AWQ weights, zero-points, scales, bias, and activations to supported Marlin thread tiles
- reuse the shared Marlin tile-padding helpers while preserving the existing aligned hot path and slicing padded outputs back to the logical width
- keep tile padding explicit-only for 4-bit AWQ while automatic selection and unsupported uint8 tails fall back

## Compatibility

- CUDA kernel math is unchanged
- aligned AWQ Marlin shapes retain the existing execution path
- output widths must still contain complete packed int32 words
- unsupported shapes and automatic selection retain their existing fallback behavior

## Tests

- Ruff checks: passed
- Focused AWQ Marlin unit tests (`tests/test_marlin_jit.py`): 6 passed
- GPU kernel tests and benchmarks: not run (CUDA runtime unavailable)