### PR TITLE
fix(marlin): validate devices and register runtime buffers

### DIFF
--- a/gptqmodel/nn_modules/qlinear/marlin.py
+++ b/gptqmodel/nn_modules/qlinear/marlin.py
@@ -16,7 +16,7 @@
 
 # Adapted from vllm at https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/quantization/gptq_marlin.py
 
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 import torch
@@ -29,7 +29,7 @@ from ...utils.backend import BACKEND
 from ...utils.env import env_flag
 from ...utils.logger import setup_logger
 from ...utils.marlin import (
-    _marlin_capability_supported,
+    _marlin_all_visible_devices_supported,
     _transform_param,
     apply_gptq_marlin_linear,
     apply_gptq_marlin_linear_padded,
@@ -49,6 +49,7 @@ from ...utils.marlin import (
     marlin_runtime_available,
     marlin_runtime_error,
     marlin_sort_g_idx,
+    marlin_validate_runtime_device,
     replace_parameter,
 )
 from ...utils.marlin_scalar_type import scalar_types
@@ -56,6 +57,10 @@ from ...utils.rocm import IS_ROCM
 
 
 log = setup_logger()
+
+# SM 7.5 is supported through the FP16-only Turing path.
+_MARLIN_SM75_CAPABILITY = (7, 5)
+_MARLIN_MIN_CAPABILITY = _MARLIN_SM75_CAPABILITY
 
 
 class MarlinLinear(GPTQQuantLinear):
@@ -209,6 +214,16 @@ class MarlinLinear(GPTQQuantLinear):
             )
         )
 
+        # Runtime-only buffers must follow device-map and later module moves.
+        self.register_buffer(
+            "workspace", torch.empty(0, dtype=torch.int32), persistent=False
+        )
+        self.register_buffer(
+            "g_idx_sort_indices",
+            torch.empty(0, dtype=torch.int32),
+            persistent=False,
+        )
+
         if bias:
             self.register_buffer("bias", torch.zeros((self.out_features), dtype=self.compute_dtype))
         else:
@@ -285,10 +300,8 @@ class MarlinLinear(GPTQQuantLinear):
             if IS_ROCM:
                 raise NotImplementedError("Marlin kernel is not supported on ROCm.")
 
-            # Directly check capabilities of all currently visible CUDA devices
-            has_supported_cuda = all(
-                _marlin_capability_supported(*torch.cuda.get_device_capability(i))
-                for i in range(torch.cuda.device_count())
+            has_supported_cuda = _marlin_all_visible_devices_supported(
+                _MARLIN_MIN_CAPABILITY
             )
             if not has_supported_cuda:
                 raise NotImplementedError(
@@ -297,6 +310,15 @@ class MarlinLinear(GPTQQuantLinear):
 
     def post_init(self):
         device = self.qweight.device
+        capability = marlin_validate_runtime_device(
+            device,
+            min_capability=_MARLIN_MIN_CAPABILITY,
+            backend_name="GPTQ Marlin",
+        )
+        if capability == _MARLIN_SM75_CAPABILITY and self.compute_dtype != torch.float16:
+            raise ValueError(
+                "GPTQ Marlin on compute capability 7.5 requires dtype=torch.float16."
+            )
 
         if not marlin_runtime_available(self.compute_dtype):
             raise ModuleNotFoundError(
@@ -371,7 +393,7 @@ class MarlinLinear(GPTQQuantLinear):
             self.g_idx_sort_indices = g_idx_sort_indices
         else:
             setattr(self, "g_idx", marlin_make_empty_g_idx(device))
-            self.g_idx_sort_indices = marlin_make_empty_g_idx(device)
+            self.g_idx_sort_indices = torch.empty(0, dtype=torch.int, device=device)
 
         setattr(self, "qzeros", marlin_make_empty_g_idx(device))
 
@@ -384,16 +406,6 @@ class MarlinLinear(GPTQQuantLinear):
             )
 
         super().post_init()
-
-    def list_buffers(self) -> List:
-        buf = super().list_buffers()
-        if hasattr(self, "workspace") and self.workspace is not None:
-            buf.append(self.workspace)
-        if hasattr(self, "g_idx_sort_indices") and self.g_idx_sort_indices is not None:
-            buf.append(self.g_idx_sort_indices)
-        if hasattr(self, "g_idx") and self.g_idx is not None:
-            buf.append(self.g_idx)
-        return buf
 
     def forward(self, x: torch.Tensor):
         # TODO FIXME: parent should never call us if there is no data to process

--- a/gptqmodel/nn_modules/qlinear/marlin_awq.py
+++ b/gptqmodel/nn_modules/qlinear/marlin_awq.py
@@ -5,8 +5,7 @@
 
 # Adapted from vllm at https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/quantization/gptq_marlin.py
 
-import os
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 import torch
 
@@ -17,13 +16,13 @@ from ...quantization import FORMAT, METHOD
 from ...utils.backend import BACKEND
 from ...utils.logger import setup_logger
 from ...utils.marlin import (
+    _marlin_all_visible_devices_supported,
     apply_awq_marlin_linear,
     apply_awq_marlin_linear_padded,
     awq_marlin_repack,
     awq_to_marlin_zero_points,
     marlin_import_exception,
     marlin_is_tile_aligned,
-    marlin_make_empty_g_idx,
     marlin_make_workspace_new,
     marlin_pad_awq_qweight,
     marlin_pad_awq_qzeros,
@@ -34,6 +33,7 @@ from ...utils.marlin import (
     marlin_permute_scales,
     marlin_runtime_available,
     marlin_runtime_error,
+    marlin_validate_runtime_device,
     replace_parameter,
 )
 from ...utils.marlin_scalar_type import scalar_types
@@ -41,6 +41,8 @@ from ...utils.rocm import IS_ROCM
 
 
 log = setup_logger()
+
+_AWQ_MARLIN_MIN_CAPABILITY = (8, 0)
 
 
 class AwqMarlinLinear(AWQuantLinear):
@@ -162,6 +164,19 @@ class AwqMarlinLinear(AWQuantLinear):
             else:
                 self.bias = None
 
+        # Runtime-only buffers must follow device-map and later module moves.
+        self.register_buffer(
+            "workspace", torch.empty(0, dtype=torch.int32), persistent=False
+        )
+        self.register_buffer(
+            "g_idx", torch.empty(0, dtype=torch.int32), persistent=False
+        )
+        self.register_buffer(
+            "g_idx_sort_indices",
+            torch.empty(0, dtype=torch.int32),
+            persistent=False,
+        )
+
         self.is_lm_head = False
         if kwargs.get("name") is not None and kwargs.get("lm_head_name") is not None:
             self.is_lm_head = kwargs["name"] == kwargs["lm_head_name"]
@@ -221,21 +236,22 @@ class AwqMarlinLinear(AWQuantLinear):
     @classmethod
     def validate_device(cls, device: DEVICE):
         super().validate_device(device)
-        CUDA_VISIBLE_DEVICES = os.environ.get("CUDA_VISIBLE_DEVICES")
         if device == DEVICE.CUDA:
             if IS_ROCM:
                 raise NotImplementedError("Marlin kernel is not supported on ROCm.")
 
-            if CUDA_VISIBLE_DEVICES is None:
-                has_cuda_v8 = all(torch.cuda.get_device_capability(i)[0] >= 8 for i in range(torch.cuda.device_count()))
-            else:
-                has_cuda_v8 = all(
-                    torch.cuda.get_device_capability(i)[0] >= 8 for i in range(len(CUDA_VISIBLE_DEVICES.split(","))))
-            if not has_cuda_v8:
+            if not _marlin_all_visible_devices_supported(
+                _AWQ_MARLIN_MIN_CAPABILITY
+            ):
                 raise NotImplementedError("Marlin kernel only supports compute capability >= 8.0.")
 
     def post_init(self):
         device = self.qweight.device
+        marlin_validate_runtime_device(
+            device,
+            min_capability=_AWQ_MARLIN_MIN_CAPABILITY,
+            backend_name="AWQ Marlin",
+        )
 
         if not marlin_runtime_available(self.compute_dtype):
             raise ModuleNotFoundError(
@@ -314,9 +330,9 @@ class AwqMarlinLinear(AWQuantLinear):
             num_bits=self.bits)
         replace_parameter(self, "qzeros", marlin_zp)
 
-        # Not-used
-        self.g_idx = marlin_make_empty_g_idx(device)
-        self.g_idx_sort_indices = marlin_make_empty_g_idx(device)
+        # AWQ does not use activation-order indices.
+        self.g_idx = torch.empty(0, dtype=torch.int, device=device)
+        self.g_idx_sort_indices = torch.empty(0, dtype=torch.int, device=device)
 
         if hasattr(self, "bias") and self.bias is not None:
             self.bias.data = marlin_permute_bias(
@@ -325,18 +341,8 @@ class AwqMarlinLinear(AWQuantLinear):
 
         super().post_init()
 
-    def list_buffers(self) -> List:
-        buf = super().list_buffers()
-        if hasattr(self, "workspace") and self.workspace is not None:
-            buf.append(self.workspace)
-        if hasattr(self, "g_idx_sort_indices") and self.g_idx_sort_indices is not None:
-            buf.append(self.g_idx_sort_indices)
-        if hasattr(self, "g_idx") and self.g_idx is not None:
-            buf.append(self.g_idx)
-        return buf
-
     def forward(self, x: torch.Tensor):
-        assert hasattr(self, "workspace"), (
+        assert self.workspace.numel() > 0, (
             "module.post_init() must be called before module.forward(). "
             "Use marlin_post_init() on the whole model."
         )

--- a/gptqmodel/utils/marlin.py
+++ b/gptqmodel/utils/marlin.py
@@ -48,6 +48,45 @@ def _marlin_capability_supported(major: int, minor: int) -> bool:
     return major > 7 or (major == 7 and minor >= 5)
 
 
+def _marlin_all_visible_devices_supported(min_capability: Tuple[int, int]) -> bool:
+    # PyTorch resolves CUDA_VISIBLE_DEVICES, including UUID and MIG entries.
+    device_count = torch.cuda.device_count()
+    return device_count > 0 and all(
+        torch.cuda.get_device_capability(index) >= min_capability
+        for index in range(device_count)
+    )
+
+
+def marlin_validate_runtime_device(
+        device: torch.device,
+        *,
+        min_capability: Tuple[int, int],
+        backend_name: str,
+) -> Tuple[int, int]:
+    """Validate the CUDA device that owns one Marlin module's weights."""
+    device = torch.device(device)
+    if IS_ROCM:
+        raise ValueError(f"{backend_name} is not supported on ROCm.")
+    if device.type != "cuda":
+        raise ValueError(f"{backend_name} requires CUDA tensors, got `{device}`.")
+
+    try:
+        capability = torch.cuda.get_device_capability(device)
+    except Exception as exc:  # pragma: no cover - depends on the CUDA runtime
+        raise ValueError(
+            f"{backend_name} failed to query CUDA device `{device}` capability: {exc}"
+        ) from exc
+
+    if capability < min_capability:
+        minimum = ".".join(str(part) for part in min_capability)
+        detected = ".".join(str(part) for part in capability)
+        raise ValueError(
+            f"{backend_name} requires compute capability >= {minimum}, "
+            f"got {detected} on `{device}`."
+        )
+    return capability
+
+
 def _marlin_environment_error() -> str:
     if IS_ROCM:
         return "Marlin kernel is not supported on ROCm."

--- a/tests/test_marlin_jit.py
+++ b/tests/test_marlin_jit.py
@@ -482,6 +482,79 @@ def test_marlin_quant_linear_validate_device_rejects_pre_turing(monkeypatch):
         marlin_qlinear_module.MarlinLinear.validate_device(marlin_qlinear_module.DEVICE.CUDA)
 
 
+def test_awq_marlin_validate_device_uses_torch_visible_ordinals(monkeypatch):
+    queried_devices = []
+
+    monkeypatch.setattr(marlin_awq_qlinear_module, "IS_ROCM", False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-first,GPU-second,MIG-third")
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 2)
+
+    def get_device_capability(device):
+        queried_devices.append(device)
+        return (8, 0)
+
+    monkeypatch.setattr(torch.cuda, "get_device_capability", get_device_capability)
+
+    marlin_awq_qlinear_module.AwqMarlinLinear.validate_device(
+        marlin_awq_qlinear_module.DEVICE.CUDA
+    )
+
+    assert queried_devices == [0, 1]
+
+
+def test_awq_marlin_validate_device_rejects_no_visible_cuda_device(monkeypatch):
+    monkeypatch.setattr(marlin_awq_qlinear_module, "IS_ROCM", False)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 0)
+
+    with pytest.raises(NotImplementedError, match="compute capability >= 8.0"):
+        marlin_awq_qlinear_module.AwqMarlinLinear.validate_device(
+            marlin_awq_qlinear_module.DEVICE.CUDA
+        )
+
+
+def test_awq_marlin_validate_device_rejects_pre_ampere(monkeypatch):
+    monkeypatch.setattr(marlin_awq_qlinear_module, "IS_ROCM", False)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device: (7, 5))
+
+    with pytest.raises(NotImplementedError, match="compute capability >= 8.0"):
+        marlin_awq_qlinear_module.AwqMarlinLinear.validate_device(
+            marlin_awq_qlinear_module.DEVICE.CUDA
+        )
+
+
+def test_marlin_runtime_device_validation_queries_explicit_device(monkeypatch):
+    queried_devices = []
+
+    monkeypatch.setattr(marlin_utils, "IS_ROCM", False)
+
+    def get_device_capability(device):
+        queried_devices.append(device)
+        return (8, 0)
+
+    monkeypatch.setattr(torch.cuda, "get_device_capability", get_device_capability)
+
+    capability = marlin_utils.marlin_validate_runtime_device(
+        torch.device("cuda:3"),
+        min_capability=(8, 0),
+        backend_name="AWQ Marlin",
+    )
+
+    assert capability == (8, 0)
+    assert queried_devices == [torch.device("cuda:3")]
+
+
+def test_marlin_runtime_device_validation_rejects_cpu(monkeypatch):
+    monkeypatch.setattr(marlin_utils, "IS_ROCM", False)
+
+    with pytest.raises(ValueError, match="requires CUDA tensors"):
+        marlin_utils.marlin_validate_runtime_device(
+            torch.device("cpu"),
+            min_capability=(8, 0),
+            backend_name="AWQ Marlin",
+        )
+
+
 def test_sm75_turing_contract_is_present_in_marlin_sources():
     marlin_root = marlin_utils._marlin_root()
     gemm_cu = (marlin_root / "gptq_marlin.cu").read_text(encoding="utf-8")
@@ -628,6 +701,11 @@ def test_marlin_quant_linear_post_init_uses_compute_dtype_for_repack(monkeypatch
     captured = {}
 
     monkeypatch.setattr(marlin_qlinear_module, "marlin_import_exception", None)
+    monkeypatch.setattr(
+        marlin_qlinear_module,
+        "marlin_validate_runtime_device",
+        lambda *args, **kwargs: (8, 0),
+    )
     monkeypatch.setattr(marlin_qlinear_module, "marlin_runtime_available", lambda dtype: True)
     monkeypatch.setattr(marlin_qlinear_module, "marlin_runtime_error", lambda dtype: "")
     monkeypatch.setattr(
@@ -663,12 +741,24 @@ def test_marlin_quant_linear_post_init_uses_compute_dtype_for_repack(monkeypatch
 
     assert captured == {"dtype": torch.bfloat16, "shape": tuple(module.qweight.shape)}
     assert module._marlin_tile_padding is None
+    assert module.workspace.numel() == 1
+    assert module.g_idx_sort_indices.numel() == 0
+
+    module.to("meta")
+
+    assert module.workspace.device.type == "meta"
+    assert module.g_idx_sort_indices.device.type == "meta"
 
 
 def test_marlin_quant_linear_post_init_pads_weight_scales_and_bias(monkeypatch):
     captured = {}
 
     monkeypatch.setattr(marlin_qlinear_module, "marlin_import_exception", None)
+    monkeypatch.setattr(
+        marlin_qlinear_module,
+        "marlin_validate_runtime_device",
+        lambda *args, **kwargs: (8, 0),
+    )
     monkeypatch.setattr(marlin_qlinear_module, "marlin_runtime_available", lambda dtype: True)
     monkeypatch.setattr(marlin_qlinear_module, "marlin_runtime_error", lambda dtype: "")
     monkeypatch.setattr(
@@ -776,7 +866,16 @@ def test_apply_gptq_marlin_linear_pads_input_and_slices_output(monkeypatch):
 def test_awq_marlin_quant_linear_post_init_pads_packed_tensors(monkeypatch):
     captured = {}
 
+    def validate_runtime_device(device, **kwargs):
+        captured["runtime_device"] = device
+        return (8, 0)
+
     monkeypatch.setattr(marlin_awq_qlinear_module, "marlin_import_exception", None)
+    monkeypatch.setattr(
+        marlin_awq_qlinear_module,
+        "marlin_validate_runtime_device",
+        validate_runtime_device,
+    )
     monkeypatch.setattr(
         marlin_awq_qlinear_module, "marlin_runtime_available", lambda dtype: True
     )
@@ -788,12 +887,6 @@ def test_awq_marlin_quant_linear_post_init_pads_packed_tensors(monkeypatch):
         "marlin_make_workspace_new",
         lambda device: torch.zeros(128, dtype=torch.int32, device=device),
     )
-    monkeypatch.setattr(
-        marlin_awq_qlinear_module,
-        "marlin_make_empty_g_idx",
-        lambda device: torch.empty(0, dtype=torch.int32, device=device),
-    )
-
     def fake_repack(qweight, size_k, size_n, num_bits, dtype=None):
         captured["qweight"] = (
             tuple(qweight.shape),
@@ -866,7 +959,15 @@ def test_awq_marlin_quant_linear_post_init_pads_packed_tensors(monkeypatch):
         "qweight": ((320, 32), 320, 256, 4, torch.float16),
         "scales": ((10, 256), 320, 256, 32),
         "qzeros": ((10, 32), 10, 256, 4),
+        "runtime_device": torch.device("cpu"),
     }
+    assert {"workspace", "g_idx", "g_idx_sort_indices"} <= module._buffers.keys()
+
+    module.to("meta")
+
+    assert module.workspace.device.type == "meta"
+    assert module.g_idx.device.type == "meta"
+    assert module.g_idx_sort_indices.device.type == "meta"
 
 
 def test_apply_awq_marlin_linear_pads_input_and_slices_output(monkeypatch):
@@ -934,10 +1035,56 @@ def test_marlin_quant_linear_registers_runtime_buffers_in_compute_dtype(monkeypa
     assert module.bias.dtype == torch.bfloat16
 
 
+def test_marlin_quant_linear_registers_nonpersistent_runtime_state(monkeypatch):
+    monkeypatch.setattr(marlin_qlinear_module, "marlin_import_exception", None)
+
+    module = marlin_qlinear_module.MarlinLinear(
+        bits=4,
+        group_size=128,
+        desc_act=False,
+        sym=True,
+        in_features=128,
+        out_features=64,
+        bias=False,
+        dtype=torch.float16,
+    )
+
+    assert {"workspace", "g_idx_sort_indices"} <= module._buffers.keys()
+    assert {"workspace", "g_idx_sort_indices"} <= module._non_persistent_buffers_set
+    assert "workspace" not in module.state_dict()
+    assert "g_idx_sort_indices" not in module.state_dict()
+
+
+def test_awq_marlin_quant_linear_registers_nonpersistent_runtime_state(monkeypatch):
+    monkeypatch.setattr(marlin_awq_qlinear_module, "marlin_import_exception", None)
+
+    module = marlin_awq_qlinear_module.AwqMarlinLinear(
+        bits=4,
+        group_size=128,
+        desc_act=False,
+        sym=False,
+        in_features=128,
+        out_features=64,
+        bias=False,
+        dtype=torch.float16,
+        register_buffers=True,
+    )
+
+    runtime_names = {"workspace", "g_idx", "g_idx_sort_indices"}
+    assert runtime_names <= module._buffers.keys()
+    assert runtime_names <= module._non_persistent_buffers_set
+    assert runtime_names.isdisjoint(module.state_dict())
+
+
 def test_marlin_quant_linear_forward_promotes_bias_to_input_dtype(monkeypatch):
     captured = {}
 
     monkeypatch.setattr(marlin_qlinear_module, "marlin_import_exception", None)
+    monkeypatch.setattr(
+        marlin_qlinear_module,
+        "marlin_validate_runtime_device",
+        lambda *args, **kwargs: (8, 0),
+    )
     monkeypatch.setattr(marlin_qlinear_module, "marlin_runtime_available", lambda dtype: True)
     monkeypatch.setattr(marlin_qlinear_module, "marlin_runtime_error", lambda dtype: "")
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

- validate GPTQ and AWQ Marlin against PyTorch-visible CUDA ordinals, including empty and unsupported device sets
- validate each module's weight-owning runtime device and preserve the GPTQ SM 7.5 FP16-only contract
- register workspace and index tensors as non-persistent buffers so module moves preserve device placement without changing checkpoints
- remove redundant buffer enumeration and strengthen the AWQ post-initialization guard
- add focused coverage for UUID/MIG-style visibility, explicit runtime devices, state-dict exclusion, and buffer movement

## Compatibility

- GPTQ Marlin continues to require compute capability 7.5 or newer; SM 7.5 remains FP16-only
- AWQ Marlin continues to require compute capability 8.0 or newer
- unsupported devices retain the existing backend fallback behavior
- kernel math, packed weight layouts, and serialized checkpoint formats are unchanged

## Tests

- `ruff check --no-cache gptqmodel/nn_modules/qlinear/marlin.py gptqmodel/nn_modules/qlinear/marlin_awq.py gptqmodel/utils/marlin.py tests/test_marlin_jit.py`
- `pytest -q -p no:cacheprovider tests/test_marlin_jit.py` (46 passed, 17 CUDA-only tests skipped)
- `git diff --check`
