### PR TITLE
Fix CUDA JIT cache reuse and update CUTLASS

### DIFF
--- a/gptqmodel/utils/cpp.py
+++ b/gptqmodel/utils/cpp.py
@@ -70,12 +70,32 @@ _NVCC_VERSION_CACHE: tuple[int, int] | None = None
 _DEFAULT_NVCC_THREADS = "8"
 _GLOBAL_KERNEL_REBUILD_ENV = "GPTQMODEL_KERNEL_REBUILD"
 _TORCH_OPS_BUILD_ROOT_ENV = "GPTQMODEL_TORCH_EXTENSIONS_DIR"
+_CUDA_BUILD_SCHEDULING_FLAGS_WITH_VALUE = frozenset(("--threads", "--split-compile"))
+_CUDA_BUILD_SCHEDULING_FLAG_PREFIXES = ("--threads=", "--split-compile=")
 # Cross-process JIT build lock tuning. The lock itself is a kernel-released
 # flock, so a killed holder can never leave the cache permanently locked; the
 # timeout only bounds how long a process waits for another's in-flight build.
 _TORCH_OPS_FILE_LOCK_TIMEOUT_ENV = "GPTQMODEL_TORCH_OPS_LOCK_TIMEOUT"
 _TORCH_OPS_FILE_LOCK_TIMEOUT_DEFAULT_SECONDS = 600.0
 _TORCH_OPS_FILE_LOCK_POLL_SECONDS = 0.1
+
+
+def _cuda_cache_relevant_flags(flags: Sequence[str]) -> list[str]:
+    """Drop NVCC scheduling knobs that cannot change generated device code."""
+
+    relevant: list[str] = []
+    skip_value = False
+    for flag in flags:
+        if skip_value:
+            skip_value = False
+            continue
+        if flag in _CUDA_BUILD_SCHEDULING_FLAGS_WITH_VALUE:
+            skip_value = True
+            continue
+        if flag.startswith(_CUDA_BUILD_SCHEDULING_FLAG_PREFIXES):
+            continue
+        relevant.append(flag)
+    return relevant
 
 
 def _log_cache_clear_callsite(*, reason: str, target_path: str | Path) -> None:
@@ -868,7 +888,7 @@ class TorchOpsJitExtension:
             payload.extend(self._source_cache_fingerprint_payload(source, include_paths))
 
         payload.extend(self._resolve_sequence(self.extra_cflags))
-        payload.extend(self._resolve_sequence(self.extra_cuda_cflags))
+        payload.extend(_cuda_cache_relevant_flags(self._resolve_sequence(self.extra_cuda_cflags)))
         payload.extend(include_paths)
         payload.extend(self._resolve_sequence(self.extra_ldflags))
         digest = hashlib.sha256("\0".join(payload).encode("utf-8")).hexdigest()

--- a/gptqmodel/utils/machete.py
+++ b/gptqmodel/utils/machete.py
@@ -37,7 +37,7 @@ log = setup_logger()
 _MACHETE_OPS_NAME = "gptqmodel_machete_ops"
 _MACHETE_OPS_NAMESPACE = "gptqmodel_machete"
 
-_CUTLASS_VERSION = "4.4.2"
+_CUTLASS_VERSION = "4.7.1"
 _CUTLASS_RELEASE_URL = f"https://github.com/NVIDIA/cutlass/archive/refs/tags/v{_CUTLASS_VERSION}.tar.gz"
 _CUTLASS_VERSION_MARKER = ".gptqmodel_cutlass_version"
 _CUTLASS_VERSION_DEFINE_PATTERN = pcre.compile(

--- a/tests/test_machete_jit.py
+++ b/tests/test_machete_jit.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -419,7 +420,8 @@ def test_ensure_cutlass_source_rejects_mismatched_configured_checkout(monkeypatc
     monkeypatch.setattr(machete_utils, "_machete_project_root", lambda: tmp_path / "project")
     monkeypatch.setenv("GPTQMODEL_CUTLASS_DIR", str(wrong_cutlass))
 
-    with pytest.raises(RuntimeError, match=r"CUTLASS v3\.5\.0.*requires v4\.4\.2"):
+    expected_version = re.escape(machete_utils._CUTLASS_VERSION)
+    with pytest.raises(RuntimeError, match=rf"CUTLASS v3\.5\.0.*requires v{expected_version}"):
         machete_utils._ensure_cutlass_source()
 
 

--- a/tests/test_torch_ops_jit_extension.py
+++ b/tests/test_torch_ops_jit_extension.py
@@ -221,6 +221,23 @@ def test_cuda_cache_fingerprint_payload_includes_resolved_arch_flags(monkeypatch
     ]
 
 
+def test_cuda_cache_fingerprint_ignores_compiler_parallelism(tmp_path):
+    """NVCC worker counts must not create duplicate binary caches."""
+
+    loader = _make_loader(tmp_path)
+    loader.extra_cuda_cflags = ["-lineinfo", "--threads", "1", "--split-compile=1"]
+    serial = loader._cache_fingerprint()
+
+    loader.extra_cuda_cflags = ["-lineinfo", "--threads=16", "--split-compile", "8"]
+    parallel = loader._cache_fingerprint()
+
+    loader.extra_cuda_cflags = ["-lineinfo", "-O2", "--threads", "16", "--split-compile=8"]
+    different_codegen = loader._cache_fingerprint()
+
+    assert serial == parallel
+    assert serial != different_codegen
+
+
 def test_default_torch_ops_build_root_ignores_removed_global_override(monkeypatch):
     monkeypatch.setenv("GPTQMODEL_EXT_BUILD_BASE", "/tmp/obsolete-jit-root")
 


### PR DESCRIPTION
## Summary

- Exclude NVCC compiler scheduling counts from JIT binary cache fingerprints.
- Keep code-generation flags in cache keys so optimization and target changes still invalidate builds.
- Pin the generated-kernel dependency to CUTLASS 4.7.1.
- Update the dependency-version validation test and add cache-key coverage.

## Validation

- 58 focused host tests passed.
- CUDA build smoke tests were not included in this environment.
