### PR TITLE
fix(tests): drop the extra self argument that makes TestKernelOutput.setUp raise TypeError

### DIFF
--- a/tests/kernels/test_intel_cpu_xpu.py
+++ b/tests/kernels/test_intel_cpu_xpu.py
@@ -86,7 +86,7 @@ class TestKernelOutput(unittest.TestCase):
             for _ in range(self.input_samples_each_size):
                 inputs = torch.rand((dim_0, self.k), dtype=self.dtype)
                 self.x.append(inputs)
-                self.torch_kernel_outs.append(self.forward(self, self.torch_model, inputs, backend=BACKEND.TORCH))
+                self.torch_kernel_outs.append(self.forward(self.torch_model, inputs, backend=BACKEND.TORCH))
 
     def forward(self, model, x, backend: BACKEND):
         target_qlinear_cls = self.target_qliner_map[backend]


### PR DESCRIPTION
## Problem

`TestKernelOutput.forward` is declared with four parameters:

```python
# tests/kernels/test_intel_cpu_xpu.py:91
def forward(self, model, x, backend: BACKEND):
```

but `setUp` calls it with an extra leading `self`:

```python
# tests/kernels/test_intel_cpu_xpu.py:89
self.torch_kernel_outs.append(self.forward(self, self.torch_model, inputs, backend=BACKEND.TORCH))
```

Because the call is already bound, `self` is supplied implicitly, so the written
arguments bind as `model=self`, `x=self.torch_model`, `backend=inputs` — and
`backend` is *also* passed as a keyword:

```
TypeError: forward() got multiple values for argument 'backend'
```

`setUp` runs before every test method in the class, so nothing in
`TestKernelOutput` can execute.

## Sibling baseline

The other two call sites in this same file already omit the extra `self`:

```python
# line 121
out = self.forward(model, self.x[i], backend=backend)
# line 220
fused_out = self.forward(model, model_input, backend)
```

## Fix

```python
self.torch_kernel_outs.append(self.forward(self.torch_model, inputs, backend=BACKEND.TORCH))
```

which gives `model=self.torch_model`, `x=inputs`, `backend=BACKEND.TORCH` — the
values setUp had just prepared.

## Verification

The kernels are native and Intel XPU-only, so the module can't be imported on
this machine. Instead the real `forward` signature and the real call expressions
were parsed out of the file and replayed through `inspect.Signature.bind`, which
is the same binding CPython performs at call time:

```
real def (line 91): forward(self, model, x, backend)

L121: self.forward(model, self.x[i], backend=backend)          -> OK
L220: self.forward(model, model_input, backend)                -> OK
L89 : self.forward(self, self.torch_model, inputs, backend=..) -> TypeError: multiple values for argument 'backend'

PATCHED L89: self.forward(self.torch_model, inputs, backend=..) -> OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
