### PR TITLE
fix(pack): forward quant_result to make_quant in pack_model

### DIFF
--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -1103,6 +1103,7 @@ def pack_model(
     quant_linear_cls = make_quant(
         model,
         qcfg=qcfg,
+        quant_result=quant_result,
         backend=backend,
         lm_head_name=lm_head_name,
         pack=True,


### PR DESCRIPTION
### Problem

`make_quant` declares `quant_result` as its **third required positional parameter**:

https://github.com/ModelCloud/GPTQModel/blob/main/gptqmodel/utils/model.py#L398-L409

```python
def make_quant(
    module,
    qcfg: QuantizeConfig,
    quant_result: Dict[str, Dict[str, Any]],
    backend: BACKEND,
    lm_head_name: str,
    ...
```

but the call inside `pack_model` never passes it:

```python
quant_linear_cls = make_quant(
    model,
    qcfg=qcfg,
    backend=backend,          # <-- quant_result never supplied
    lm_head_name=lm_head_name,
    pack=True,
    device=DEVICE.CPU,
)
```

So **every** call to `pack_model` fails immediately with:

```
TypeError: make_quant() missing 1 required positional argument: 'quant_result'
```

### Why this is an omission rather than intended

The value is already in scope and is used correctly everywhere else in the very same function — `pack_model` takes `quant_result` as its own second required parameter, and:

* line 1167 — `modules = {n: modules[n] for n in quant_result}` (three lines *above* the broken call)
* line 1180 — `if name in quant_result` when building `qModules`
* line 1213 — `pack_module(..., quant_result=quant_result, ...)`

The two other `make_quant` call sites in the codebase both pass it:

| call site | passes `quant_result`? |
|---|---|
| `gptqmodel/models/loader.py:1418` | ✅ `quant_result=modules` |
| `gptqmodel/models/writer.py:1171` | ✅ `quant_result=modules` |
| `gptqmodel/utils/model.py:1168` (`pack_model`) | ❌ — this PR |

### Fix

One line — forward the parameter that is already in scope:

```diff
     quant_linear_cls = make_quant(
         model,
         qcfg=qcfg,
+        quant_result=quant_result,
         backend=backend,
```

### Verification

I do not have a GPU box here, so rather than hand-copying a repro (which can silently diverge from the source) I replayed the **actual** argument binding straight out of the AST: `make_quant`'s parameter list and each `Call` node's positional/keyword shape are read from the real files, a signature-identical stub is generated, and the binding is replayed.

```
make_quant signature reconstructed from source:
    (module, qcfg, quant_result, backend, lm_head_name, pack=None, device=None,
     from_quantized=None, dtype=None, is_sharded=None)

UNPATCHED -- callsite gptqmodel/utils/model.py:1168 (inside pack_model)
  passes 1 positional + keywords ['qcfg', 'backend', 'lm_head_name', 'pack', 'device']
  pack_model -> make_quant           TypeError: make_quant() missing 1 required
                                     positional argument: 'quant_result'

SIBLING CALLSITES (the baseline this one deviates from)
  loader.py:1418                     BINDS OK
  writer.py:1171                     BINDS OK

PATCHED -- add quant_result=quant_result to the pack_model callsite
  pack_model -> make_quant (fixed)   BINDS OK
```

The unpatched run reproduces the exact `TypeError` from the report above, and the patched run binds cleanly.

### Note on the base commit

My fork could not be synced to `main` (the GitHub API refuses `merge-upstream` for this token because the sync would touch `.github/workflows/code_quality.yml`, which needs the `workflow` OAuth scope). The branch is therefore based on my fork's own tip. I checked the drift explicitly: the `make_quant` call block in `pack_model` is **byte-identical** between that commit and current `main`, and the upstream changes to `pack_model` since then (the `qModules` comprehension and the `GPTQMODEL_MAX_PACKERS` handling) are all *below* the lines this patch touches. The resulting diff is exactly `+1/-0` against `main`. Happy to rebase if you'd prefer.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
