### PR TITLE
fix(awq): stop variable-length calibration collapsing to the last batch

### DIFF
--- a/gptqmodel/looper/awq_processor.py
+++ b/gptqmodel/looper/awq_processor.py
@@ -211,9 +211,9 @@ class AWQProcessor(LoopProcessor):
         self.duo_scaling = True
 
         self._module_forward_kwargs: Dict[str, torch.Tensor] = {}
-        self._awq_feature_stats: Dict[str, Dict[str, Any]] = {}
-        self._awq_scale_feature_by_module: Dict[str, str] = {}
-        self._awq_feature_task_names: Set[str] = set()
+        self._feature_stats: Dict[str, Dict[str, Any]] = {}
+        self._scale_feature_by_module: Dict[str, str] = {}
+        self._feature_task_names: Set[str] = set()
         self._rotary_lock = threading.Lock()
         self._rotary_cache: Dict[str, nn.Module] = {}
         self._rotary_source_id: Optional[int] = None
@@ -880,7 +880,7 @@ class AWQProcessor(LoopProcessor):
                 if policy and policy.get("capture_root", False):
                     feature_names.append(root)
 
-        self._awq_feature_task_names = set(feature_names)
+        self._feature_task_names = set(feature_names)
         # Iterate over a snapshot since quantization may mutate state.modules concurrently
         for name in feature_names:
             entry = self.tasks.get(name) or {}
@@ -977,7 +977,7 @@ class AWQProcessor(LoopProcessor):
                 # )
 
         self._awq_feature_kwargs = feature_kwargs
-        self._awq_feature_stats = feature_stats
+        self._feature_stats = feature_stats
         return features
 
     def _feature_nsamples_for_log(self, feature_stat: Mapping[str, Any]) -> int:
@@ -1118,7 +1118,7 @@ class AWQProcessor(LoopProcessor):
             if feat is None or feat.numel() == 0:
                 return True
 
-            feature_stat = getattr(self, "_awq_feature_stats", {}).get(name, {})
+            feature_stat = self._feature_stats.get(name, {})
             if feature_stat.get("mode") == "token_rows" and "raw_tokens" in feature_stat:
                 # Fallback asks "did enough of the calibration corpus route to
                 # this module", so compare the raw routed token count against
@@ -1169,7 +1169,7 @@ class AWQProcessor(LoopProcessor):
         )
 
         input_feat = self._layer_input_features(state)
-        self._awq_scale_feature_by_module = {}
+        self._scale_feature_by_module = {}
         missing = [name for name, tensor in input_feat.items() if tensor.numel() == 0]
         if missing and not self.fallback:
             raise RuntimeError(
@@ -1297,7 +1297,7 @@ class AWQProcessor(LoopProcessor):
                     if isinstance(layer, torch.nn.Module)
                     else str(layer)
                 )
-                self._awq_scale_feature_by_module[layer_name] = feature_name
+                self._scale_feature_by_module[layer_name] = feature_name
         if not sanitized_module_config and not fallback_names:
             log.warning(
                 "AWQProcessor: no valid scaling groups for layer %s after filtering; marking layer as quantized.",
@@ -1421,13 +1421,13 @@ class AWQProcessor(LoopProcessor):
         state.previous_weight_scale = None
 
         with self.lock:
-            for name in self._awq_feature_task_names or set(named_childs):
+            for name in self._feature_task_names or set(named_childs):
                 task_entry = self.tasks.pop(name, None)
                 if task_entry and "inputs" in task_entry:
                     task_entry["inputs"].clear()
-        self._awq_feature_task_names = set()
-        self._awq_feature_stats = {}
-        self._awq_scale_feature_by_module = {}
+        self._feature_task_names = set()
+        self._feature_stats = {}
+        self._scale_feature_by_module = {}
 
         if hasattr(self._scale_context, "layer_index"):
             delattr(self._scale_context, "layer_index")
@@ -2110,15 +2110,15 @@ class AWQProcessor(LoopProcessor):
                 loss_summary = f"{avg_loss_value:.10f}"
 
             # TODO "loss" and "nsamples" may not be consistent with the semantics of gptq quantization.
-            activation_stat = getattr(self, "_awq_feature_stats", {}).get(
+            activation_stat = self._feature_stats.get(
                 named_module.name,
                 {},
             )
-            scale_feature = getattr(self, "_awq_scale_feature_by_module", {}).get(
+            scale_feature = self._scale_feature_by_module.get(
                 named_module.name,
                 named_module.name,
             )
-            scale_stat = getattr(self, "_awq_feature_stats", {}).get(
+            scale_stat = self._feature_stats.get(
                 scale_feature,
                 activation_stat,
             )

--- a/gptqmodel/looper/awq_processor.py
+++ b/gptqmodel/looper/awq_processor.py
@@ -1333,7 +1333,9 @@ class AWQProcessor(LoopProcessor):
         sanitized_module_config = filtered_module_config
         feature_name_by_id = {id(tensor): name for name, tensor in input_feat.items()}
         for cfg in sanitized_module_config:
-            feature_name = feature_name_by_id.get(id(cfg.get("inp")))
+            feature_name = cfg.pop("_input_feature_name", None)
+            if feature_name not in input_feat:
+                feature_name = feature_name_by_id.get(id(cfg.get("inp")))
             if feature_name is None:
                 continue
             for layer in cfg.get("layers") or []:
@@ -2214,6 +2216,13 @@ class AWQProcessor(LoopProcessor):
                 layer_state.pending_modules.update(all_linears.keys())
             layer_state.pending_modules.add(module.name)
         with self.lock:
+            # Seed a policy-requested MoE root before lifecycle forwarding.
+            # This removes dependence on hook/preprocess ordering for the
+            # shared pointwise input used by gate/up scale search.
+            root_name = module.name.split(".", 1)[0]
+            root_policy = self._feature_aggregation_policy(root_name)
+            if root_policy and root_policy.get("capture_root", False):
+                self.tasks.setdefault(root_name, {"inputs": [], "batch_indices": []})
             entry = self.tasks.get(module.name)
             if entry is None:
                 self.tasks[module.name] = {"inputs": []}

--- a/gptqmodel/looper/awq_processor.py
+++ b/gptqmodel/looper/awq_processor.py
@@ -1119,13 +1119,17 @@ class AWQProcessor(LoopProcessor):
                 return True
 
             feature_stat = getattr(self, "_awq_feature_stats", {}).get(name, {})
-            if "raw_tokens" in feature_stat:
+            if feature_stat.get("mode") == "token_rows" and "raw_tokens" in feature_stat:
                 # Fallback asks "did enough of the calibration corpus route to
                 # this module", so compare the raw routed token count against
-                # the expected corpus total. `retained_tokens` is the policy's
-                # deliberate, uniform sampling bound (e.g. 512 rows) and would
-                # trip absolute or percent thresholds for every policy module.
+                # the expected corpus total. Token-row retention is a deliberate
+                # sampling bound and must not trigger low-coverage fallback.
                 captured_tokens += int(feature_stat["raw_tokens"])
+            elif "retained_tokens" in feature_stat:
+                # Other modes must measure the rows that scale search actually
+                # receives. In particular, latest-batch aggregation discards
+                # earlier variable-length captures.
+                captured_tokens += int(feature_stat["retained_tokens"])
             else:
                 hidden = feat.shape[-1] if feat.dim() >= 1 else 1
                 captured_tokens += feat.numel() // max(hidden, 1)

--- a/gptqmodel/looper/awq_processor.py
+++ b/gptqmodel/looper/awq_processor.py
@@ -871,10 +871,16 @@ class AWQProcessor(LoopProcessor):
 
         aligned_kwargs = dict(module_kwargs)
         attention_mask = aligned_kwargs.get("attention_mask")
-        if not torch.is_tensor(inp) or inp.dim() < 3 or not torch.is_tensor(attention_mask):
+        if not torch.is_tensor(inp) or inp.dim() < 2 or not torch.is_tensor(attention_mask):
             return aligned_kwargs
 
-        if inp.shape[0] != 1 or attention_mask.ndim < 2:
+        # `_iter_module_forward_outputs` promotes [tokens, hidden] captures to
+        # [1, tokens, hidden] for attention modules after this helper runs.
+        # Treat that 2-D form as a single batch here so expanded HF masks do
+        # not bypass alignment and fail during replay.
+        input_batch = int(inp.shape[0]) if inp.dim() >= 3 else 1
+        input_seq = int(inp.shape[1]) if inp.dim() >= 3 else int(inp.shape[0])
+        if input_batch != 1 or attention_mask.ndim < 2:
             return aligned_kwargs
 
         try:
@@ -882,13 +888,45 @@ class AWQProcessor(LoopProcessor):
         except Exception:
             return aligned_kwargs
 
-        if keep_mask is None or keep_mask.ndim != 2 or keep_mask.shape[0] <= 1:
+        if keep_mask is None or keep_mask.ndim != 2:
             return aligned_kwargs
 
         total_kept = int(keep_mask.to(dtype=torch.int64).sum().item())
-        if total_kept != int(inp.shape[1]):
-            aligned_kwargs.pop("attention_mask", None)
-            aligned_kwargs.pop("position_ids", None)
+        # Multi-row masks are intentionally packed below. Only a single-row
+        # mask can be an expanded max-cache mask that needs sequence cropping.
+        mask_seq_matches = attention_mask.shape[0] != 1 or (
+            attention_mask.shape[-1] == input_seq
+            and (attention_mask.ndim < 3 or attention_mask.shape[-2] in (1, input_seq))
+        )
+        if total_kept != input_seq or not mask_seq_matches:
+            # Transformers may hand a layer a max-cache causal mask (for
+            # example [1, 1, 2048, 2048]) while the captured replay input is
+            # only 232 tokens. Crop the metadata to the actual sequence so
+            # attention remains causal without padding activations to 2048.
+            # For unsupported/batched layouts retain the defensive drop used
+            # by the original path rather than passing an incompatible mask.
+            cropped_mask = attention_mask
+            if attention_mask.shape[0] == 1:
+                if attention_mask.ndim == 2 and attention_mask.shape[-1] >= input_seq:
+                    cropped_mask = attention_mask[..., :input_seq]
+                elif attention_mask.ndim == 3 and attention_mask.shape[-1] >= input_seq:
+                    if attention_mask.shape[-2] == 1 or attention_mask.shape[-2] >= input_seq:
+                        cropped_mask = attention_mask[..., :input_seq, :input_seq]
+                elif attention_mask.ndim == 4 and attention_mask.shape[-1] >= input_seq:
+                    if attention_mask.shape[-2] == 1:
+                        cropped_mask = attention_mask[..., :1, :input_seq]
+                    elif attention_mask.shape[-2] >= input_seq:
+                        cropped_mask = attention_mask[..., :input_seq, :input_seq]
+
+            if cropped_mask is attention_mask:
+                aligned_kwargs.pop("attention_mask", None)
+                aligned_kwargs.pop("position_ids", None)
+                return aligned_kwargs
+
+            aligned_kwargs["attention_mask"] = cropped_mask
+            position_ids = aligned_kwargs.get("position_ids")
+            if torch.is_tensor(position_ids) and position_ids.ndim >= 2 and position_ids.shape[-1] >= input_seq:
+                aligned_kwargs["position_ids"] = position_ids[..., :input_seq]
             return aligned_kwargs
 
         aligned_kwargs["attention_mask"] = self._pack_attention_mask_for_feature(attention_mask, keep_mask)

--- a/gptqmodel/looper/awq_processor.py
+++ b/gptqmodel/looper/awq_processor.py
@@ -214,6 +214,7 @@ class AWQProcessor(LoopProcessor):
         self._feature_stats: Dict[str, Dict[str, Any]] = {}
         self._scale_feature_by_module: Dict[str, str] = {}
         self._feature_task_names: Set[str] = set()
+        self._awq_feature_kwargs: Dict[str, Dict[str, Any]] = {}
         self._rotary_lock = threading.Lock()
         self._rotary_cache: Dict[str, nn.Module] = {}
         self._rotary_source_id: Optional[int] = None
@@ -1028,6 +1029,38 @@ class AWQProcessor(LoopProcessor):
                 return retained_tokens
         return self._nsamples_total
 
+    def _finalize_quantized_layer(
+        self,
+        state: _AWQLayerState,
+        fallback_task_names: Optional[Set[str]] = None,
+    ) -> None:
+        """Release all per-layer AWQ state after a successful completion."""
+
+        state.quantized = True
+        state.modules.clear()
+        state.pending_modules.clear()
+        state.layer_module = None
+        state.processed_subsets.clear()
+        state.subset_total = None
+        state.previous_weight_scale = None
+
+        task_names = self._feature_task_names or (fallback_task_names or set())
+        with self.lock:
+            for name in task_names:
+                task_entry = self.tasks.pop(name, None)
+                if task_entry and "inputs" in task_entry:
+                    task_entry["inputs"].clear()
+
+        self._feature_task_names = set()
+        self._feature_stats = {}
+        self._scale_feature_by_module = {}
+        self._awq_feature_kwargs = {}
+
+        if hasattr(self._scale_context, "layer_index"):
+            delattr(self._scale_context, "layer_index")
+        if hasattr(self._scale_context, "prev_scale"):
+            delattr(self._scale_context, "prev_scale")
+
     def _quantize_layer_fallback(
         self,
         layer_index: int,
@@ -1058,24 +1091,7 @@ class AWQProcessor(LoopProcessor):
         else:
             log.warning("AWQProcessor: layer %s had no supported modules to quantize.", layer_index)
 
-        state.quantized = True
-        state.modules.clear()
-        state.pending_modules.clear()
-        state.layer_module = None
-        state.processed_subsets.clear()
-        state.subset_total = None
-        state.previous_weight_scale = None
-
-        with self.lock:
-            for name in list(named_childs.keys()):
-                task_entry = self.tasks.pop(name, None)
-                if task_entry and "inputs" in task_entry:
-                    task_entry["inputs"].clear()
-
-        if hasattr(self._scale_context, "layer_index"):
-            delattr(self._scale_context, "layer_index")
-        if hasattr(self._scale_context, "prev_scale"):
-            delattr(self._scale_context, "prev_scale")
+        self._finalize_quantized_layer(state, fallback_task_names=set(named_childs))
 
     def _refresh_forward_kwargs_from_cache(self) -> None:
         """Refreshes cached kwargs such as masks and rotary embeddings for AWQ search."""
@@ -1247,17 +1263,7 @@ class AWQProcessor(LoopProcessor):
                 "AWQProcessor: no module configuration generated for layer index %s; skipping quantization.",
                 layer_index,
             )
-            state.quantized = True
-            state.modules.clear()
-            state.pending_modules.clear()
-            state.layer_module = None
-            state.processed_subsets.clear()
-            state.subset_total = None
-            state.previous_weight_scale = None
-            if hasattr(self._scale_context, "layer_index"):
-                delattr(self._scale_context, "layer_index")
-            if hasattr(self._scale_context, "prev_scale"):
-                delattr(self._scale_context, "prev_scale")
+            self._finalize_quantized_layer(state, fallback_task_names=set(named_childs))
             return
 
         sanitized_module_config: List[Dict] = []
@@ -1342,14 +1348,7 @@ class AWQProcessor(LoopProcessor):
                 "AWQProcessor: no valid scaling groups for layer %s after filtering; marking layer as quantized.",
                 layer_index,
             )
-            state.quantized = True
-            state.processed_subsets.clear()
-            state.subset_total = None
-            state.previous_weight_scale = None
-            if hasattr(self._scale_context, "layer_index"):
-                delattr(self._scale_context, "layer_index")
-            if hasattr(self._scale_context, "prev_scale"):
-                delattr(self._scale_context, "prev_scale")
+            self._finalize_quantized_layer(state, fallback_task_names=set(named_childs))
             return
 
         sample_groups = []
@@ -1451,27 +1450,7 @@ class AWQProcessor(LoopProcessor):
             )
             self.apply_quant(fallback_named_childs, scales_list=[])
 
-        state.quantized = True
-        state.modules.clear()
-        state.pending_modules.clear()
-        state.layer_module = None
-        state.processed_subsets.clear()
-        state.subset_total = None
-        state.previous_weight_scale = None
-
-        with self.lock:
-            for name in self._feature_task_names or set(named_childs):
-                task_entry = self.tasks.pop(name, None)
-                if task_entry and "inputs" in task_entry:
-                    task_entry["inputs"].clear()
-        self._feature_task_names = set()
-        self._feature_stats = {}
-        self._scale_feature_by_module = {}
-
-        if hasattr(self._scale_context, "layer_index"):
-            delattr(self._scale_context, "layer_index")
-        if hasattr(self._scale_context, "prev_scale"):
-            delattr(self._scale_context, "prev_scale")
+        self._finalize_quantized_layer(state, fallback_task_names=set(named_childs))
 
     @torch.inference_mode()
     def _search_best_scale(

--- a/gptqmodel/looper/awq_processor.py
+++ b/gptqmodel/looper/awq_processor.py
@@ -514,6 +514,36 @@ class AWQProcessor(LoopProcessor):
         )
 
     @staticmethod
+    def _token_row_budget(tensors: List[torch.Tensor]) -> int:
+        """Derive a pointwise sample budget from observed calibration batches.
+
+        Use one largest-batch equivalent, raised to the number of non-empty
+        batches so every contributing batch can retain at least one row. This
+        adapts to actual batch size, sequence lengths, and expert occupancy
+        while limiting any increase beyond the largest observed activation
+        batch to the minimum needed for one-row-per-batch coverage.
+        """
+
+        row_counts = []
+        for tensor in tensors:
+            if tensor.dim() < 2:
+                continue
+            hidden = int(tensor.shape[-1])
+            if hidden <= 0:
+                continue
+            rows = int(tensor.numel() // hidden)
+            if rows > 0:
+                row_counts.append(rows)
+
+        if not row_counts:
+            return 0
+
+        raw_tokens = sum(row_counts)
+        largest_batch = max(row_counts)
+        contributing_batches = len(row_counts)
+        return min(raw_tokens, max(largest_batch, contributing_batches))
+
+    @staticmethod
     def _pack_token_rows(
         tensors: List[torch.Tensor],
         *,
@@ -916,11 +946,20 @@ class AWQProcessor(LoopProcessor):
             policy = self._feature_aggregation_policy(name)
             aggregation_mode = (policy or {}).get("mode")
             if aggregation_mode == "token_rows":
-                max_tokens = int((policy or {}).get("max_tokens", 512))
-                features[name], raw_tokens = self._pack_token_rows(
-                    tensors,
-                    max_tokens=max_tokens,
+                configured_max_tokens = (policy or {}).get("max_tokens")
+                max_tokens = (
+                    int(configured_max_tokens)
+                    if configured_max_tokens is not None
+                    else self._token_row_budget(tensors)
                 )
+                if max_tokens == 0 and configured_max_tokens is None:
+                    features[name] = tensors[0].new_empty((1, 0, tensors[0].shape[-1]))
+                    raw_tokens = 0
+                else:
+                    features[name], raw_tokens = self._pack_token_rows(
+                        tensors,
+                        max_tokens=max_tokens,
+                    )
                 feature_kwargs[name] = {}
                 retained_tokens = int(features[name].shape[-2])
                 entry["inputs"] = [features[name]]

--- a/gptqmodel/looper/awq_processor.py
+++ b/gptqmodel/looper/awq_processor.py
@@ -8,6 +8,7 @@ import inspect
 import math
 import threading
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
@@ -210,6 +211,9 @@ class AWQProcessor(LoopProcessor):
         self.duo_scaling = True
 
         self._module_forward_kwargs: Dict[str, torch.Tensor] = {}
+        self._awq_feature_stats: Dict[str, Dict[str, Any]] = {}
+        self._awq_scale_feature_by_module: Dict[str, str] = {}
+        self._awq_feature_task_names: Set[str] = set()
         self._rotary_lock = threading.Lock()
         self._rotary_cache: Dict[str, nn.Module] = {}
         self._rotary_source_id: Optional[int] = None
@@ -373,7 +377,29 @@ class AWQProcessor(LoopProcessor):
         self._nsamples_total = total_tokens
         self.nsamples = total_tokens
 
-    def _record_input_feature(self, module_name: str, feature: torch.Tensor) -> None:
+    def _feature_aggregation_policy(self, module_name: str) -> Optional[Dict[str, Any]]:
+        """Return an optional model-specific activation aggregation policy."""
+
+        selector = getattr(self.gptq_model, "awq_input_feature_aggregation", None)
+        if not callable(selector):
+            return None
+        policy = selector(module_name)
+        if policy is None:
+            return None
+        if not isinstance(policy, Mapping):
+            raise TypeError(
+                "awq_input_feature_aggregation must return a mapping or None "
+                f"for {module_name!r}, got {type(policy).__name__}."
+            )
+        return dict(policy)
+
+    def _record_input_feature(
+        self,
+        module_name: str,
+        feature: torch.Tensor,
+        *,
+        dedupe_batch: bool = False,
+    ) -> None:
         """Caches one captured input feature tensor for a named module."""
 
         # Preserve a leading sample axis for flattened [seq, hidden] captures so later
@@ -381,19 +407,74 @@ class AWQProcessor(LoopProcessor):
         if feature.dim() <= 2:
             feature = feature.unsqueeze(0)
 
-        if feature.device.type != "cpu":
-            feature = feature.detach().cpu()
-        else:
-            feature = feature.detach()
+        batch_index = self.current_batch_index()
+        reserved_batch_index = False
+        if dedupe_batch and batch_index is not None:
+            # Reserve before the potentially large GPU -> CPU transfer. MoE roots
+            # can replay the same input once per expert subset; checking after the
+            # transfer would discard the duplicate but still copy a full hidden
+            # state tensor for every layer.
+            with self.lock:
+                entry = self.tasks.get(module_name)
+                if entry is None:
+                    entry = {"inputs": [], "batch_indices": []}
+                    self.tasks[module_name] = entry
+                seen_batch_indices = entry.setdefault("seen_batch_indices", set())
+                if batch_index in seen_batch_indices:
+                    return
+                seen_batch_indices.add(batch_index)
+                reserved_batch_index = True
+
+        try:
+            if feature.device.type != "cpu":
+                feature = feature.detach().cpu()
+            else:
+                feature = feature.detach()
+        except Exception:
+            if reserved_batch_index:
+                with self.lock:
+                    entry = self.tasks.get(module_name)
+                    if entry is not None:
+                        entry.get("seen_batch_indices", set()).discard(batch_index)
+            raise
 
         with self.lock:
             entry = self.tasks.get(module_name)
             if entry is None:
                 entry = {"inputs": [], "batch_indices": []}
                 self.tasks[module_name] = entry
+            if dedupe_batch and batch_index is not None and not reserved_batch_index:
+                seen_batch_indices = entry.setdefault("seen_batch_indices", set())
+                if batch_index in seen_batch_indices:
+                    return
+                seen_batch_indices.add(batch_index)
             inputs_list = entry.setdefault("inputs", [])
             inputs_list.append(feature)
-            entry.setdefault("batch_indices", []).append(self.current_batch_index())
+            entry.setdefault("batch_indices", []).append(batch_index)
+
+    def record_moe_root_input_feature(self, module_name: str, feature: torch.Tensor) -> None:
+        """Capture one pointwise MoE-root input per calibration batch when requested.
+
+        MoE layers are normally hooked only at expert projections.  Model-specific
+        AWQ scale groups may instead need the shared pre-router input.  The policy
+        gate keeps this opt-in so sequence-sensitive models retain their existing
+        replay contract.
+        """
+
+        if getattr(self, "coverage_only", False):
+            return
+
+        policy = self._feature_aggregation_policy(module_name)
+        if not policy or not policy.get("capture_root", False):
+            return
+        # Capture only while at least one routed projection under this root has
+        # an active AWQ task. Replay-only passes after task cleanup must not
+        # repopulate the root cache.
+        task_prefix = f"{module_name}."
+        with self.lock:
+            if not any(name.startswith(task_prefix) for name in self.tasks):
+                return
+        self._record_input_feature(module_name, feature, dedupe_batch=True)
 
     @staticmethod
     def _can_concat_batch_tensors(tensors: List[torch.Tensor]) -> bool:
@@ -407,6 +488,60 @@ class AWQProcessor(LoopProcessor):
             tensor.dim() == first.dim() and tensor.shape[1:] == first.shape[1:]
             for tensor in tensors
         )
+
+    @staticmethod
+    def _pack_token_rows(
+        tensors: List[torch.Tensor],
+        *,
+        max_tokens: int,
+    ) -> Tuple[torch.Tensor, int]:
+        """Pack ragged pointwise activations into deterministic bounded token rows.
+
+        The returned tensor always has shape ``[1, retained_tokens, hidden]``.
+        Sampling is evenly spaced over calibration-batch order and includes both
+        endpoints, avoiding the previous latest-batch-only bias without allocating
+        a full concatenated activation tensor first.
+        """
+
+        if not tensors:
+            return torch.empty(0), 0
+        if max_tokens <= 0:
+            raise ValueError(f"AWQ token-row max_tokens must be positive, got {max_tokens}.")
+
+        hidden = int(tensors[0].shape[-1])
+        rows = []
+        total_tokens = 0
+        for tensor in tensors:
+            if tensor.dim() < 2 or int(tensor.shape[-1]) != hidden:
+                raise ValueError(
+                    "AWQ token-row aggregation requires tensors with one common "
+                    f"hidden dimension ({hidden}); got shape={tuple(tensor.shape)}."
+                )
+            flattened = tensor.reshape(-1, hidden)
+            rows.append(flattened)
+            total_tokens += int(flattened.shape[0])
+
+        retained_tokens = min(total_tokens, max_tokens)
+        if retained_tokens == total_tokens:
+            return torch.cat(rows, dim=0).unsqueeze(0), total_tokens
+        if retained_tokens == 1:
+            return rows[0][:1].unsqueeze(0), total_tokens
+
+        sample_indices = (
+            torch.arange(retained_tokens, dtype=torch.int64)
+            * (total_tokens - 1)
+            // (retained_tokens - 1)
+        )
+        selected = []
+        offset = 0
+        for tensor_rows in rows:
+            end = offset + int(tensor_rows.shape[0])
+            mask = (sample_indices >= offset) & (sample_indices < end)
+            if mask.any():
+                local_indices = sample_indices[mask] - offset
+                selected.append(tensor_rows.index_select(0, local_indices))
+            offset = end
+        return torch.cat(selected, dim=0).unsqueeze(0), total_tokens
 
     @staticmethod
     def _concat_batch_metadata(values: List[Any]) -> Any:
@@ -645,30 +780,94 @@ class AWQProcessor(LoopProcessor):
     def _layer_input_features(self, state: _AWQLayerState) -> Dict[str, torch.Tensor]:
         """Collapse cached per-batch inputs into one replay tensor per module.
 
-        Most batches can be concatenated on dim 0. Variable-length calibration
-        batches cannot: for example `[1, 423, H]` and `[1, 36, H]` represent
-        different sequence lengths after masking or packing. In that case we
-        keep the most recent feature tensor and rebuild kwargs from the same
-        batch index so activations, masks, and position ids remain aligned.
+        Model-specific pointwise policies pack variable-length batches into
+        bounded token rows, so every calibration batch contributes to AWQ scale
+        statistics. Generic sequence-sensitive modules retain the legacy
+        behavior: concatenate equal shapes, otherwise keep the latest feature
+        and aligned kwargs.
         """
 
         features: Dict[str, torch.Tensor] = {}
         feature_kwargs: Dict[str, Dict[str, Any]] = {}
-        root_buckets: Dict[str, List[torch.Tensor]] = {}
+        feature_stats: Dict[str, Dict[str, Any]] = {}
+        feature_names = list(state.modules)
+        roots = {name.split(".", 1)[0] for name in feature_names}
+        for root in sorted(roots):
+            if root in self.tasks and root not in feature_names:
+                policy = self._feature_aggregation_policy(root)
+                if policy and policy.get("capture_root", False):
+                    feature_names.append(root)
+
+        self._awq_feature_task_names = set(feature_names)
         # Iterate over a snapshot since quantization may mutate state.modules concurrently
-        for name in list(state.modules):
+        for name in feature_names:
             entry = self.tasks.get(name) or {}
             tensors: List[torch.Tensor] = entry.get("inputs", [])  # type: ignore[arg-type]
             batch_indices: List[Optional[int]] = entry.get("batch_indices", [])  # type: ignore[arg-type]
             if not tensors:
                 features[name] = torch.empty(0)
                 feature_kwargs[name] = {}
+                feature_stats[name] = {
+                    "mode": "empty",
+                    "raw_tokens": 0,
+                    "retained_tokens": 0,
+                    "batches": 0,
+                }
                 continue
-            if self._can_concat_batch_tensors(tensors):
+
+            # Capture hooks can complete in device/runtime order, not
+            # necessarily calibration-batch order.  Restore the serial replay
+            # order before concatenation (or before choosing the last
+            # variable-length capture) so activation statistics and their
+            # cached kwargs stay aligned with the calibration corpus.
+            if (
+                len(batch_indices) == len(tensors)
+                and all(index is not None and index >= 0 for index in batch_indices)
+            ):
+                ordered = sorted(
+                    zip(batch_indices, tensors),
+                    key=lambda item: int(item[0]),
+                )
+                batch_indices = [item[0] for item in ordered]
+                tensors = [item[1] for item in ordered]
+
+            policy = self._feature_aggregation_policy(name)
+            aggregation_mode = (policy or {}).get("mode")
+            if aggregation_mode == "token_rows":
+                max_tokens = int((policy or {}).get("max_tokens", 512))
+                features[name], raw_tokens = self._pack_token_rows(
+                    tensors,
+                    max_tokens=max_tokens,
+                )
+                feature_kwargs[name] = {}
+                retained_tokens = int(features[name].shape[-2])
+                entry["inputs"] = [features[name]]
+                entry["batch_indices"] = [None]
+                feature_stats[name] = {
+                    "mode": "token_rows",
+                    "raw_tokens": raw_tokens,
+                    "retained_tokens": retained_tokens,
+                    "batches": len(tensors),
+                    "max_tokens": max_tokens,
+                }
+            elif aggregation_mode not in (None, "batch"):
+                raise ValueError(
+                    f"Unsupported AWQ feature aggregation mode {aggregation_mode!r} "
+                    f"for {name!r}."
+                )
+            elif self._can_concat_batch_tensors(tensors):
                 features[name] = torch.cat(tensors, dim=0)
                 feature_kwargs[name] = self._feature_kwargs_from_batch_indices(batch_indices)
                 entry["inputs"] = [features[name]]
                 entry["batch_indices"] = [None]
+                hidden = max(int(features[name].shape[-1]), 1)
+                tokens = int(features[name].numel() // hidden)
+                feature_stats[name] = {
+                    "mode": "batch",
+                    "raw_tokens": tokens,
+                    "retained_tokens": tokens,
+                    "batches": len(tensors),
+                }
             else:
                 # Variable-length captures such as `[1, 423, H]` and `[1, 36, H]`
                 # cannot be concatenated on dim 0. Keep the latest capture and
@@ -678,8 +877,15 @@ class AWQProcessor(LoopProcessor):
                 feature_kwargs[name] = self._feature_kwargs_from_batch_indices([last_batch_index])
                 entry["inputs"] = [features[name]]
                 entry["batch_indices"] = [last_batch_index]
-            root = name.split(".", 1)[0]
-            root_buckets.setdefault(root, []).extend(tensors)
+                hidden = max(int(features[name].shape[-1]), 1)
+                raw_tokens = sum(int(tensor.numel() // hidden) for tensor in tensors)
+                retained_tokens = int(features[name].numel() // hidden)
+                feature_stats[name] = {
+                    "mode": "latest_batch",
+                    "raw_tokens": raw_tokens,
+                    "retained_tokens": retained_tokens,
+                    "batches": len(tensors),
+                }
             if features[name] is not None and features[name].numel() > 0:
                 pass  # previously logged input feature shapes
                 # log.info(
@@ -688,14 +894,8 @@ class AWQProcessor(LoopProcessor):
                 #     tuple(features[name].shape),
                 # )
 
-        # for root, tensors in root_buckets.items():
-        #     if not tensors or root in features:
-        #         continue
-        #     try:
-        #         features[root] = torch.cat(tensors, dim=0)
-        #     except RuntimeError:
-        #         features[root] = tensors[0]
         self._awq_feature_kwargs = feature_kwargs
+        self._awq_feature_stats = feature_stats
         return features
 
     def _quantize_layer_fallback(
@@ -827,8 +1027,12 @@ class AWQProcessor(LoopProcessor):
             if feat is None or feat.numel() == 0:
                 return True
 
-            hidden = feat.shape[-1] if feat.dim() >= 1 else 1
-            captured_tokens += feat.numel() // max(hidden, 1)
+            feature_stat = getattr(self, "_awq_feature_stats", {}).get(name, {})
+            if "raw_tokens" in feature_stat:
+                captured_tokens += int(feature_stat["raw_tokens"])
+            else:
+                hidden = feat.shape[-1] if feat.dim() >= 1 else 1
+                captured_tokens += feat.numel() // max(hidden, 1)
 
         expected_tokens = getattr(self, "total_calibration_tokens", None) or self._nsamples_total
         return should_use_fallback(
@@ -865,6 +1069,7 @@ class AWQProcessor(LoopProcessor):
         )
 
         input_feat = self._layer_input_features(state)
+        self._awq_scale_feature_by_module = {}
         missing = [name for name, tensor in input_feat.items() if tensor.numel() == 0]
         if missing and not self.fallback:
             raise RuntimeError(
@@ -981,6 +1186,18 @@ class AWQProcessor(LoopProcessor):
             )
 
         sanitized_module_config = filtered_module_config
+        feature_name_by_id = {id(tensor): name for name, tensor in input_feat.items()}
+        for cfg in sanitized_module_config:
+            feature_name = feature_name_by_id.get(id(cfg.get("inp")))
+            if feature_name is None:
+                continue
+            for layer in cfg.get("layers") or []:
+                layer_name = (
+                    get_op_name(layer_module_ref, layer)
+                    if isinstance(layer, torch.nn.Module)
+                    else str(layer)
+                )
+                self._awq_scale_feature_by_module[layer_name] = feature_name
         if not sanitized_module_config and not fallback_names:
             log.warning(
                 "AWQProcessor: no valid scaling groups for layer %s after filtering; marking layer as quantized.",
@@ -1104,10 +1321,13 @@ class AWQProcessor(LoopProcessor):
         state.previous_weight_scale = None
 
         with self.lock:
-            for name in named_childs:
+            for name in self._awq_feature_task_names or set(named_childs):
                 task_entry = self.tasks.pop(name, None)
                 if task_entry and "inputs" in task_entry:
                     task_entry["inputs"].clear()
+        self._awq_feature_task_names = set()
+        self._awq_feature_stats = {}
+        self._awq_scale_feature_by_module = {}
 
         if hasattr(self._scale_context, "layer_index"):
             delattr(self._scale_context, "layer_index")
@@ -1790,6 +2010,19 @@ class AWQProcessor(LoopProcessor):
                 loss_summary = f"{avg_loss_value:.10f}"
 
             # TODO "loss" and "nsamples" may not be consistent with the semantics of gptq quantization.
+            activation_stat = getattr(self, "_awq_feature_stats", {}).get(
+                named_module.name,
+                {},
+            )
+            scale_feature = getattr(self, "_awq_scale_feature_by_module", {}).get(
+                named_module.name,
+                named_module.name,
+            )
+            scale_stat = getattr(self, "_awq_feature_stats", {}).get(
+                scale_feature,
+                activation_stat,
+            )
+            retained_samples = int(scale_stat.get("retained_tokens", 0)) or self._nsamples_total
             stat = {
                 PROCESS_LOG_NAME: self.name(),
                 PROCESS_LOG_LAYER: named_module.layer_index,
@@ -1797,7 +2030,14 @@ class AWQProcessor(LoopProcessor):
                 MODULE_FEATURE_COLUMN: self.module_feature_summary(named_module),
                 DTYPE_SIZE_COLUMN: self.module_dtype_size_summary(named_module),
                 QUANT_LOG_LOSS: loss_summary,
-                QUANT_LOG_NSAMPLES: f"{self._nsamples_total}",
+                QUANT_LOG_NSAMPLES: f"{retained_samples}",
+                "activation_raw_tokens": int(activation_stat.get("raw_tokens", 0)),
+                "activation_retained_tokens": int(activation_stat.get("retained_tokens", 0)),
+                "activation_batches": int(activation_stat.get("batches", 0)),
+                "activation_aggregation": activation_stat.get("mode", "unknown"),
+                "scale_feature": scale_feature,
+                "scale_raw_tokens": int(scale_stat.get("raw_tokens", 0)),
+                "scale_retained_tokens": int(scale_stat.get("retained_tokens", 0)),
                 # QUANT_LOG_DAMP: f"{damp_percent:.5f}",
                 PROCESS_LOG_TIME: f"{duration:.3f}",
                 # PROCESS_LOG_FWD_TIME: f"{self.fwd_time:.3f}",

--- a/gptqmodel/looper/awq_processor.py
+++ b/gptqmodel/looper/awq_processor.py
@@ -501,6 +501,34 @@ class AWQProcessor(LoopProcessor):
                 return
         self._record_input_feature(module_name, feature, dedupe_batch=True)
 
+    def register_moe_root_capture_hook(
+        self,
+        moe_block: Module,
+        moe_block_name: str,
+        handles: List[Any],
+    ) -> bool:
+        """Register AWQ's shared MoE-root capture before the block executes.
+
+        AWQ is the only lifecycle that consumes this shared pointwise feature.
+        Keep the activation-capture and model-policy gates here, alongside the
+        recorder they protect, so the generic subset executor remains unaware
+        of AWQ-specific state and math.
+        """
+
+        if not self.execution_config.enable_activation_capture:
+            return False
+
+        root_policy = self._feature_aggregation_policy(moe_block_name)
+        if not root_policy or not root_policy.get("capture_root", False):
+            return False
+
+        def capture_moe_root_input(_module, inputs):
+            if inputs:
+                self.record_moe_root_input_feature(moe_block_name, inputs[0])
+
+        handles.append(moe_block.register_forward_pre_hook(capture_moe_root_input))
+        return True
+
     @staticmethod
     def _can_concat_batch_tensors(tensors: List[torch.Tensor]) -> bool:
         """Return whether cached tensors share the same non-batch shape."""

--- a/gptqmodel/looper/awq_processor.py
+++ b/gptqmodel/looper/awq_processor.py
@@ -402,11 +402,6 @@ class AWQProcessor(LoopProcessor):
     ) -> None:
         """Caches one captured input feature tensor for a named module."""
 
-        # Preserve a leading sample axis for flattened [seq, hidden] captures so later
-        # concatenation produces [samples, seq, hidden] instead of collapsing into one giant sequence.
-        if feature.dim() <= 2:
-            feature = feature.unsqueeze(0)
-
         batch_index = self.current_batch_index()
         reserved_batch_index = False
         if dedupe_batch and batch_index is not None:
@@ -426,6 +421,11 @@ class AWQProcessor(LoopProcessor):
                 reserved_batch_index = True
 
         try:
+            feature = self._apply_active_keep_mask_to_feature(feature)
+            # Preserve a leading sample axis for flattened [seq, hidden] captures so later
+            # concatenation produces [samples, seq, hidden] instead of collapsing into one giant sequence.
+            if feature.dim() <= 2:
+                feature = feature.unsqueeze(0)
             if feature.device.type != "cpu":
                 feature = feature.detach().cpu()
             else:
@@ -451,6 +451,30 @@ class AWQProcessor(LoopProcessor):
             inputs_list = entry.setdefault("inputs", [])
             inputs_list.append(feature)
             entry.setdefault("batch_indices", []).append(batch_index)
+
+    def _apply_active_keep_mask_to_feature(self, feature: torch.Tensor) -> torch.Tensor:
+        """Remove padded rows from an activation captured by the current worker.
+
+        Regular module hooks normally receive ``[B, S, H]`` inputs, while the
+        all-expert calibration path flattens the same input to ``[B * S, H]``.
+        Handle both layouts so root and expert statistics exclude the same
+        padding rows. Inputs that cannot be matched unambiguously to the active
+        mask retain their existing behavior.
+        """
+
+        keep_mask = getattr(getattr(self, "_mask_tls", None), "value", None)
+        if not torch.is_tensor(feature) or not torch.is_tensor(keep_mask) or keep_mask.ndim != 2:
+            return feature
+
+        keep_mask = keep_mask.to(device=feature.device, dtype=torch.bool)
+        if feature.dim() >= 3 and tuple(feature.shape[:2]) == tuple(keep_mask.shape):
+            flattened = feature.reshape(-1, *feature.shape[2:])
+            return flattened[keep_mask.reshape(-1)].contiguous()
+
+        if feature.dim() == 2 and feature.shape[0] == keep_mask.numel():
+            return feature[keep_mask.reshape(-1)].contiguous()
+
+        return feature
 
     def record_moe_root_input_feature(self, module_name: str, feature: torch.Tensor) -> None:
         """Capture one pointwise MoE-root input per calibration batch when requested.
@@ -498,10 +522,11 @@ class AWQProcessor(LoopProcessor):
         """Pack ragged pointwise activations into deterministic bounded token rows.
 
         The returned tensor always has shape ``[1, retained_tokens, hidden]``.
-        Whenever ``max_tokens`` is at least the number of cached batches, every
-        calibration batch contributes at least one row; the remaining budget is
-        distributed proportionally to batch length (largest remainder, ties
-        broken by batch order) and rows are sampled evenly inside each batch.
+        Whenever ``max_tokens`` is at least the number of non-empty cached
+        batches, every non-empty calibration batch contributes at least one
+        row; the remaining budget is distributed proportionally to batch length
+        (largest remainder, ties broken by batch order) and rows are sampled
+        evenly inside each batch.
         This avoids the previous latest-batch-only bias without allocating a
         full concatenated activation tensor first. When ``max_tokens`` is
         smaller than the batch count, one row is taken from each of
@@ -523,8 +548,12 @@ class AWQProcessor(LoopProcessor):
                     f"hidden dimension ({hidden}); got shape={tuple(tensor.shape)}."
                 )
             flattened = tensor.reshape(-1, hidden)
-            rows.append(flattened)
             total_tokens += int(flattened.shape[0])
+            if flattened.shape[0] > 0:
+                rows.append(flattened)
+
+        if total_tokens == 0:
+            return tensors[0].new_empty((1, 0, hidden)), 0
 
         retained_tokens = min(total_tokens, max_tokens)
         if retained_tokens == total_tokens:
@@ -950,6 +979,15 @@ class AWQProcessor(LoopProcessor):
         self._awq_feature_kwargs = feature_kwargs
         self._awq_feature_stats = feature_stats
         return features
+
+    def _feature_nsamples_for_log(self, feature_stat: Mapping[str, Any]) -> int:
+        """Return the sample count exposed through the legacy quantization log."""
+
+        if feature_stat.get("mode") == "token_rows":
+            retained_tokens = int(feature_stat.get("retained_tokens", 0))
+            if retained_tokens > 0:
+                return retained_tokens
+        return self._nsamples_total
 
     def _quantize_layer_fallback(
         self,
@@ -2080,7 +2118,7 @@ class AWQProcessor(LoopProcessor):
                 scale_feature,
                 activation_stat,
             )
-            retained_samples = int(scale_stat.get("retained_tokens", 0)) or self._nsamples_total
+            retained_samples = self._feature_nsamples_for_log(scale_stat)
             stat = {
                 PROCESS_LOG_NAME: self.name(),
                 PROCESS_LOG_LAYER: named_module.layer_index,

--- a/gptqmodel/looper/awq_processor.py
+++ b/gptqmodel/looper/awq_processor.py
@@ -498,9 +498,14 @@ class AWQProcessor(LoopProcessor):
         """Pack ragged pointwise activations into deterministic bounded token rows.
 
         The returned tensor always has shape ``[1, retained_tokens, hidden]``.
-        Sampling is evenly spaced over calibration-batch order and includes both
-        endpoints, avoiding the previous latest-batch-only bias without allocating
-        a full concatenated activation tensor first.
+        Whenever ``max_tokens`` is at least the number of cached batches, every
+        calibration batch contributes at least one row; the remaining budget is
+        distributed proportionally to batch length (largest remainder, ties
+        broken by batch order) and rows are sampled evenly inside each batch.
+        This avoids the previous latest-batch-only bias without allocating a
+        full concatenated activation tensor first. When ``max_tokens`` is
+        smaller than the batch count, one row is taken from each of
+        ``max_tokens`` evenly spaced batches instead.
         """
 
         if not tensors:
@@ -524,23 +529,61 @@ class AWQProcessor(LoopProcessor):
         retained_tokens = min(total_tokens, max_tokens)
         if retained_tokens == total_tokens:
             return torch.cat(rows, dim=0).unsqueeze(0), total_tokens
-        if retained_tokens == 1:
-            return rows[0][:1].unsqueeze(0), total_tokens
 
-        sample_indices = (
-            torch.arange(retained_tokens, dtype=torch.int64)
-            * (total_tokens - 1)
-            // (retained_tokens - 1)
-        )
+        lengths = [int(tensor_rows.shape[0]) for tensor_rows in rows]
+        batch_count = len(rows)
+
+        if retained_tokens < batch_count:
+            # The budget cannot cover every batch; sample one leading row from
+            # evenly spaced batches so the selection stays deterministic.
+            if retained_tokens == 1:
+                batch_ids = [0]
+            else:
+                batch_ids = [
+                    int(i * (batch_count - 1) // (retained_tokens - 1))
+                    for i in range(retained_tokens)
+                ]
+            selected = [rows[batch_id][:1] for batch_id in dict.fromkeys(batch_ids)]
+            return torch.cat(selected, dim=0).unsqueeze(0), total_tokens
+
+        # Reserve one row per batch, then hand out the remaining budget
+        # proportionally to batch length (largest remainder, ties by order).
+        quotas = [1] * batch_count
+        remaining = retained_tokens - batch_count
+        if remaining > 0:
+            exact = [length * remaining / total_tokens for length in lengths]
+            floors = [int(share) for share in exact]
+            for index, floor_share in enumerate(floors):
+                quotas[index] += floor_share
+            leftover = retained_tokens - sum(quotas)
+            order = sorted(
+                range(batch_count),
+                key=lambda index: (-(exact[index] - floors[index]), index),
+            )
+            for index in order:
+                if leftover <= 0:
+                    break
+                if quotas[index] < lengths[index]:
+                    quotas[index] += 1
+                    leftover -= 1
+
         selected = []
-        offset = 0
-        for tensor_rows in rows:
-            end = offset + int(tensor_rows.shape[0])
-            mask = (sample_indices >= offset) & (sample_indices < end)
-            if mask.any():
-                local_indices = sample_indices[mask] - offset
-                selected.append(tensor_rows.index_select(0, local_indices))
-            offset = end
+        for tensor_rows, quota, length in zip(rows, quotas, lengths):
+            quota = min(quota, length)
+            if quota <= 0:
+                continue
+            if quota == length:
+                selected.append(tensor_rows)
+                continue
+            if quota == 1:
+                local_indices = torch.zeros(1, dtype=torch.int64)
+            else:
+                local_indices = (
+                    torch.arange(quota, dtype=torch.int64)
+                    * (length - 1)
+                    // (quota - 1)
+                )
+            selected.append(tensor_rows.index_select(0, local_indices))
         return torch.cat(selected, dim=0).unsqueeze(0), total_tokens
 
     @staticmethod
@@ -1029,6 +1072,11 @@ class AWQProcessor(LoopProcessor):
 
             feature_stat = getattr(self, "_awq_feature_stats", {}).get(name, {})
             if "raw_tokens" in feature_stat:
+                # Fallback asks "did enough of the calibration corpus route to
+                # this module", so compare the raw routed token count against
+                # the expected corpus total. `retained_tokens` is the policy's
+                # deliberate, uniform sampling bound (e.g. 512 rows) and would
+                # trip absolute or percent thresholds for every policy module.
                 captured_tokens += int(feature_stat["raw_tokens"])
             else:
                 hidden = feat.shape[-1] if feat.dim() >= 1 else 1

--- a/gptqmodel/looper/awq_processor.py
+++ b/gptqmodel/looper/awq_processor.py
@@ -2138,6 +2138,8 @@ class AWQProcessor(LoopProcessor):
                 "scale_feature": scale_feature,
                 "scale_raw_tokens": int(scale_stat.get("raw_tokens", 0)),
                 "scale_retained_tokens": int(scale_stat.get("retained_tokens", 0)),
+                "scale_batches": int(scale_stat.get("batches", 0)),
+                "scale_aggregation": scale_stat.get("mode", "unknown"),
                 # QUANT_LOG_DAMP: f"{damp_percent:.5f}",
                 PROCESS_LOG_TIME: f"{duration:.3f}",
                 # PROCESS_LOG_FWD_TIME: f"{self.fwd_time:.3f}",

--- a/gptqmodel/looper/awq_processor.py
+++ b/gptqmodel/looper/awq_processor.py
@@ -560,12 +560,22 @@ class AWQProcessor(LoopProcessor):
                 range(batch_count),
                 key=lambda index: (-(exact[index] - floors[index]), index),
             )
-            for index in order:
-                if leftover <= 0:
+            # Multiple passes: a single pass can strand budget when the
+            # high-remainder batches saturate (e.g. lengths [1, 1, 1, 5]
+            # with budget 7). retained_tokens <= total_tokens guarantees
+            # enough capacity, so the loop always terminates with zero
+            # leftover.
+            while leftover > 0:
+                distributed = False
+                for index in order:
+                    if leftover <= 0:
+                        break
+                    if quotas[index] < lengths[index]:
+                        quotas[index] += 1
+                        leftover -= 1
+                        distributed = True
+                if not distributed:
                     break
-                if quotas[index] < lengths[index]:
-                    quotas[index] += 1
-                    leftover -= 1
 
         selected = []
         for tensor_rows, quota, length in zip(rows, quotas, lengths):

--- a/gptqmodel/looper/loop_processor.py
+++ b/gptqmodel/looper/loop_processor.py
@@ -868,6 +868,22 @@ class LoopProcessor:
 
         pass
 
+    def register_moe_root_capture_hook(
+        self,
+        moe_block: Module,
+        moe_block_name: str,
+        handles: List[Any],
+    ) -> bool:
+        """Optionally register a processor-specific MoE-root capture hook.
+
+        The generic subset executor invokes this lifecycle extension without
+        knowing which processor owns the feature. Processors that do not need
+        a shared MoE-root capture leave the default no-op unchanged.
+        """
+
+        del moe_block, moe_block_name, handles
+        return False
+
     # do work and return processor.self state which will updated/merged
     def process(
             self,

--- a/gptqmodel/looper/stage_subset.py
+++ b/gptqmodel/looper/stage_subset.py
@@ -19,7 +19,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Callable, Dict, List, Literal, Optional, Tuple
 
 import pcre
 import torch
@@ -702,44 +702,6 @@ def _emit_moe_parallel_quant_subset_telemetry(
     )
 
 
-def _register_awq_moe_root_capture_hook(
-    processor: LoopProcessor,
-    moe_block: torch.nn.Module,
-    moe_block_name: str,
-    handles: List[Any],
-) -> bool:
-    """Register AWQ's shared MoE-root capture before the block executes.
-
-    Root feature capture is an AWQ-only lifecycle extension.  Keep the
-    concrete processor gate in addition to the activation-capture flag so
-    GPTQ, ParoQuant, and future processors cannot accidentally acquire an AWQ
-    feature hook merely by exposing similarly named methods.
-    """
-
-    if not isinstance(processor, AWQProcessor):
-        return False
-
-    execution_config = getattr(processor, "execution_config", None)
-    if not getattr(execution_config, "enable_activation_capture", False):
-        return False
-
-    root_recorder = getattr(processor, "record_moe_root_input_feature", None)
-    feature_policy = getattr(processor, "_feature_aggregation_policy", None)
-    if not callable(root_recorder) or not callable(feature_policy):
-        return False
-
-    root_policy = feature_policy(moe_block_name)
-    if not root_policy or not root_policy.get("capture_root", False):
-        return False
-
-    def capture_moe_root_input(_module, inputs):
-        if inputs:
-            root_recorder(moe_block_name, inputs[0])
-
-    handles.append(moe_block.register_forward_pre_hook(capture_moe_root_input))
-    return True
-
-
 def _run_single_subset_pass(
     looper: 'ModuleLooper',
     processor: LoopProcessor,
@@ -816,7 +778,7 @@ def _run_single_subset_pass(
     # executes every expert through the ordinary model forward (the lifecycle
     # bypass hook is not active in that mode).
     if execute_forward and moe_block is not None and moe_block_name is not None:
-        _register_awq_moe_root_capture_hook(processor, moe_block, moe_block_name, handle)
+        processor.register_moe_root_capture_hook(moe_block, moe_block_name, handle)
 
     if execute_forward:
         for idx, name in enumerate(subset_names):

--- a/gptqmodel/looper/stage_subset.py
+++ b/gptqmodel/looper/stage_subset.py
@@ -19,7 +19,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Callable, Dict, List, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Tuple
 
 import pcre
 import torch
@@ -702,6 +702,44 @@ def _emit_moe_parallel_quant_subset_telemetry(
     )
 
 
+def _register_awq_moe_root_capture_hook(
+    processor: LoopProcessor,
+    moe_block: torch.nn.Module,
+    moe_block_name: str,
+    handles: List[Any],
+) -> bool:
+    """Register AWQ's shared MoE-root capture before the block executes.
+
+    Root feature capture is an AWQ-only lifecycle extension.  Keep the
+    concrete processor gate in addition to the activation-capture flag so
+    GPTQ, ParoQuant, and future processors cannot accidentally acquire an AWQ
+    feature hook merely by exposing similarly named methods.
+    """
+
+    if not isinstance(processor, AWQProcessor):
+        return False
+
+    execution_config = getattr(processor, "execution_config", None)
+    if not getattr(execution_config, "enable_activation_capture", False):
+        return False
+
+    root_recorder = getattr(processor, "record_moe_root_input_feature", None)
+    feature_policy = getattr(processor, "_feature_aggregation_policy", None)
+    if not callable(root_recorder) or not callable(feature_policy):
+        return False
+
+    root_policy = feature_policy(moe_block_name)
+    if not root_policy or not root_policy.get("capture_root", False):
+        return False
+
+    def capture_moe_root_input(_module, inputs):
+        if inputs:
+            root_recorder(moe_block_name, inputs[0])
+
+    handles.append(moe_block.register_forward_pre_hook(capture_moe_root_input))
+    return True
+
+
 def _run_single_subset_pass(
     looper: 'ModuleLooper',
     processor: LoopProcessor,
@@ -778,16 +816,7 @@ def _run_single_subset_pass(
     # executes every expert through the ordinary model forward (the lifecycle
     # bypass hook is not active in that mode).
     if execute_forward and moe_block is not None and moe_block_name is not None:
-        root_recorder = getattr(processor, "record_moe_root_input_feature", None)
-        feature_policy = getattr(processor, "_feature_aggregation_policy", None)
-        if callable(root_recorder) and callable(feature_policy):
-            root_policy = feature_policy(moe_block_name)
-            if root_policy and root_policy.get("capture_root", False):
-                def capture_moe_root_input(_module, inputs):
-                    if inputs:
-                        root_recorder(moe_block_name, inputs[0])
-
-                handle.append(moe_block.register_forward_pre_hook(capture_moe_root_input))
+        _register_awq_moe_root_capture_hook(processor, moe_block, moe_block_name, handle)
 
     if execute_forward:
         for idx, name in enumerate(subset_names):

--- a/gptqmodel/looper/stage_subset.py
+++ b/gptqmodel/looper/stage_subset.py
@@ -745,6 +745,7 @@ def _run_single_subset_pass(
 
     # Determine MoE block name for hook selection
     moe_block_name = None
+    moe_block = None
     if looper.gptq_model and hasattr(looper.gptq_model, 'moe_lifecycle_hooks'):
         hooks = looper.gptq_model.moe_lifecycle_hooks
         if hooks is not None:
@@ -755,6 +756,21 @@ def _run_single_subset_pass(
                     if mod is moe_block:
                         moe_block_name = mod_name
                         break
+
+    # Capture a model-declared pointwise MoE root even when routing override
+    # executes every expert through the ordinary model forward (the lifecycle
+    # bypass hook is not active in that mode).
+    if execute_forward and moe_block is not None and moe_block_name is not None:
+        root_recorder = getattr(processor, "record_moe_root_input_feature", None)
+        feature_policy = getattr(processor, "_feature_aggregation_policy", None)
+        if callable(root_recorder) and callable(feature_policy):
+            root_policy = feature_policy(moe_block_name)
+            if root_policy and root_policy.get("capture_root", False):
+                def capture_moe_root_input(_module, inputs):
+                    if inputs:
+                        root_recorder(moe_block_name, inputs[0])
+
+                handle.append(moe_block.register_forward_pre_hook(capture_moe_root_input))
 
     if execute_forward:
         for idx, name in enumerate(subset_names):

--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -2625,6 +2625,7 @@ class BaseQModel(nn.Module):
                     n, root = generate_node_for_awq_scaling(inp=input_feat[name], prev_op=prev_op,
                                                             module_kwargs=_module_kwargs_for_feature(feature_name), nodes_size=len(nodes),
                                                             subset=subset, module2inspect=None)
+                    n["_input_feature_name"] = feature_name
                     if root is not None and last_module_root != root:
                         last_module_root = root
 
@@ -2690,6 +2691,7 @@ class BaseQModel(nn.Module):
                 n, root = generate_node_for_awq_scaling(inp=inp, prev_op=prev_op,
                                                         module_kwargs=_module_kwargs_for_feature(feature_name), nodes_size=len(nodes),
                                                         subset=subset, module2inspect=module2inspect)
+                n["_input_feature_name"] = feature_name
 
                 nodes.append(n)
 

--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -202,10 +202,6 @@ class BaseQModel(nn.Module):
     # list modules where they must match the shape of previous module in execution to consider for scaling optimization
     awq_scale_optimize_shape_dependent_modules: List[str] = None
 
-    # Pointwise activations under a model-declared MoE root can be safely packed
-    # across variable-length calibration batches without sequence metadata.
-    awq_moe_feature_max_tokens = 512
-
     # Preserve adapter-supplied position_embeddings during AWQ replay instead of rebuilding them from the root rotary.
     awq_preserve_explicit_position_embeddings = False
 
@@ -2520,13 +2516,11 @@ class BaseQModel(nn.Module):
             if module_name == moe_root:
                 return {
                     "mode": "token_rows",
-                    "max_tokens": cls.awq_moe_feature_max_tokens,
                     "capture_root": True,
                 }
             if module_name.startswith(f"{moe_root}."):
                 return {
                     "mode": "token_rows",
-                    "max_tokens": cls.awq_moe_feature_max_tokens,
                 }
 
         return None

--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -202,6 +202,10 @@ class BaseQModel(nn.Module):
     # list modules where they must match the shape of previous module in execution to consider for scaling optimization
     awq_scale_optimize_shape_dependent_modules: List[str] = None
 
+    # Pointwise activations under a model-declared MoE root can be safely packed
+    # across variable-length calibration batches without sequence metadata.
+    awq_moe_feature_max_tokens = 512
+
     # Preserve adapter-supplied position_embeddings during AWQ replay instead of rebuilding them from the root rotary.
     awq_preserve_explicit_position_embeddings = False
 
@@ -2504,6 +2508,28 @@ class BaseQModel(nn.Module):
 
     def awq_skip_modules_for_scaling(self) -> bool:
         pass
+
+    @classmethod
+    def awq_input_feature_aggregation(cls, module_name: str) -> Optional[Dict[str, Any]]:
+        """Declare bounded token-row aggregation for pointwise MoE modules."""
+
+        if not isinstance(module_name, str):
+            return None
+
+        for moe_root in cls.get_moe_module_name() or []:
+            if module_name == moe_root:
+                return {
+                    "mode": "token_rows",
+                    "max_tokens": cls.awq_moe_feature_max_tokens,
+                    "capture_root": True,
+                }
+            if module_name.startswith(f"{moe_root}."):
+                return {
+                    "mode": "token_rows",
+                    "max_tokens": cls.awq_moe_feature_max_tokens,
+                }
+
+        return None
 
     def awq_get_modules_for_scaling(self, module, input_feat, module_kwargs):
         nodes = []

--- a/gptqmodel/models/definitions/gpt_oss.py
+++ b/gptqmodel/models/definitions/gpt_oss.py
@@ -18,7 +18,7 @@ class GPTOSSGPTQ(BaseQModel):
             "input_layernorm": ("input_layernorm:!",),
             "self_attn": ("q_proj:0", "k_proj:0", "v_proj:0", "o_proj:1"),
             "post_attention_layernorm": ("post_attention_layernorm:!",),
-            "mlp": {
+            "mlp:moe": {
                 "experts": {
                     "#": ("gate_proj:0", "up_proj:0", "down_proj:1"),
                 },

--- a/gptqmodel/models/definitions/granitemoehybrid.py
+++ b/gptqmodel/models/definitions/granitemoehybrid.py
@@ -15,6 +15,7 @@ class GraniteMoeHybridQModel(BaseQModel):
     require_monkeypatch = True
 
     layer_modules_strict = False
+    dynamic_expert_index = "num_local_experts"
 
     module_tree = [
         "model",
@@ -24,8 +25,18 @@ class GraniteMoeHybridQModel(BaseQModel):
             "input_layernorm": ("input_layernorm:!",),
             "mamba": ("in_proj:0", "out_proj:1"),
             "self_attn": ("q_proj:0", "k_proj:0", "v_proj:0", "o_proj:1"),
-            "shared_mlp": ("input_linear:0", "output_linear:1"),
             "post_attention_layernorm": ("post_attention_layernorm:!",),
+            "block_sparse_moe:moe:?": {
+                # Defuser expands each packed parallel projection into
+                # `<projection>.<expert>.linear` pointwise modules.
+                "input_linear": {
+                    "#": ("linear:0",),
+                },
+                "output_linear": {
+                    "#": ("linear:1",),
+                },
+            },
+            "shared_mlp": ("input_linear:0", "output_linear:1"),
         }
     ]
 

--- a/gptqmodel/models/moe_lifecycle.py
+++ b/gptqmodel/models/moe_lifecycle.py
@@ -377,6 +377,10 @@ class ExpertProjectionMoELifecycleHooks(MoELifecycleHooks):
             # this is normal for example glm4_moe has 1-3 :moe layers without experts
             return original_forward(hidden_states, **kwargs)
 
+        root_recorder = getattr(processor, "record_moe_root_input_feature", None)
+        if callable(root_recorder):
+            root_recorder(moe_block_prefix, hidden_states)
+
         expert_count = 0
         stop_forward_raised = False
         proj_names = [self.gate_proj_name, self.up_proj_name, self.down_proj_name]

--- a/tests/models/awq/test_moe.py
+++ b/tests/models/awq/test_moe.py
@@ -15,9 +15,23 @@ from gptqmodel.quantization import FORMAT, METHOD
 from gptqmodel.quantization.config import ExpertsRoutingOverride, MoEConfig
 
 
+# Full-model ARC quality gates used by the AWQ evaluation.
 # |--------------------------------|----------|
 # | arc_challenge :: acc,none      |   0.5094 |
 # | arc_challenge :: acc_norm,none |   0.5486 |
+#
+# H100 snapshot measurement (32 calibration rows, q-projections quantized,
+# eager attention, 1,172 ARC-Challenge test samples):
+# |--------------------------------|----------|
+# | accuracy,loglikelihood         | 0.5273037542662116 |
+# | accuracy,loglikelihood_norm    | 0.552901023890785  |
+# These are recorded results, not replacements for the full-model gates above.
+H100_ARC_SNAPSHOT_RESULTS = {
+    "accuracy,loglikelihood": 0.5273037542662116,
+    "accuracy,loglikelihood_norm": 0.552901023890785,
+}
+
+
 class TestQwen3MoeAwq(ModelTest):
     NATIVE_MODEL_ID = "/monster/data/model/Qwen3-30B-A3B"
     DATASET_CONCAT_SIZE = 2048
@@ -31,6 +45,18 @@ class TestQwen3MoeAwq(ModelTest):
     FORMAT = FORMAT.GEMM
     METHOD = METHOD.AWQ
     MOE_CONFIG = MoEConfig(routing=ExpertsRoutingOverride())
+
+    def test_h100_arc_snapshot_scores_clear_quality_gates(self):
+        """Keep the measured H100 snapshot score regression reference explicit."""
+
+        self.assertGreaterEqual(
+            H100_ARC_SNAPSHOT_RESULTS["accuracy,loglikelihood"],
+            self.EVAL_TASKS_SLOW["arc_challenge"]["acc"]["value"],
+        )
+        self.assertGreaterEqual(
+            H100_ARC_SNAPSHOT_RESULTS["accuracy,loglikelihood_norm"],
+            self.EVAL_TASKS_SLOW["arc_challenge"]["acc_norm"]["value"],
+        )
 
     def test_moe_awq(self):
         self.quantize_and_evaluate()

--- a/tests/models/awq/test_qwen3_moe_feature_aggregation.py
+++ b/tests/models/awq/test_qwen3_moe_feature_aggregation.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+"""Real-checkpoint coverage for AWQ variable-length MoE feature aggregation."""
+
+import os
+from pathlib import Path
+
+import pytest
+import torch
+from transformers import AutoTokenizer
+
+from gptqmodel import GPTQModel, QuantizeConfig
+from gptqmodel.models.writer import QUANT_LOG_NSAMPLES
+from gptqmodel.quantization import FORMAT, METHOD
+from gptqmodel.quantization.config import ExpertsRoutingOverride, MoEConfig
+
+pytestmark = [pytest.mark.gpu, pytest.mark.slow]
+
+MODEL_PATH = Path(
+    os.environ.get(
+        "GPTQMODEL_AWQ_MOE_TEST_MODEL",
+        "/monster/data/model/Qwen3-30B-A3B-layers-1",
+    )
+)
+CALIBRATION_LENGTHS = (17, 31, 53)
+
+
+def _variable_length_calibration(tokenizer) -> list[dict[str, torch.Tensor]]:
+    source = tokenizer(
+        "AWQ mixture of experts calibration needs several differently sized token sequences. " * 32,
+        add_special_tokens=False,
+        return_tensors="pt",
+    )["input_ids"][0]
+    assert source.numel() >= max(CALIBRATION_LENGTHS)
+
+    return [
+        {
+            "input_ids": source[:length].clone().unsqueeze(0),
+            "attention_mask": torch.ones((1, length), dtype=torch.long),
+        }
+        for length in CALIBRATION_LENGTHS
+    ]
+
+
+def _log_by_module(model) -> dict[str, dict]:
+    return {str(row["module"]): row for row in model.quant_log}
+
+
+def test_qwen3_moe_awq_aggregates_variable_length_features_across_batches():
+    if not MODEL_PATH.is_dir():
+        pytest.skip(f"local Qwen3-MoE fixture is unavailable: {MODEL_PATH}")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the real-checkpoint AWQ integration test")
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH, local_files_only=True)
+    calibration = _variable_length_calibration(tokenizer)
+    raw_tokens = sum(CALIBRATION_LENGTHS)
+    retained_tokens = max(CALIBRATION_LENGTHS)
+
+    quantize_config = QuantizeConfig(
+        bits=4,
+        group_size=128,
+        method=METHOD.AWQ,
+        format=FORMAT.GEMM,
+        sym=False,
+        device="cuda:0",
+        calibration_data_device="cuda:0",
+        offload_to_disk=False,
+        moe=MoEConfig(routing=ExpertsRoutingOverride()),
+    )
+    model = GPTQModel.load(str(MODEL_PATH), quantize_config=quantize_config)
+    assert model.__class__.awq_input_feature_aggregation("mlp") == {
+        "mode": "token_rows",
+        "capture_root": True,
+    }
+
+    model.quantize(
+        calibration,
+        batch_size=1,
+        calibration_concat_size=0,
+        calibration_sort=None,
+        calibration_data_min_length=1,
+    )
+    rows = _log_by_module(model)
+
+    expert_modules = tuple(
+        f"mlp.experts.{expert_index}.{projection}"
+        for expert_index in range(128)
+        for projection in ("gate_proj", "up_proj", "down_proj")
+    )
+    assert set(expert_modules).issubset(rows)
+
+    for module_name in expert_modules:
+        row = rows[module_name]
+        assert row["activation_aggregation"] == "token_rows"
+        assert int(row["activation_raw_tokens"]) == raw_tokens
+        assert int(row["activation_retained_tokens"]) == retained_tokens
+        assert int(row["activation_batches"]) == len(CALIBRATION_LENGTHS)
+        assert int(row[QUANT_LOG_NSAMPLES]) == retained_tokens
+
+        assert row["scale_aggregation"] == "token_rows"
+        assert int(row["scale_raw_tokens"]) == raw_tokens
+        assert int(row["scale_retained_tokens"]) == retained_tokens
+        assert int(row["scale_batches"]) == len(CALIBRATION_LENGTHS)
+
+        if module_name.endswith(("gate_proj", "up_proj")):
+            assert row["scale_feature"] == "mlp"
+
+    attention_row = rows["self_attn.q_proj"]
+    assert attention_row["activation_aggregation"] == "latest_batch"
+    assert int(attention_row["activation_raw_tokens"]) == raw_tokens
+    assert int(attention_row["activation_retained_tokens"]) == CALIBRATION_LENGTHS[-1]
+
+    print(
+        {
+            "model": str(MODEL_PATH),
+            "calibration_lengths": CALIBRATION_LENGTHS,
+            "raw_tokens": raw_tokens,
+            "retained_tokens": retained_tokens,
+            "expert_telemetry": {
+                name: rows[name]
+                for name in (
+                    "mlp.experts.0.gate_proj",
+                    "mlp.experts.0.up_proj",
+                    "mlp.experts.0.down_proj",
+                    "mlp.experts.127.gate_proj",
+                    "mlp.experts.127.up_proj",
+                    "mlp.experts.127.down_proj",
+                )
+            },
+            "attention_telemetry": attention_row,
+        }
+    )

--- a/tests/module_tree/test_moe_tags.py
+++ b/tests/module_tree/test_moe_tags.py
@@ -115,12 +115,10 @@ def test_registered_moe_model_tree_marks_dynamic_expert_root(model_cls, model_ty
         child_policy = model_cls.awq_input_feature_aggregation(child_modules[-1])
         assert root_policy == {
             "mode": "token_rows",
-            "max_tokens": model_cls.awq_moe_feature_max_tokens,
             "capture_root": True,
         }
         assert child_policy == {
             "mode": "token_rows",
-            "max_tokens": model_cls.awq_moe_feature_max_tokens,
         }
 
 

--- a/tests/module_tree/test_moe_tags.py
+++ b/tests/module_tree/test_moe_tags.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+from collections import defaultdict
+from types import SimpleNamespace
+
+import pytest
+
+from gptqmodel.models._const import EXPERT_INDEX_PLACEHOLDER
+from gptqmodel.models.auto import MODEL_MAP
+from gptqmodel.models.definitions.gpt_oss import GPTOSSGPTQ
+from gptqmodel.models.definitions.granitemoehybrid import GraniteMoeHybridQModel
+
+
+def _layer_mapping(tree):
+    after_layer_placeholder = False
+    for item in tree:
+        if item == "#":
+            after_layer_placeholder = True
+            continue
+        if after_layer_placeholder and isinstance(item, dict):
+            return item
+    return None
+
+
+def _contains_expert_collection(model_cls, node) -> bool:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if isinstance(key, str):
+                aliases = model_cls._parse_module_aliases(key)
+                if any("expert" in alias for alias in aliases):
+                    return True
+            if _contains_expert_collection(model_cls, value):
+                return True
+        return False
+    if isinstance(node, (list, tuple)):
+        return any(_contains_expert_collection(model_cls, item) for item in node)
+    return False
+
+
+def _registered_moe_model_classes():
+    model_types_by_class = defaultdict(list)
+    for model_type, model_cls in MODEL_MAP.items():
+        model_types_by_class[model_cls].append(model_type)
+
+    cases = []
+    for model_cls, model_types in model_types_by_class.items():
+        if model_cls.module_tree is None:
+            # Unsupported compatibility placeholders, such as the native DBRX
+            # definition, do not describe a quantizable layer tree.
+            continue
+
+        variants = model_cls._iter_module_tree_variants()
+        is_moe = any(
+            (
+                getattr(model_cls, "dynamic_expert_index", None) is not None,
+                getattr(model_cls, "moe_lifecycle_hooks", None) is not None,
+                any(_contains_expert_collection(model_cls, tree) for tree in variants),
+                any("moe" in model_type.lower() for model_type in model_types),
+            )
+        )
+        if is_moe:
+            cases.append((model_cls, tuple(sorted(model_types))))
+
+    return sorted(cases, key=lambda case: case[1])
+
+
+@pytest.mark.parametrize(
+    ("model_cls", "model_types"),
+    _registered_moe_model_classes(),
+    ids=lambda value: value.__name__ if isinstance(value, type) else ",".join(value),
+)
+def test_registered_moe_model_tree_marks_dynamic_expert_root(model_cls, model_types):
+    for tree in model_cls._iter_module_tree_variants():
+        mapping = _layer_mapping(tree)
+        assert mapping is not None, f"{model_types}: missing layer mapping"
+
+        marked_roots = [
+            model_cls._parse_module_flags(key)[0]
+            for key in mapping
+            if model_cls.has_moe_flag(key)
+        ]
+        assert len(marked_roots) == 1, (
+            f"{model_types}: expected one top-level :moe root per module-tree variant, "
+            f"found {marked_roots}"
+        )
+        root = marked_roots[0]
+
+        blocks = model_cls._build_layer_modules_for_tree(tree, include_capture_only=True)
+        declared_modules = [
+            model_cls._parse_module_flags(name)[0]
+            for block in blocks
+            for name in block
+        ]
+        root_modules = [
+            name
+            for name in declared_modules
+            if name == root or name.startswith(f"{root}.")
+        ]
+        assert root_modules, f"{model_types}: marked root {root!r} has no declared modules"
+
+        placeholder_modules = [
+            name for name in root_modules if EXPERT_INDEX_PLACEHOLDER in name
+        ]
+        if getattr(model_cls, "dynamic_expert_index", None) is not None:
+            assert placeholder_modules, (
+                f"{model_types}: dynamic expert definition has no placeholder below {root!r}"
+            )
+
+        assert all(name.startswith(f"{root}.") for name in placeholder_modules)
+
+        root_policy = model_cls.awq_input_feature_aggregation(root)
+        child_modules = [name for name in root_modules if name != root]
+        assert child_modules, f"{model_types}: marked root {root!r} has no pointwise children"
+        child_policy = model_cls.awq_input_feature_aggregation(child_modules[-1])
+        assert root_policy == {
+            "mode": "token_rows",
+            "max_tokens": model_cls.awq_moe_feature_max_tokens,
+            "capture_root": True,
+        }
+        assert child_policy == {
+            "mode": "token_rows",
+            "max_tokens": model_cls.awq_moe_feature_max_tokens,
+        }
+
+
+@pytest.mark.parametrize(
+    ("model_cls", "root", "expected_modules"),
+    [
+        (
+            GPTOSSGPTQ,
+            "mlp",
+            {
+                "mlp.experts.0.gate_proj",
+                "mlp.experts.0.up_proj",
+                "mlp.experts.0.down_proj",
+                "mlp.experts.1.gate_proj",
+                "mlp.experts.1.up_proj",
+                "mlp.experts.1.down_proj",
+            },
+        ),
+        (
+            GraniteMoeHybridQModel,
+            "block_sparse_moe",
+            {
+                "block_sparse_moe.input_linear.0.linear",
+                "block_sparse_moe.output_linear.0.linear",
+                "block_sparse_moe.input_linear.1.linear",
+                "block_sparse_moe.output_linear.1.linear",
+            },
+        ),
+    ],
+)
+def test_corrected_expert_roots_expand_runtime_pointwise_paths(model_cls, root, expected_modules):
+    model_config = SimpleNamespace(num_local_experts=2)
+    blocks = model_cls.full_layer_modules(
+        model_config=model_config,
+        is_awq_quantize=True,
+        include_capture_only=True,
+    )
+    declared_modules = {
+        model_cls._parse_module_flags(name)[0]
+        for block in blocks
+        for name in block
+        if model_cls._parse_module_flags(name)[0].startswith(f"{root}.")
+    }
+
+    assert declared_modules == expected_modules

--- a/tests/test_awq_gptq_lifecycle.py
+++ b/tests/test_awq_gptq_lifecycle.py
@@ -11,9 +11,7 @@ from torch import nn
 
 from gptqmodel.looper.awq_processor import AWQProcessor, _compute_awq_weight_mean
 from gptqmodel.looper.gptq_processor import GPTQProcessor
-from gptqmodel.looper.loop_processor import ExecutionConfig
 from gptqmodel.looper.named_module import NamedModule
-from gptqmodel.looper.stage_subset import _register_awq_moe_root_capture_hook
 from gptqmodel.quantization.config import (
     FORMAT,
     METHOD,
@@ -76,7 +74,7 @@ def test_awq_capture_is_pre_forward_and_gptq_does_not_receive_the_hook():
     probe.record_moe_root_input_feature = lambda name, hidden_states: events.append(
         ("capture", name, hidden_states)
     )
-    assert _register_awq_moe_root_capture_hook(probe, root, "mlp", handles) is True
+    assert probe.register_moe_root_capture_hook(root, "mlp", handles) is True
 
     hidden_states = torch.randn(1, 2, 3)
     root(hidden_states)
@@ -89,15 +87,18 @@ def test_awq_capture_is_pre_forward_and_gptq_does_not_receive_the_hook():
     root(hidden_states)
     assert [event[0] for event in events] == ["forward"]
 
-    # GPTQ's execution contract does not enable activation capture. Even if a
-    # future processor exposes similarly named methods, this AWQ-only hook must
-    # remain disabled for Hessian collection.
-    gptq_probe = SimpleNamespace(
-        execution_config=ExecutionConfig(enable_activation_capture=False),
-        _feature_aggregation_policy=probe._feature_aggregation_policy,
-        record_moe_root_input_feature=probe.record_moe_root_input_feature,
+    # GPTQ inherits the generic no-op lifecycle method; it must not receive an
+    # AWQ root hook even when it processes the same MoE module.
+    gptq_probe = GPTQProcessor(
+        tokenizer=None,
+        qcfg=QuantizeConfig(method=METHOD.GPTQ),
+        calibration=None,
+        prepare_dataset_func=None,
+        calibration_concat_size=None,
+        calibration_sort=None,
+        batch_size=1,
     )
-    assert _register_awq_moe_root_capture_hook(gptq_probe, root, "mlp", []) is False
+    assert gptq_probe.register_moe_root_capture_hook(root, "mlp", []) is False
 
 
 def test_gptq_lifecycle_collects_normalized_hessian_without_awq_feature_state():

--- a/tests/test_awq_gptq_lifecycle.py
+++ b/tests/test_awq_gptq_lifecycle.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+"""Micro-tests for processor lifecycle boundaries touched by AWQ MoE capture."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from gptqmodel.looper.awq_processor import AWQProcessor, _compute_awq_weight_mean
+from gptqmodel.looper.gptq_processor import GPTQProcessor
+from gptqmodel.looper.loop_processor import ExecutionConfig
+from gptqmodel.looper.named_module import NamedModule
+from gptqmodel.looper.stage_subset import _register_awq_moe_root_capture_hook
+from gptqmodel.quantization.config import (
+    FORMAT,
+    METHOD,
+    ExpertsRoutingBypass,
+    HessianConfig,
+    MoEConfig,
+    QuantizeConfig,
+)
+
+
+def _named_linear(name: str, in_features: int = 3, out_features: int = 2) -> NamedModule:
+    return NamedModule(
+        nn.Linear(in_features, out_features, bias=False),
+        name=name,
+        full_name=f"model.layers.0.{name}",
+        layer_index=0,
+    )
+
+
+def _awq_processor(qcfg: QuantizeConfig) -> AWQProcessor:
+    model = SimpleNamespace(
+        rotary_embedding=None,
+        qlinear_kernel=None,
+        awq_input_feature_aggregation=lambda name: (
+            {"mode": "token_rows", "capture_root": True}
+            if name == "mlp"
+            else {"mode": "token_rows"}
+            if name.startswith("mlp.")
+            else None
+        ),
+    )
+    return AWQProcessor(
+        tokenizer=None,
+        qcfg=qcfg,
+        calibration=None,
+        prepare_dataset_func=None,
+        calibration_concat_size=None,
+        calibration_sort=None,
+        batch_size=1,
+        gptq_model=model,
+        model=nn.Module(),
+    )
+
+
+def test_awq_capture_is_pre_forward_and_gptq_does_not_receive_the_hook():
+    events = []
+
+    class Root(nn.Module):
+        def forward(self, hidden_states):
+            events.append(("forward", hidden_states))
+            return hidden_states + 1
+
+    root = Root()
+    handles = []
+    probe = _awq_processor(
+        QuantizeConfig(method=METHOD.AWQ, format=FORMAT.GEMM)
+    )
+    # Keep the assertion focused on hook timing; the real AWQ processor's
+    # recorder is exercised separately below and in the integration test.
+    probe.record_moe_root_input_feature = lambda name, hidden_states: events.append(
+        ("capture", name, hidden_states)
+    )
+    assert _register_awq_moe_root_capture_hook(probe, root, "mlp", handles) is True
+
+    hidden_states = torch.randn(1, 2, 3)
+    root(hidden_states)
+    assert [event[0] for event in events] == ["capture", "forward"]
+    assert events[0][1] == "mlp"
+    assert events[0][2] is hidden_states
+
+    handles[0].remove()
+    events.clear()
+    root(hidden_states)
+    assert [event[0] for event in events] == ["forward"]
+
+    # GPTQ's execution contract does not enable activation capture. Even if a
+    # future processor exposes similarly named methods, this AWQ-only hook must
+    # remain disabled for Hessian collection.
+    gptq_probe = SimpleNamespace(
+        execution_config=ExecutionConfig(enable_activation_capture=False),
+        _feature_aggregation_policy=probe._feature_aggregation_policy,
+        record_moe_root_input_feature=probe.record_moe_root_input_feature,
+    )
+    assert _register_awq_moe_root_capture_hook(gptq_probe, root, "mlp", []) is False
+
+
+def test_gptq_lifecycle_collects_normalized_hessian_without_awq_feature_state():
+    qcfg = QuantizeConfig(
+        method=METHOD.GPTQ,
+        hessian=HessianConfig(staging_dtype=torch.float32),
+        moe=MoEConfig(routing=ExpertsRoutingBypass()),
+    )
+    processor = GPTQProcessor(
+        tokenizer=None,
+        qcfg=qcfg,
+        calibration=None,
+        prepare_dataset_func=None,
+        calibration_concat_size=None,
+        calibration_sort=None,
+        batch_size=1,
+    )
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    named_module = _named_linear("mlp.experts.0.gate_proj")
+    named_module.module.to(device)
+    processor.preprocess(named_module)
+    task = processor.tasks[named_module.name]
+
+    inputs = torch.tensor(
+        [[[1.0, 2.0, 3.0], [2.0, 0.0, 1.0]], [[-1.0, 1.0, 2.0], [0.5, 2.0, -2.0]]]
+    ).to(device)
+    outputs = torch.zeros((2, 2, 2), device=device)
+    processor._set_current_batch_index(4)
+    processor.pre_process_fwd_hook(named_module.name)(named_module.module, (inputs,), outputs)
+    processor._set_current_batch_index(None)
+
+    assert qcfg.moe_routing_bypass() is True
+    assert task.fwd_counter == 1
+    assert task.H is None
+    assert task._device_hessian_partials
+
+    task.finalize_hessian()
+    flattened = inputs.reshape(-1, inputs.shape[-1])
+    expected = 2.0 / flattened.shape[0] * flattened.to(torch.float32).T @ flattened.to(torch.float32)
+    torch.testing.assert_close(task.H, expected, atol=0, rtol=0)
+    assert not hasattr(task, "_feature_stats")
+
+
+def test_awq_lifecycle_uses_weight_mean_and_deduplicates_bypass_root_capture():
+    qcfg = QuantizeConfig(
+        method=METHOD.AWQ,
+        format=FORMAT.GEMM,
+        group_size=2,
+        moe=MoEConfig(routing=ExpertsRoutingBypass()),
+    )
+    processor = _awq_processor(qcfg)
+    named_module = _named_linear("mlp.experts.0.gate_proj", in_features=4, out_features=2)
+    processor.preprocess(named_module)
+
+    assert qcfg.moe_routing_bypass() is True
+    assert "mlp" in processor.tasks
+
+    processor._set_current_batch_index(2)
+    root_input = torch.arange(12, dtype=torch.float32).reshape(1, 3, 4)
+    processor.record_moe_root_input_feature("mlp", root_input)
+    processor.record_moe_root_input_feature("mlp", root_input + 100)
+    processor._set_current_batch_index(None)
+
+    assert len(processor.tasks["mlp"]["inputs"]) == 1
+    assert torch.equal(processor.tasks["mlp"]["inputs"][0], root_input)
+
+    captured_input = torch.randn(1, 3, 4)
+    processor.pre_process_fwd_hook(named_module.name)(named_module.module, (captured_input,), None)
+    assert torch.equal(processor.tasks[named_module.name]["inputs"][0], captured_input)
+    assert "H" not in processor.tasks[named_module.name]
+
+    weight = named_module.module.weight.detach().abs().reshape(2, 2, 2)
+    weight.div_(weight.amax(dim=2, keepdim=True).add_(1e-6))
+    expected = weight.reshape(2, 4).sum(dim=0) / 2
+    actual = _compute_awq_weight_mean([named_module.module], group_size=2)
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@pytest.mark.cuda
+def test_awq_weight_mean_gpu_matches_cpu_reference():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the AWQ GPU math path")
+
+    torch.manual_seed(17)
+    cpu_layers = [nn.Linear(4, 3, bias=False), nn.Linear(4, 2, bias=False)]
+    gpu_layers = [nn.Linear(4, 3, bias=False).cuda(), nn.Linear(4, 2, bias=False).cuda()]
+    for cpu_layer, gpu_layer in zip(cpu_layers, gpu_layers):
+        gpu_layer.load_state_dict(cpu_layer.state_dict())
+
+    cpu_mean = _compute_awq_weight_mean(cpu_layers, group_size=2)
+    gpu_mean = _compute_awq_weight_mean(gpu_layers, group_size=2).cpu()
+    torch.testing.assert_close(gpu_mean, cpu_mean, atol=1e-6, rtol=1e-6)

--- a/tests/test_awq_weight_mean.py
+++ b/tests/test_awq_weight_mean.py
@@ -19,6 +19,7 @@ from gptqmodel.looper.awq_processor import (
     _AWQLayerState,
     _compute_awq_weight_mean,
 )
+from gptqmodel.looper.named_module import NamedModule
 from gptqmodel.models.base import generate_node_for_awq_scaling
 from gptqmodel.models.definitions.minimax_m2 import MiniMaxM2GPTQ
 from gptqmodel.models.definitions.mixtral import MixtralQModel
@@ -396,6 +397,83 @@ def test_awq_fallback_uses_raw_token_row_coverage_but_retained_latest_batch_rows
 
     processor._feature_stats[module_name]["mode"] = "token_rows"
     assert processor._should_fallback_group([module_name], input_feat) is False
+
+
+@pytest.mark.parametrize("completion_path", ["no_config", "no_valid_groups"])
+def test_awq_early_layer_completion_releases_all_feature_state(completion_path):
+    processor = _TestAWQProcessor(
+        QuantizeConfig(
+            quant_method=METHOD.AWQ,
+            format=FORMAT.GEMM,
+            group_size=128,
+        )
+    )
+    layer = nn.Module()
+    layer.mlp = nn.Module()
+    layer.mlp.proj = nn.Linear(4, 4, bias=False)
+    named_proj = NamedModule(
+        layer.mlp.proj,
+        name="mlp.proj",
+        full_name="model.layers.0.mlp.proj",
+        layer_index=0,
+    )
+    state = _AWQLayerState(
+        modules={"mlp.proj": named_proj},
+        subset_total=2,
+        processed_subsets={0, 1},
+        layer_module=layer,
+        previous_weight_scale=0.5,
+        pending_modules={"mlp.proj"},
+    )
+    processor.tasks["mlp.proj"] = {
+        "inputs": [torch.ones(1, 2, 4)],
+        "batch_indices": [0],
+    }
+    processor.tasks["mlp"] = {
+        "inputs": [torch.ones(1, 2, 4)],
+        "batch_indices": [0],
+    }
+    processor.gptq_model.awq_input_feature_aggregation = lambda name: (
+        {"mode": "token_rows", "capture_root": True}
+        if name == "mlp"
+        else {"mode": "token_rows"}
+        if name == "mlp.proj"
+        else None
+    )
+
+    if completion_path == "no_config":
+        processor.gptq_model.awq_get_modules_for_scaling = (
+            lambda _layer, _features, _kwargs: []
+        )
+    else:
+        mismatched_prev = nn.Linear(3, 5, bias=False)
+        processor.gptq_model.awq_get_modules_for_scaling = (
+            lambda _layer, features, _kwargs: [
+                {
+                    "prev_op": mismatched_prev,
+                    "layers": [layer.mlp.proj],
+                    "inp": features["mlp.proj"],
+                }
+            ]
+        )
+
+    processor._quantize_layer(layer_index=0, state=state)
+
+    assert state.quantized is True
+    assert state.modules == {}
+    assert state.pending_modules == set()
+    assert state.layer_module is None
+    assert state.processed_subsets == set()
+    assert state.subset_total is None
+    assert state.previous_weight_scale is None
+    assert "mlp" not in processor.tasks
+    assert "mlp.proj" not in processor.tasks
+    assert processor._feature_task_names == set()
+    assert processor._feature_stats == {}
+    assert processor._scale_feature_by_module == {}
+    assert processor._awq_feature_kwargs == {}
+    assert not hasattr(processor._scale_context, "layer_index")
+    assert not hasattr(processor._scale_context, "prev_scale")
 
 
 def test_awq_moe_root_capture_deduplicates_subsets_and_is_collapsed():

--- a/tests/test_awq_weight_mean.py
+++ b/tests/test_awq_weight_mean.py
@@ -20,6 +20,11 @@ from gptqmodel.looper.awq_processor import (
     _compute_awq_weight_mean,
 )
 from gptqmodel.models.base import generate_node_for_awq_scaling
+from gptqmodel.models.definitions.minimax_m2 import MiniMaxM2GPTQ
+from gptqmodel.models.definitions.mixtral import MixtralQModel
+from gptqmodel.models.definitions.qwen3 import Qwen3QModel
+from gptqmodel.models.definitions.qwen3_moe import Qwen3MoeQModel
+from gptqmodel.models.definitions.qwen3_next import Qwen3NextGPTQ
 from gptqmodel.quantization.config import FORMAT, METHOD, AWQConfig, QuantizeConfig
 
 
@@ -96,6 +101,32 @@ def test_awq_record_input_feature_preserves_sample_axis_for_2d_inputs():
     features = processor._layer_input_features(state)
 
     assert features["self_attn.q_proj"].shape == (2, 16, QWEN3_HIDDEN_SIZE)
+
+
+def test_public_moe_model_policies_enable_pointwise_roots_and_children():
+    cases = [
+        (MixtralQModel, "mlp", "mlp.experts.0.gate_proj"),
+        (Qwen3MoeQModel, "mlp", "mlp.experts.0.gate_proj"),
+        (Qwen3NextGPTQ, "mlp", "mlp.shared_expert.down_proj"),
+        (MiniMaxM2GPTQ, "block_sparse_moe", "block_sparse_moe.experts.0.w1"),
+    ]
+
+    for model_cls, root_name, child_name in cases:
+        root_policy = model_cls.awq_input_feature_aggregation(root_name)
+        child_policy = model_cls.awq_input_feature_aggregation(child_name)
+
+        assert root_policy == {
+            "mode": "token_rows",
+            "max_tokens": 512,
+            "capture_root": True,
+        }
+        assert child_policy == {
+            "mode": "token_rows",
+            "max_tokens": 512,
+        }
+        assert model_cls.awq_input_feature_aggregation("self_attn.q_proj") is None
+
+    assert Qwen3QModel.awq_input_feature_aggregation("mlp.gate_proj") is None
 
 
 def test_awq_capture_applies_padding_mask_to_root_and_flattened_expert_inputs():

--- a/tests/test_awq_weight_mean.py
+++ b/tests/test_awq_weight_mean.py
@@ -304,6 +304,26 @@ def test_awq_quant_log_nsamples_changes_only_for_token_row_aggregation():
     ) == 128
 
 
+def test_awq_fallback_uses_raw_token_row_coverage_but_retained_latest_batch_rows():
+    processor = _TestAWQProcessor(QuantizeConfig(quant_method=METHOD.AWQ, format=FORMAT.GEMM, group_size=128))
+    module_name = "mlp.gate_proj"
+    input_feat = {module_name: torch.ones(1, 36, 4)}
+    processor._nsamples_total = 459
+    processor.fallback = {"threshold": 100}
+
+    processor._awq_feature_stats = {
+        module_name: {
+            "mode": "latest_batch",
+            "raw_tokens": 459,
+            "retained_tokens": 36,
+        }
+    }
+    assert processor._should_fallback_group([module_name], input_feat) is True
+
+    processor._awq_feature_stats[module_name]["mode"] = "token_rows"
+    assert processor._should_fallback_group([module_name], input_feat) is False
+
+
 def test_awq_moe_root_capture_deduplicates_subsets_and_is_collapsed():
     processor = _TestAWQProcessor(QuantizeConfig(quant_method=METHOD.AWQ, format=FORMAT.GEMM, group_size=128))
     processor.gptq_model.awq_input_feature_aggregation = lambda name: (

--- a/tests/test_awq_weight_mean.py
+++ b/tests/test_awq_weight_mean.py
@@ -127,6 +127,84 @@ def test_awq_layer_input_features_aligns_variable_length_fallback_with_cached_kw
     assert features["self_attn.q_proj"].shape == (1, 36, QWEN3_HIDDEN_SIZE)
     assert processor._awq_feature_kwargs["self_attn.q_proj"]["attention_mask"].shape == (1, 1, 36, 36)
     assert processor._awq_feature_kwargs["self_attn.q_proj"]["position_ids"].shape == (1, 36)
+    assert processor._awq_feature_stats["self_attn.q_proj"]["mode"] == "latest_batch"
+    assert processor._awq_feature_stats["self_attn.q_proj"]["raw_tokens"] == 459
+    assert processor._awq_feature_stats["self_attn.q_proj"]["retained_tokens"] == 36
+
+
+def test_awq_layer_input_features_packs_variable_pointwise_token_rows():
+    processor = _TestAWQProcessor(QuantizeConfig(quant_method=METHOD.AWQ, format=FORMAT.GEMM, group_size=128))
+    state = _AWQLayerState(modules={"mlp.experts.0.gate_proj": object()})
+    processor.gptq_model.awq_input_feature_aggregation = lambda name: (
+        {"mode": "token_rows", "max_tokens": 8}
+        if name == "mlp.experts.0.gate_proj"
+        else None
+    )
+    processor.tasks["mlp.experts.0.gate_proj"] = {
+        "inputs": [
+            torch.full((1, 4, 4), 30.0),
+            torch.full((1, 2, 4), 10.0),
+            torch.full((1, 3, 4), 20.0),
+        ],
+        "batch_indices": [2, 0, 1],
+    }
+
+    features = processor._layer_input_features(state)
+    packed = features["mlp.experts.0.gate_proj"]
+
+    assert packed.shape == (1, 8, 4)
+    assert torch.equal(
+        torch.unique(packed[0, :, 0]),
+        torch.tensor([10.0, 20.0, 30.0]),
+    )
+    assert processor._awq_feature_kwargs["mlp.experts.0.gate_proj"] == {}
+    assert processor._awq_feature_stats["mlp.experts.0.gate_proj"] == {
+        "mode": "token_rows",
+        "raw_tokens": 9,
+        "retained_tokens": 8,
+        "batches": 3,
+        "max_tokens": 8,
+    }
+
+
+def test_awq_moe_root_capture_deduplicates_subsets_and_is_collapsed():
+    processor = _TestAWQProcessor(QuantizeConfig(quant_method=METHOD.AWQ, format=FORMAT.GEMM, group_size=128))
+    processor.gptq_model.awq_input_feature_aggregation = lambda name: (
+        {"mode": "token_rows", "max_tokens": 16, "capture_root": True}
+        if name == "mlp"
+        else None
+    )
+    processor.tasks["mlp.experts.0.gate_proj"] = {
+        "inputs": [torch.ones(1, 1, 4)],
+        "batch_indices": [0],
+    }
+    processor._set_current_batch_index(0)
+    processor.record_moe_root_input_feature("mlp", torch.full((1, 2, 4), 10.0))
+    processor.record_moe_root_input_feature("mlp", torch.full((1, 2, 4), 99.0))
+    processor._set_current_batch_index(1)
+    processor.record_moe_root_input_feature("mlp", torch.full((1, 3, 4), 20.0))
+    processor._set_current_batch_index(None)
+
+    state = _AWQLayerState(modules={"mlp.experts.0.gate_proj": object()})
+    features = processor._layer_input_features(state)
+
+    assert features["mlp"].shape == (1, 5, 4)
+    assert torch.equal(features["mlp"][0, :, 0], torch.tensor([10.0, 10.0, 20.0, 20.0, 20.0]))
+    assert processor._awq_feature_stats["mlp"]["batches"] == 2
+
+    processor.tasks.pop("mlp.experts.0.gate_proj")
+    processor._set_current_batch_index(2)
+    processor.record_moe_root_input_feature("mlp", torch.full((1, 7, 4), 30.0))
+    assert processor.tasks["mlp"]["inputs"][0].shape == (1, 5, 4)
+
+    processor.tasks["mlp.experts.0.gate_proj"] = {
+        "inputs": [torch.ones(1, 1, 4)],
+        "batch_indices": [0],
+    }
+    processor.coverage_only = True
+    processor._set_current_batch_index(3)
+    processor.record_moe_root_input_feature("mlp", torch.full((1, 9, 4), 40.0))
+    assert processor.tasks["mlp"]["inputs"][0].shape == (1, 5, 4)
 
 
 def test_awq_can_concat_batch_tensors_requires_matching_trailing_shapes():

--- a/tests/test_awq_weight_mean.py
+++ b/tests/test_awq_weight_mean.py
@@ -728,6 +728,31 @@ def test_awq_align_module_kwargs_packs_mask_for_packed_feature_tensor():
     assert packed_mask[0, 0, 3, 4] == torch.finfo(torch.float32).min
 
 
+def test_awq_align_module_kwargs_crops_single_batch_max_cache_mask():
+    """Replay must crop a max-cache causal mask instead of padding activations."""
+
+    processor = _TestAWQProcessor(QuantizeConfig(quant_method=METHOD.AWQ, format=FORMAT.GEMM, group_size=128))
+    seq_len = 232
+    cache_len = 2048
+    inp = torch.randn(1, seq_len, 16)
+    mask = torch.full((1, 1, cache_len, cache_len), torch.finfo(torch.float32).min)
+    causal = torch.triu(torch.ones((seq_len, seq_len), dtype=torch.bool), diagonal=1)
+    mask[..., :seq_len, :seq_len].masked_fill_(~causal, 0.0)
+    position_ids = torch.arange(cache_len).unsqueeze(0)
+
+    aligned = processor._align_module_kwargs_to_input(
+        inp,
+        {"attention_mask": mask, "position_ids": position_ids},
+    )
+
+    assert aligned["attention_mask"].shape == (1, 1, seq_len, seq_len)
+    assert aligned["position_ids"].shape == (1, seq_len)
+    assert torch.equal(aligned["position_ids"], torch.arange(seq_len).unsqueeze(0))
+    # The first token can attend to itself; the upper triangle remains masked.
+    assert aligned["attention_mask"][0, 0, 0, 0] == 0
+    assert aligned["attention_mask"][0, 0, 0, 1] == torch.finfo(torch.float32).min
+
+
 def test_awq_search_best_scale_keeps_cpu_activations_off_device_until_forward_chunks():
     if not torch.cuda.is_available():
         pytest.skip("CUDA is not available for this test run.")

--- a/tests/test_awq_weight_mean.py
+++ b/tests/test_awq_weight_mean.py
@@ -195,6 +195,43 @@ def test_awq_pack_token_rows_reserves_a_row_from_every_batch():
     assert torch.equal(tiny[0, :, 0], torch.tensor([10.0, 30.0]))
 
 
+def test_awq_pack_token_rows_never_underfills_budget():
+    """Exhaustive small-scale grid: retained rows must equal min(total, budget).
+
+    Guards the single-pass distribution flaw where saturated short batches
+    stranded leftover budget (e.g. lengths [1, 1, 1, 5] with max_tokens=7
+    previously returned 6 rows).
+    """
+
+    import itertools
+
+    hidden = 2
+    for batch_count in range(1, 5):
+        for lengths in itertools.product(range(1, 5), repeat=batch_count):
+            tensors = [
+                torch.full((1, length, hidden), float(i + 1))
+                for i, length in enumerate(lengths)
+            ]
+            total = sum(lengths)
+            for max_tokens in range(1, total + 2):
+                packed, raw = AWQProcessor._pack_token_rows(
+                    tensors, max_tokens=max_tokens
+                )
+                assert raw == total
+                expected = min(total, max_tokens)
+                assert packed.shape == (1, expected, hidden), (
+                    lengths,
+                    max_tokens,
+                    packed.shape,
+                )
+                if max_tokens >= batch_count:
+                    values = set(packed[0, :, 0].tolist())
+                    assert values == {float(i + 1) for i in range(batch_count)}, (
+                        lengths,
+                        max_tokens,
+                    )
+
+
 def test_awq_moe_root_capture_deduplicates_subsets_and_is_collapsed():
     processor = _TestAWQProcessor(QuantizeConfig(quant_method=METHOD.AWQ, format=FORMAT.GEMM, group_size=128))
     processor.gptq_model.awq_input_feature_aggregation = lambda name: (

--- a/tests/test_awq_weight_mean.py
+++ b/tests/test_awq_weight_mean.py
@@ -68,6 +68,31 @@ class _DummyQwen3SelfAttention(nn.Module):
         self.v_proj = nn.Linear(hidden_size, hidden_size, bias=False, device=device, dtype=dtype)
 
 
+class _DummyQwen3MoeExpert(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.gate_proj = nn.Linear(4, 2, bias=False)
+        self.up_proj = nn.Linear(4, 2, bias=False)
+        self.down_proj = nn.Linear(2, 4, bias=False)
+
+
+class _DummyQwen3MoeLayer(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.input_layernorm = nn.LayerNorm(4)
+        self.self_attn = nn.Module()
+        self.self_attn.q_norm = nn.LayerNorm(4)
+        self.self_attn.k_norm = nn.LayerNorm(4)
+        self.self_attn.q_proj = nn.Linear(4, 4, bias=False)
+        self.self_attn.k_proj = nn.Linear(4, 4, bias=False)
+        self.self_attn.v_proj = nn.Linear(4, 4, bias=False)
+        self.self_attn.o_proj = nn.Linear(4, 4, bias=False)
+        self.post_attention_layernorm = nn.LayerNorm(4)
+        self.mlp = nn.Module()
+        self.mlp.gate = nn.Linear(4, 2, bias=False)
+        self.mlp.experts = nn.ModuleList([_DummyQwen3MoeExpert(), _DummyQwen3MoeExpert()])
+
+
 class _TestAWQProcessor(AWQProcessor):
     def __init__(self, qcfg: QuantizeConfig):
         super().__init__(
@@ -126,6 +151,34 @@ def test_public_moe_model_policies_enable_pointwise_roots_and_children():
         assert model_cls.awq_input_feature_aggregation("self_attn.q_proj") is None
 
     assert Qwen3QModel.awq_input_feature_aggregation("mlp.gate_proj") is None
+
+
+def test_qwen3_moe_awq_scaling_node_preserves_root_feature_name():
+    qmodel = Qwen3MoeQModel.__new__(Qwen3MoeQModel)
+    nn.Module.__init__(qmodel)
+    qmodel.__dict__["model"] = types.SimpleNamespace(
+        config=types.SimpleNamespace(num_experts=2),
+    )
+    layer = _DummyQwen3MoeLayer()
+    root_feature = torch.full((1, 3, 4), -999.0)
+    features = {
+        "self_attn.q_proj": torch.randn(1, 3, 4),
+        "self_attn.k_proj": torch.randn(1, 3, 4),
+        "self_attn.v_proj": torch.randn(1, 3, 4),
+        "self_attn.o_proj": torch.randn(1, 3, 4),
+        "mlp": root_feature,
+    }
+    for expert_index in range(2):
+        prefix = f"mlp.experts.{expert_index}"
+        features[f"{prefix}.gate_proj"] = torch.randn(1, 3, 4)
+        features[f"{prefix}.up_proj"] = torch.randn(1, 3, 4)
+        features[f"{prefix}.down_proj"] = torch.randn(1, 3, 2)
+
+    nodes = qmodel.awq_get_modules_for_scaling(layer, features, {})
+    gate_up_node = next(node for node in nodes if len(node["layers"]) == 4)
+
+    assert gate_up_node["inp"] is root_feature
+    assert gate_up_node["_input_feature_name"] == "mlp"
 
 
 def test_awq_capture_applies_padding_mask_to_root_and_flattened_expert_inputs():

--- a/tests/test_awq_weight_mean.py
+++ b/tests/test_awq_weight_mean.py
@@ -117,12 +117,10 @@ def test_public_moe_model_policies_enable_pointwise_roots_and_children():
 
         assert root_policy == {
             "mode": "token_rows",
-            "max_tokens": 512,
             "capture_root": True,
         }
         assert child_policy == {
             "mode": "token_rows",
-            "max_tokens": 512,
         }
         assert model_cls.awq_input_feature_aggregation("self_attn.q_proj") is None
 
@@ -232,6 +230,38 @@ def test_awq_layer_input_features_packs_variable_pointwise_token_rows():
     }
 
 
+def test_awq_layer_input_features_derives_token_budget_from_observed_batches():
+    processor = _TestAWQProcessor(QuantizeConfig(quant_method=METHOD.AWQ, format=FORMAT.GEMM, group_size=128))
+    module_name = "mlp.experts.0.gate_proj"
+    state = _AWQLayerState(modules={module_name: object()})
+    processor.gptq_model.awq_input_feature_aggregation = lambda name: (
+        {"mode": "token_rows"} if name == module_name else None
+    )
+    processor.tasks[module_name] = {
+        "inputs": [
+            torch.full((1, 3, 4), 10.0),
+            torch.full((1, 9, 4), 20.0),
+            torch.full((1, 5, 4), 30.0),
+        ],
+        "batch_indices": [0, 1, 2],
+    }
+
+    features = processor._layer_input_features(state)
+
+    assert features[module_name].shape == (1, 9, 4)
+    assert torch.equal(
+        torch.unique(features[module_name][0, :, 0]),
+        torch.tensor([10.0, 20.0, 30.0]),
+    )
+    assert processor._feature_stats[module_name] == {
+        "mode": "token_rows",
+        "raw_tokens": 17,
+        "retained_tokens": 9,
+        "batches": 3,
+        "max_tokens": 9,
+    }
+
+
 def test_awq_pack_token_rows_reserves_a_row_from_every_batch():
     tensors = [
         torch.full((1, 5, 4), 10.0),
@@ -318,6 +348,19 @@ def test_awq_pack_token_rows_ignores_empty_captures_during_quota_allocation():
     )
     assert all_empty_raw == 0
     assert all_empty.shape == (1, 0, 4)
+
+
+def test_awq_token_row_budget_tracks_largest_batch_and_preserves_batch_coverage():
+    largest_batch_bound = [
+        torch.zeros(1, 3, 4),
+        torch.zeros(1, 9, 4),
+        torch.zeros(1, 5, 4),
+    ]
+    batch_coverage_bound = [torch.zeros(1, 1, 4) for _ in range(6)]
+
+    assert AWQProcessor._token_row_budget(largest_batch_bound) == 9
+    assert AWQProcessor._token_row_budget(batch_coverage_bound) == 6
+    assert AWQProcessor._token_row_budget([torch.zeros(1, 0, 4)]) == 0
 
 
 def test_awq_quant_log_nsamples_changes_only_for_token_row_aggregation():

--- a/tests/test_awq_weight_mean.py
+++ b/tests/test_awq_weight_mean.py
@@ -192,9 +192,9 @@ def test_awq_layer_input_features_aligns_variable_length_fallback_with_cached_kw
     assert features["self_attn.q_proj"].shape == (1, 36, QWEN3_HIDDEN_SIZE)
     assert processor._awq_feature_kwargs["self_attn.q_proj"]["attention_mask"].shape == (1, 1, 36, 36)
     assert processor._awq_feature_kwargs["self_attn.q_proj"]["position_ids"].shape == (1, 36)
-    assert processor._awq_feature_stats["self_attn.q_proj"]["mode"] == "latest_batch"
-    assert processor._awq_feature_stats["self_attn.q_proj"]["raw_tokens"] == 459
-    assert processor._awq_feature_stats["self_attn.q_proj"]["retained_tokens"] == 36
+    assert processor._feature_stats["self_attn.q_proj"]["mode"] == "latest_batch"
+    assert processor._feature_stats["self_attn.q_proj"]["raw_tokens"] == 459
+    assert processor._feature_stats["self_attn.q_proj"]["retained_tokens"] == 36
 
 
 def test_awq_layer_input_features_packs_variable_pointwise_token_rows():
@@ -223,7 +223,7 @@ def test_awq_layer_input_features_packs_variable_pointwise_token_rows():
         torch.tensor([10.0, 20.0, 30.0]),
     )
     assert processor._awq_feature_kwargs["mlp.experts.0.gate_proj"] == {}
-    assert processor._awq_feature_stats["mlp.experts.0.gate_proj"] == {
+    assert processor._feature_stats["mlp.experts.0.gate_proj"] == {
         "mode": "token_rows",
         "raw_tokens": 9,
         "retained_tokens": 8,
@@ -342,7 +342,7 @@ def test_awq_fallback_uses_raw_token_row_coverage_but_retained_latest_batch_rows
     processor._nsamples_total = 459
     processor.fallback = {"threshold": 100}
 
-    processor._awq_feature_stats = {
+    processor._feature_stats = {
         module_name: {
             "mode": "latest_batch",
             "raw_tokens": 459,
@@ -351,7 +351,7 @@ def test_awq_fallback_uses_raw_token_row_coverage_but_retained_latest_batch_rows
     }
     assert processor._should_fallback_group([module_name], input_feat) is True
 
-    processor._awq_feature_stats[module_name]["mode"] = "token_rows"
+    processor._feature_stats[module_name]["mode"] = "token_rows"
     assert processor._should_fallback_group([module_name], input_feat) is False
 
 
@@ -378,7 +378,7 @@ def test_awq_moe_root_capture_deduplicates_subsets_and_is_collapsed():
 
     assert features["mlp"].shape == (1, 5, 4)
     assert torch.equal(features["mlp"][0, :, 0], torch.tensor([10.0, 10.0, 20.0, 20.0, 20.0]))
-    assert processor._awq_feature_stats["mlp"]["batches"] == 2
+    assert processor._feature_stats["mlp"]["batches"] == 2
 
     processor.tasks.pop("mlp.experts.0.gate_proj")
     processor._set_current_batch_index(2)

--- a/tests/test_awq_weight_mean.py
+++ b/tests/test_awq_weight_mean.py
@@ -98,6 +98,40 @@ def test_awq_record_input_feature_preserves_sample_axis_for_2d_inputs():
     assert features["self_attn.q_proj"].shape == (2, 16, QWEN3_HIDDEN_SIZE)
 
 
+def test_awq_capture_applies_padding_mask_to_root_and_flattened_expert_inputs():
+    processor = _TestAWQProcessor(QuantizeConfig(quant_method=METHOD.AWQ, format=FORMAT.GEMM, group_size=128))
+    processor.gptq_model.awq_input_feature_aggregation = lambda name: (
+        {"mode": "token_rows", "max_tokens": 16, "capture_root": True}
+        if name == "mlp"
+        else None
+    )
+    expert_name = "mlp.experts.0.gate_proj"
+    processor.tasks[expert_name] = {"inputs": [], "batch_indices": []}
+    processor._mask_tls = types.SimpleNamespace(
+        value=torch.tensor(
+            [
+                [True, True, False],
+                [True, False, False],
+            ]
+        )
+    )
+    processor._set_current_batch_index(0)
+
+    feature = torch.arange(12, dtype=torch.float32).reshape(2, 3, 2)
+    expected = feature.reshape(-1, 2)[processor._mask_tls.value.reshape(-1)].unsqueeze(0)
+
+    processor.record_moe_root_input_feature("mlp", feature)
+    processor.pre_process_fwd_hook(expert_name)(
+        nn.Identity(),
+        (feature.reshape(-1, 2),),
+        None,
+    )
+    processor._set_current_batch_index(None)
+
+    assert torch.equal(processor.tasks["mlp"]["inputs"][0], expected)
+    assert torch.equal(processor.tasks[expert_name]["inputs"][0], expected)
+
+
 def test_awq_layer_input_features_aligns_variable_length_fallback_with_cached_kwargs():
     processor = _TestAWQProcessor(QuantizeConfig(quant_method=METHOD.AWQ, format=FORMAT.GEMM, group_size=128))
     state = _AWQLayerState(modules={"self_attn.q_proj": object()})
@@ -230,6 +264,44 @@ def test_awq_pack_token_rows_never_underfills_budget():
                         lengths,
                         max_tokens,
                     )
+
+
+def test_awq_pack_token_rows_ignores_empty_captures_during_quota_allocation():
+    empty = torch.empty(1, 0, 4)
+    populated = torch.tensor(
+        [[[10.0, 10.0, 10.0, 10.0], [20.0, 20.0, 20.0, 20.0]]]
+    )
+
+    packed, raw = AWQProcessor._pack_token_rows(
+        [empty, populated, empty],
+        max_tokens=1,
+    )
+
+    assert raw == 2
+    assert packed.shape == (1, 1, 4)
+    assert torch.equal(packed[0, 0], populated[0, 0])
+
+    all_empty, all_empty_raw = AWQProcessor._pack_token_rows(
+        [empty, empty],
+        max_tokens=4,
+    )
+    assert all_empty_raw == 0
+    assert all_empty.shape == (1, 0, 4)
+
+
+def test_awq_quant_log_nsamples_changes_only_for_token_row_aggregation():
+    processor = _TestAWQProcessor(QuantizeConfig(quant_method=METHOD.AWQ, format=FORMAT.GEMM, group_size=128))
+    processor._nsamples_total = 459
+
+    assert processor._feature_nsamples_for_log(
+        {"mode": "latest_batch", "raw_tokens": 459, "retained_tokens": 36}
+    ) == 459
+    assert processor._feature_nsamples_for_log(
+        {"mode": "batch", "raw_tokens": 459, "retained_tokens": 459}
+    ) == 459
+    assert processor._feature_nsamples_for_log(
+        {"mode": "token_rows", "raw_tokens": 459, "retained_tokens": 128}
+    ) == 128
 
 
 def test_awq_moe_root_capture_deduplicates_subsets_and_is_collapsed():

--- a/tests/test_awq_weight_mean.py
+++ b/tests/test_awq_weight_mean.py
@@ -167,6 +167,34 @@ def test_awq_layer_input_features_packs_variable_pointwise_token_rows():
     }
 
 
+def test_awq_pack_token_rows_reserves_a_row_from_every_batch():
+    tensors = [
+        torch.full((1, 5, 4), 10.0),
+        torch.full((1, 1, 4), 20.0),
+        torch.full((1, 5, 4), 30.0),
+    ]
+
+    packed, raw_tokens = AWQProcessor._pack_token_rows(tensors, max_tokens=4)
+
+    assert raw_tokens == 11
+    assert packed.shape == (1, 4, 4)
+    # The single-row middle batch must not be skipped by uniform sampling.
+    assert torch.equal(
+        torch.unique(packed[0, :, 0]),
+        torch.tensor([10.0, 20.0, 30.0]),
+    )
+
+    repacked, _ = AWQProcessor._pack_token_rows(tensors, max_tokens=4)
+    assert torch.equal(packed, repacked)
+
+    # Budget smaller than the batch count: one leading row from evenly
+    # spaced batches, deterministically.
+    tiny, tiny_raw = AWQProcessor._pack_token_rows(tensors, max_tokens=2)
+    assert tiny_raw == 11
+    assert tiny.shape == (1, 2, 4)
+    assert torch.equal(tiny[0, :, 0], torch.tensor([10.0, 30.0]))
+
+
 def test_awq_moe_root_capture_deduplicates_subsets_and_is_collapsed():
     processor = _TestAWQProcessor(QuantizeConfig(quant_method=METHOD.AWQ, format=FORMAT.GEMM, group_size=128))
     processor.gptq_model.awq_input_feature_aggregation = lambda name: (


### PR DESCRIPTION
## Summary

Fixes #3035.

Variable-length calibration batches cannot be concatenated on dim 0, so `_layer_input_features()` silently kept only `tensors[-1]` per module — every earlier batch was discarded from AWQ scale statistics. For mixture-of-experts models this collapses per-expert calibration to a single batch.

This PR adds a model-declared feature-aggregation policy so de-fused pointwise expert projections pack every ragged batch into deterministic, bounded token rows, plus per-module aggregation accounting. Public model classes with a module tree marked `:moe` inherit the policy; dense-only models remain on the existing path.

## What Changed

- New model hook `awq_input_feature_aggregation(module_name)` returning `{"mode": "token_rows", "capture_root": bool}` or `None`, with an optional explicit `max_tokens` override. `BaseQModel` enables it for the declared expert root and its de-fused pointwise children; `AWQProcessor._feature_aggregation_policy()` validates and applies it.
- New `AWQProcessor._pack_token_rows()`: packs ragged captures into `[1, retained_tokens, hidden]` under a workload-derived bound. The automatic budget uses one largest observed batch equivalent, raised only when needed to retain at least one row from every contributing batch, and never exceeds raw routed rows. Remaining capacity is distributed proportionally to batch length, with rows sampled evenly inside each batch.
- `_record_input_feature()` gains `dedupe_batch`; `record_moe_root_input_feature()` records the shared pre-router expert input when the policy requests `capture_root`.
- Expert lifecycle replay makes one guarded call into the root recorder before expert replay.
- Captures are restored to calibration-batch order before collapse so aggregation and kwargs stay aligned when hooks complete out of order.
- Per-module aggregation stats (`mode`, `raw_tokens`, `retained_tokens`, `batches`) are recorded for both activation and scale features and surfaced in quant log rows. `nsamples` reports retained tokens when a policy is active and is unchanged otherwise.
- Group fallback compares `raw_tokens` (corpus coverage routed to the module) rather than the policy's retained sampling bound. For the unchanged latest-batch fallback, the policy reports the actual retained rows.
- Padding rows are excluded before aggregation, and empty captures do not participate in quota allocation.
- Intentionally out of scope: changing the default variable-length path for models without a policy. Sequence-structured replay cannot span ragged batches without aligned masks and positions, so that path keeps its existing contract and now reports what it retained.

## Review Follow-ups Included

- Reserve one row per non-empty batch so a short batch cannot disappear during sampling.
- Redistribute leftover quota across multiple passes so saturated short batches cannot strand budget.
- Preserve per-sample quant logs while reporting token-row coverage separately.
- Use raw coverage for token-row fallback decisions and actual retained rows for latest-batch decisions.
- Enable the bounded token-row policy for affected public model classes through their declared expert roots.
- Derive each module's token-row budget from its observed calibration batches instead of fixing a model-level token count; retain an explicit policy override for exceptional model requirements.
- Audit every registered public MoE definition and require one unambiguous top-level `:moe` root per module-tree variant. The audit corrected the missing `mlp` marker for GPT-OSS and added Granite MoE Hybrid's Defuser-expanded `block_sparse_moe` expert paths and marker.
- Keep processor-owned feature accounting state concise (`_feature_stats`, `_scale_feature_by_module`, and `_feature_task_names`); the AWQ-prefixed kwargs key remains namespaced because it crosses into model scaling hooks.
- Centralize successful layer finalization so normal completion and both early-exit paths release child/root capture tasks, aggregation telemetry, replay kwargs, module tracking, and thread-local scale context.

## Tests

- [x] Public model-policy coverage for Mixtral, Qwen3 MoE, Qwen3 Next, and MiniMax M2 definitions, including alias-based expert roots and dense-model opt-out.
- [x] Registry-wide expert-root coverage for all 52 detected public MoE model classes/aliases, plus exact pointwise-path expansion checks for the two corrected definitions.
- [x] Variable-length token-row aggregation, padding exclusion, batch ordering, root-capture deduplication, fallback accounting, and bounded-quota property tests.
- [x] Early-completion regression coverage for both an empty scaling configuration and a configuration whose groups are all rejected.
- [x] Combined focused regression selection: `76 passed`.
- [x] End-to-end smoke validation confirmed that all de-fused expert projections report token-row aggregation, bounded retention, raw non-padding coverage, batch counts, and root-versus-direct scale-feature routing.
