### PR TITLE
Reuse ABI-compatible JIT extension caches across Python/torch envs

### DIFF
--- a/gptqmodel/exllamav3/ext.py
+++ b/gptqmodel/exllamav3/ext.py
@@ -180,6 +180,7 @@ _EXLLAMAV3_TORCH_OPS_EXTENSION = TorchOpsJitExtension(
     force_rebuild_env="GPTQMODEL_EXLLAMAV3_FORCE_REBUILD",
     verbose_env="GPTQMODEL_EXT_VERBOSE",
     requires_cuda=True,
+    python_abi_dependent=False,
 )
 
 

--- a/gptqmodel/utils/awq.py
+++ b/gptqmodel/utils/awq.py
@@ -84,6 +84,7 @@ _AWQ_TORCH_OPS_EXTENSION = TorchOpsJitExtension(
     force_rebuild_env="GPTQMODEL_AWQ_FORCE_REBUILD",
     verbose_env="GPTQMODEL_EXT_VERBOSE",
     requires_cuda=True,
+    python_abi_dependent=False,
 )
 
 

--- a/gptqmodel/utils/cpp.py
+++ b/gptqmodel/utils/cpp.py
@@ -58,10 +58,6 @@ _cpp_ext_initialized = False
 _SHARED_LIBRARY_SUFFIXES = (".so", ".pyd", ".dylib", ".dll")
 _COMPILE_PROGRESS_TOTAL_STEPS = 100
 _COMPILE_PROGRESS_INTERVAL_SECONDS = 1.0
-_LOCAL_INCLUDE_PATTERN = pcre.compile(
-    r'^\s*#\s*include\s+"([^"]+)"',
-    flags=pcre.Flag.MULTILINE,
-)
 _SOURCE_INCLUDE_PATTERN = pcre.compile(
     r'^\s*#\s*include\s+([<"])([^">]+)[">]',
     flags=pcre.Flag.MULTILINE,

--- a/gptqmodel/utils/cpp.py
+++ b/gptqmodel/utils/cpp.py
@@ -13,6 +13,7 @@ import platform
 import shutil
 import subprocess
 import sys
+import sysconfig
 import threading
 import time
 import traceback
@@ -61,6 +62,19 @@ _LOCAL_INCLUDE_PATTERN = pcre.compile(
     r'^\s*#\s*include\s+"([^"]+)"',
     flags=pcre.Flag.MULTILINE,
 )
+_SOURCE_INCLUDE_PATTERN = pcre.compile(
+    r'^\s*#\s*include\s+([<"])([^">]+)[">]',
+    flags=pcre.Flag.MULTILINE,
+)
+_TORCH_INCLUDE_PATTERN = pcre.compile(
+    r'^\s*#\s*include\s+[<"]([^">]+)[">]',
+    flags=pcre.Flag.MULTILINE,
+)
+_TORCH_ACCELERATOR_LOCAL_TAG_PATTERN = pcre.compile(r"^(?:cpu|cu\d+|rocm[\d.]+|xpu)$")
+_C_COMMENT_PATTERN = pcre.compile(r"//[^\n]*|/\*[\s\S]*?\*/")
+_PYTHON_ABI_USAGE_PATTERN = pcre.compile(r"\b(?:Py[A-Z]\w*|PYBIND11_\w+)\b|\bpy::")
+_REGISTER_EXTENSION_PATTERN = pcre.compile(r"(?m)\bREGISTER_EXTENSION\s*\(")
+_STABLE_TORCH_REGISTRATION_PATTERN = pcre.compile(r"\bSTABLE_TORCH_LIBRARY(?:_[A-Z]+)?\s*\(")
 _NVCC_RELEASE_PATTERN = pcre.compile(r"release\s+(\d+)\.(\d+)")
 _NVCC_VERSION_LOCK = threading.Lock()
 _NVCC_VERSION_CACHE: tuple[int, int] | None = None
@@ -78,6 +92,32 @@ _CUDA_BUILD_SCHEDULING_FLAG_PREFIXES = ("--threads=", "--split-compile=")
 _TORCH_OPS_FILE_LOCK_TIMEOUT_ENV = "GPTQMODEL_TORCH_OPS_LOCK_TIMEOUT"
 _TORCH_OPS_FILE_LOCK_TIMEOUT_DEFAULT_SECONDS = 600.0
 _TORCH_OPS_FILE_LOCK_POLL_SECONDS = 0.1
+
+
+def _python_abi_tag() -> str:
+    """Return the interpreter's extension-module ABI tag."""
+
+    soabi = sysconfig.get_config_var("SOABI")
+    if soabi:
+        return str(soabi)
+    return f"cpython-{sys.version_info.major}.{sys.version_info.minor}{sys.abiflags}"
+
+
+def _torch_cpu_cache_version() -> str:
+    """Return torch.__version__ with only accelerator-wheel local tags removed."""
+
+    version = torch.__version__
+    public, sep, local = version.partition("+")
+    if sep and _TORCH_ACCELERATOR_LOCAL_TAG_PATTERN.match(local):
+        return public
+    return version
+
+
+def torch_stable_abi_target_define(major: int, minor: int) -> str:
+    """Return the stable-ABI target define for a minimum torch major/minor version."""
+
+    encoded_version = (int(major) << 56) | (int(minor) << 48)
+    return f"-DTORCH_TARGET_VERSION=0x{encoded_version:016X}"
 
 
 def _cuda_cache_relevant_flags(flags: Sequence[str]) -> list[str]:
@@ -732,6 +772,8 @@ class TorchOpsJitExtension:
         requires_cuda: bool = False,
         merge_visible_cuda_arch_override: bool = True,
         binary_names: Optional[Sequence[str]] = None,
+        python_abi_dependent: bool | None = None,
+        torch_stable_abi_target: tuple[int, int] | None = None,
     ) -> None:
         self.name = name
         self.namespace = namespace
@@ -749,12 +791,18 @@ class TorchOpsJitExtension:
         self.requires_cuda = bool(requires_cuda)
         self.merge_visible_cuda_arch_override = bool(merge_visible_cuda_arch_override)
         self.binary_names = tuple(binary_names or (name,))
+        self.python_abi_dependent = python_abi_dependent
+        self.torch_stable_abi_target = tuple(torch_stable_abi_target) if torch_stable_abi_target else None
         self.compile_baseline_seconds = get_jit_compile_baseline_seconds(name)
         self._load_attempted = False
         self._load_result = False
         self._last_error = ""
         self._namespace_cache: Optional[object] = None
         self._op_cache: dict[str, object] = {}
+        self._source_abi_detection_cache: dict[
+            tuple[tuple[tuple[str, str], ...], tuple[str, ...]],
+            tuple[bool, bool, tuple[str, ...]],
+        ] = {}
         self._lock = self._get_shared_lock()
 
     @classmethod
@@ -782,6 +830,20 @@ class TorchOpsJitExtension:
         if not self.requires_cuda:
             return _dedupe_path_strings(include_paths)
         return cuda_include_paths_with_fallback(include_paths)
+
+    def _with_stable_abi_target(self, flags: Sequence[str]) -> list[str]:
+        resolved = list(flags)
+        if self.torch_stable_abi_target is not None:
+            target_define = torch_stable_abi_target_define(*self.torch_stable_abi_target)
+            if target_define not in resolved:
+                resolved.append(target_define)
+        return resolved
+
+    def _resolved_extra_cflags(self) -> list[str]:
+        return self._with_stable_abi_target(self._resolve_sequence(self.extra_cflags))
+
+    def _resolved_extra_cuda_cflags(self) -> list[str]:
+        return self._with_stable_abi_target(self._resolve_sequence(self.extra_cuda_cflags))
 
     def base_build_root(self) -> Path:
         """Return the user-visible cache root before applying the loader fingerprint."""
@@ -835,7 +897,7 @@ class TorchOpsJitExtension:
             pass
 
     def _source_cache_fingerprint_payload(self, source: str, include_paths: Sequence[str]) -> list[str]:
-        """Hash one source file plus recursively discovered quoted local includes."""
+        """Hash one source file plus recursively discovered local includes."""
 
         payload: list[str] = []
         visited: set[Path] = set()
@@ -861,34 +923,163 @@ class TorchOpsJitExtension:
             payload.append(hashlib.sha256(source_bytes).hexdigest())
 
             source_text = source_bytes.decode("utf-8", errors="ignore")
-            for include_name in _LOCAL_INCLUDE_PATTERN.findall(source_text):
+            for delimiter, include_name in _SOURCE_INCLUDE_PATTERN.findall(source_text):
                 included_path = _resolve_local_include_path(
                     include_name,
                     including_path=normalized,
                     include_search_roots=include_search_roots,
                 )
                 if included_path is None:
-                    payload.append(f"missing_include={normalized}:{include_name}")
+                    if delimiter == '"':
+                        payload.append(f"missing_include={normalized}:{include_name}")
                     continue
                 visit(included_path)
 
         visit(Path(source))
         return payload
 
+    def _source_texts(self, source: str, include_paths: Sequence[str]) -> list[tuple[Path, str]]:
+        """Collect source text and recursively discovered local includes."""
+
+        texts: list[tuple[Path, str]] = []
+        visited: set[Path] = set()
+        include_search_roots = [Path(path).expanduser().resolve(strict=False) for path in include_paths]
+
+        def visit(path: Path) -> None:
+            normalized = path.expanduser().resolve(strict=False)
+            if normalized in visited or not normalized.exists():
+                return
+            visited.add(normalized)
+            try:
+                source_text = normalized.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                return
+            texts.append((normalized, source_text))
+            for _, include_name in _SOURCE_INCLUDE_PATTERN.findall(source_text):
+                included_path = _resolve_local_include_path(
+                    include_name,
+                    including_path=normalized,
+                    include_search_roots=include_search_roots,
+                )
+                if included_path is not None:
+                    visit(included_path)
+
+        visit(Path(source))
+        return texts
+
+    def _source_abi_details(
+        self,
+        sources: Sequence[str],
+        include_paths: Sequence[str],
+    ) -> tuple[bool, bool, tuple[str, ...]]:
+        """Detect ABI requirements and report non-stable headers."""
+
+        source_texts = [
+            item
+            for source in sources
+            for item in self._source_texts(source, include_paths)
+        ]
+        source_key = tuple(
+            (str(path), hashlib.sha256(text.encode("utf-8")).hexdigest())
+            for path, text in source_texts
+        )
+        cache_key = (source_key, tuple(include_paths))
+        cached = self._source_abi_detection_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        python_dependent = False
+        stable_registration = False
+        stable_torch_headers = True
+        non_stable_headers: set[str] = set()
+        for _, source_text in source_texts:
+            marker_text = _C_COMMENT_PATTERN.sub("", source_text)
+            if _PYTHON_ABI_USAGE_PATTERN.search(marker_text) or _REGISTER_EXTENSION_PATTERN.search(marker_text):
+                python_dependent = True
+            if _STABLE_TORCH_REGISTRATION_PATTERN.search(marker_text):
+                stable_registration = True
+            for include_name in _TORCH_INCLUDE_PATTERN.findall(marker_text):
+                python_include = (
+                    include_name == "Python.h"
+                    or include_name.startswith("pybind11/")
+                    or include_name in {"torch/extension.h", "torch/python.h"}
+                )
+                if python_include:
+                    python_dependent = True
+                is_non_stable = (
+                    include_name.startswith("ATen/")
+                    or include_name.startswith("c10/")
+                    or include_name.startswith("caffe2/")
+                    or (
+                        include_name.startswith("torch/")
+                        and not (
+                            include_name.startswith("torch/csrc/stable/")
+                            or include_name.startswith("torch/headeronly/")
+                        )
+                    )
+                )
+                if is_non_stable:
+                    stable_torch_headers = False
+                    non_stable_headers.add(include_name)
+
+        detected = (
+            python_dependent,
+            stable_registration and stable_torch_headers,
+            tuple(sorted(non_stable_headers)),
+        )
+        self._source_abi_detection_cache[cache_key] = detected
+        return detected
+
+    def _source_abi_flags(self, sources: Sequence[str], include_paths: Sequence[str]) -> tuple[bool, bool]:
+        """Detect Python and torch ABI requirements from sources and local includes."""
+
+        detected = self._source_abi_details(sources, include_paths)
+        return detected[:2]
+
+    def _resolved_abi_flags(self, sources: Sequence[str], include_paths: Sequence[str]) -> tuple[bool, bool]:
+        detected_python_abi_dependent, _, non_stable_headers = self._source_abi_details(
+            sources,
+            include_paths,
+        )
+        if self.torch_stable_abi_target is not None and non_stable_headers:
+            raise RuntimeError(
+                f"{self.display_name} explicitly requests the Torch stable ABI but uses non-stable header "
+                f"{non_stable_headers[0]!r}"
+            )
+        return (
+            self.python_abi_dependent
+            if self.python_abi_dependent is not None
+            else detected_python_abi_dependent,
+            self.torch_stable_abi_target is not None,
+        )
+
     def _cache_fingerprint(self) -> str:
         """Hash the effective op surface and source metadata to avoid stale cache reuse."""
 
         payload: list[str] = [self.name, self.namespace, *self.required_ops]
-        payload.append(f"python={sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")
-        payload.append(f"torch={torch.__version__}")
-        payload.append(f"torch_cuda={torch.version.cuda or 'none'}")
-        payload.extend(self._cuda_cache_fingerprint_payload())
+        sources = self._resolve_sequence(self.sources)
+        extra_cflags = self._resolved_extra_cflags()
+        extra_cuda_cflags = self._resolved_extra_cuda_cflags()
         include_paths = self._resolved_extra_include_paths()
-        for source in self._resolve_sequence(self.sources):
+        python_abi_dependent, torch_stable_abi = self._resolved_abi_flags(sources, include_paths)
+        if python_abi_dependent:
+            payload.append(f"python_abi={_python_abi_tag()}")
+        else:
+            payload.append("python_abi=agnostic")
+        if torch_stable_abi:
+            major, minor = self.torch_stable_abi_target
+            payload.append(f"torch_abi=stable-{major}.{minor}")
+        else:
+            torch_version = torch.__version__ if self.requires_cuda else _torch_cpu_cache_version()
+            payload.append(f"torch={torch_version}")
+        if self.requires_cuda:
+            payload.append(f"torch_cuda={torch.version.cuda or 'none'}")
+        payload.extend(self._cuda_cache_fingerprint_payload())
+        for source in sources:
             payload.extend(self._source_cache_fingerprint_payload(source, include_paths))
 
-        payload.extend(self._resolve_sequence(self.extra_cflags))
-        payload.extend(_cuda_cache_relevant_flags(self._resolve_sequence(self.extra_cuda_cflags)))
+        payload.extend(extra_cflags)
+        payload.extend(_cuda_cache_relevant_flags(extra_cuda_cflags))
         payload.extend(include_paths)
         payload.extend(self._resolve_sequence(self.extra_ldflags))
         digest = hashlib.sha256("\0".join(payload).encode("utf-8")).hexdigest()
@@ -1024,8 +1215,31 @@ class TorchOpsJitExtension:
 
         return self._last_error
 
+    def _stable_abi_runtime_error(self) -> str:
+        if self.torch_stable_abi_target is None:
+            return ""
+        torch_public = torch.__version__.partition("+")[0]
+        try:
+            torch_major_minor = tuple(int(part) for part in torch_public.split(".")[:2])
+        except (TypeError, ValueError):
+            return ""
+        if torch_major_minor < self.torch_stable_abi_target:
+            major, minor = self.torch_stable_abi_target
+            return (
+                f"{self.display_name}: requires torch >= {major}.{minor} "
+                f"(compiled against the torch {major}.{minor} stable ABI); found torch {torch.__version__}"
+            )
+        return ""
+
     def load(self) -> bool:
         """Load the extension from cache or JIT-compile it on first use."""
+
+        stable_abi_error = self._stable_abi_runtime_error()
+        if stable_abi_error:
+            self._load_attempted = True
+            self._load_result = False
+            self._last_error = stable_abi_error
+            return False
 
         if self._load_attempted and self._load_result and not self.force_rebuild_enabled():
             return True
@@ -1122,10 +1336,10 @@ class TorchOpsJitExtension:
                         "is_python_module": False,
                         "verbose": env_flag(self.verbose_env, default=False) if self.verbose_env else False,
                     }
-                    extra_cflags = self._resolve_sequence(self.extra_cflags)
+                    extra_cflags = self._resolved_extra_cflags()
                     if extra_cflags:
                         kwargs["extra_cflags"] = extra_cflags
-                    extra_cuda_cflags = self._resolve_sequence(self.extra_cuda_cflags)
+                    extra_cuda_cflags = self._resolved_extra_cuda_cflags()
                     if extra_cuda_cflags:
                         kwargs["extra_cuda_cflags"] = extra_cuda_cflags
                     if extra_include_paths:
@@ -1301,6 +1515,7 @@ def _pack_block_extension() -> TorchOpsJitExtension:
             extra_ldflags=[],
             verbose_env="GPTQMODEL_EXT_VERBOSE",
             requires_cuda=False,
+            python_abi_dependent=False,
         )
     return _PACK_BLOCK_TORCH_OPS_EXTENSION
 
@@ -1322,6 +1537,7 @@ def _floatx_cpu_extension() -> TorchOpsJitExtension:
             extra_ldflags=[],
             verbose_env="GPTQMODEL_EXT_VERBOSE",
             requires_cuda=False,
+            python_abi_dependent=False,
         )
     return _FLOATX_CPU_TORCH_OPS_EXTENSION
 

--- a/gptqmodel/utils/cpp.py
+++ b/gptqmodel/utils/cpp.py
@@ -96,7 +96,10 @@ def _python_abi_tag() -> str:
     soabi = sysconfig.get_config_var("SOABI")
     if soabi:
         return str(soabi)
-    return f"cpython-{sys.version_info.major}.{sys.version_info.minor}{sys.abiflags}"
+    # ``sys.abiflags`` is a Unix-only attribute on some supported Python
+    # builds (for example, Windows).  The SOABI fallback must still produce a
+    # stable key there instead of raising while constructing the cache path.
+    return f"cpython-{sys.version_info.major}.{sys.version_info.minor}{getattr(sys, 'abiflags', '')}"
 
 
 def _torch_cpu_cache_version() -> str:
@@ -1218,7 +1221,11 @@ class TorchOpsJitExtension:
         try:
             torch_major_minor = tuple(int(part) for part in torch_public.split(".")[:2])
         except (TypeError, ValueError):
-            return ""
+            major, minor = self.torch_stable_abi_target
+            return (
+                f"{self.display_name}: cannot verify torch stable ABI requirement >= {major}.{minor}; "
+                f"unrecognized torch version {torch.__version__!r}"
+            )
         if torch_major_minor < self.torch_stable_abi_target:
             major, minor = self.torch_stable_abi_target
             return (

--- a/gptqmodel/utils/exllamav2.py
+++ b/gptqmodel/utils/exllamav2.py
@@ -139,6 +139,7 @@ _EXLLAMAV2_GPTQ_TORCH_OPS_EXTENSION = TorchOpsJitExtension(
     force_rebuild_env="GPTQMODEL_EXLLAMAV2_FORCE_REBUILD",
     verbose_env="GPTQMODEL_EXT_VERBOSE",
     requires_cuda=True,
+    python_abi_dependent=False,
 )
 
 # Shared AWQ singleton so every caller reuses the same torch.ops cache and
@@ -162,6 +163,7 @@ _EXLLAMAV2_AWQ_TORCH_OPS_EXTENSION = TorchOpsJitExtension(
     force_rebuild_env="GPTQMODEL_EXLLAMAV2_AWQ_FORCE_REBUILD",
     verbose_env="GPTQMODEL_EXT_VERBOSE",
     requires_cuda=True,
+    python_abi_dependent=False,
 )
 
 

--- a/gptqmodel/utils/hadamard.py
+++ b/gptqmodel/utils/hadamard.py
@@ -72,6 +72,7 @@ _HADAMARD_TORCH_OPS_EXTENSION = TorchOpsJitExtension(
     force_rebuild_env="GPTQMODEL_HADAMARD_FORCE_REBUILD",
     verbose_env="GPTQMODEL_EXT_VERBOSE",
     requires_cuda=True,
+    python_abi_dependent=False,
 )
 
 

--- a/gptqmodel/utils/machete.py
+++ b/gptqmodel/utils/machete.py
@@ -418,6 +418,7 @@ _MACHETE_TORCH_OPS_EXTENSION = TorchOpsJitExtension(
     force_rebuild_env="GPTQMODEL_MACHETE_FORCE_REBUILD",
     verbose_env="GPTQMODEL_EXT_VERBOSE",
     requires_cuda=True,
+    python_abi_dependent=False,
     # Machete kernels are Hopper-only, so compile-only workflows may need to
     # force a non-local target such as `TORCH_CUDA_ARCH_LIST=9.0a`.
     merge_visible_cuda_arch_override=False,

--- a/gptqmodel/utils/marlin.py
+++ b/gptqmodel/utils/marlin.py
@@ -245,6 +245,7 @@ _MARLIN_FP16_TORCH_OPS_EXTENSION = TorchOpsJitExtension(
     force_rebuild_env="GPTQMODEL_MARLIN_FORCE_REBUILD",
     verbose_env="GPTQMODEL_EXT_VERBOSE",
     requires_cuda=True,
+    python_abi_dependent=False,
 )
 
 
@@ -262,6 +263,7 @@ _MARLIN_BF16_TORCH_OPS_EXTENSION = TorchOpsJitExtension(
     force_rebuild_env="GPTQMODEL_MARLIN_FORCE_REBUILD",
     verbose_env="GPTQMODEL_EXT_VERBOSE",
     requires_cuda=True,
+    python_abi_dependent=False,
 )
 
 

--- a/gptqmodel/utils/paroquant.py
+++ b/gptqmodel/utils/paroquant.py
@@ -213,6 +213,7 @@ _PAROQUANT_ROTATION_EXTENSION = TorchOpsJitExtension(
     force_rebuild_env="GPTQMODEL_PAROQUANT_FORCE_REBUILD",
     verbose_env="GPTQMODEL_EXT_VERBOSE",
     requires_cuda=True,
+    python_abi_dependent=False,
 )
 
 

--- a/gptqmodel/utils/qqq.py
+++ b/gptqmodel/utils/qqq.py
@@ -69,6 +69,7 @@ _QQQ_TORCH_OPS_EXTENSION = TorchOpsJitExtension(
     force_rebuild_env="GPTQMODEL_QQQ_FORCE_REBUILD",
     verbose_env="GPTQMODEL_EXT_VERBOSE",
     requires_cuda=True,
+    python_abi_dependent=False,
 )
 
 

--- a/gptqmodel/utils/swordfish.py
+++ b/gptqmodel/utils/swordfish.py
@@ -32,6 +32,7 @@ log = setup_logger()
 
 _SWORDFISH_OPS_NAME = "gptqmodel_swordfish_ops"
 _SWORDFISH_OPS_NAMESPACE = "gptqmodel_swordfish"
+_SWORDFISH_TORCH_STABLE_ABI_TARGET = (2, 10)
 
 _SWORDFISH_GENCODE_SM_RE = re.compile(r"code=sm_(\d+)([a-z]?)")
 _SWORDFISH_GENCODE_PTX_RE = re.compile(r"code=compute_(\d+)([a-z]?)")
@@ -167,6 +168,7 @@ _SWORDFISH_TORCH_OPS_EXTENSION = TorchOpsJitExtension(
     force_rebuild_env="GPTQMODEL_SWORDFISH_FORCE_REBUILD",
     verbose_env="GPTQMODEL_EXT_VERBOSE",
     requires_cuda=True,
+    torch_stable_abi_target=_SWORDFISH_TORCH_STABLE_ABI_TARGET,
     # The kernel targets sm100f/sm110f family; do not let PyTorch merge the
     # visible sm103 capability into the arch list and drop the family flag.
     merge_visible_cuda_arch_override=False,
@@ -227,6 +229,18 @@ _SWORDFISH_SUPPORTED_CAPABILITIES: Tuple[
 def _swordfish_static_runtime_error() -> str:
     if IS_ROCM:
         return "Swordfish kernel is not supported on ROCm."
+    torch_public = torch.__version__.partition("+")[0]
+    try:
+        torch_major_minor = tuple(int(part) for part in torch_public.split(".")[:2])
+    except (TypeError, ValueError):
+        torch_major_minor = _SWORDFISH_TORCH_STABLE_ABI_TARGET
+    if torch_major_minor < _SWORDFISH_TORCH_STABLE_ABI_TARGET:
+        major, minor = _SWORDFISH_TORCH_STABLE_ABI_TARGET
+        return (
+            f"Swordfish kernel requires torch >= {major}.{minor} "
+            f"(compiled against the torch {major}.{minor} stable ABI); "
+            f"found torch {torch.__version__}."
+        )
     if not torch.cuda.is_available():
         return "Swordfish kernel requires CUDA."
     major, minor = torch.cuda.get_device_capability()

--- a/gptqmodel/utils/swordfish.py
+++ b/gptqmodel/utils/swordfish.py
@@ -233,7 +233,11 @@ def _swordfish_static_runtime_error() -> str:
     try:
         torch_major_minor = tuple(int(part) for part in torch_public.split(".")[:2])
     except (TypeError, ValueError):
-        torch_major_minor = _SWORDFISH_TORCH_STABLE_ABI_TARGET
+        major, minor = _SWORDFISH_TORCH_STABLE_ABI_TARGET
+        return (
+            f"Swordfish kernel cannot verify torch stable ABI requirement >= {major}.{minor}; "
+            f"unrecognized torch version {torch.__version__}."
+        )
     if torch_major_minor < _SWORDFISH_TORCH_STABLE_ABI_TARGET:
         major, minor = _SWORDFISH_TORCH_STABLE_ABI_TARGET
         return (

--- a/tests/test_machete_jit.py
+++ b/tests/test_machete_jit.py
@@ -128,7 +128,7 @@ def test_machete_static_runtime_error_requires_hopper_sm90(monkeypatch):
 
     error = machete_utils._machete_static_runtime_error()
 
-    assert "Hopper-class SM90 GPUs only" in error
+    assert "Machete kernel is Hopper-only (SM90)" in error
     assert "12.0" in error
 
 

--- a/tests/test_torch_ops_jit_extension.py
+++ b/tests/test_torch_ops_jit_extension.py
@@ -111,6 +111,14 @@ def test_torch_ops_jit_extension_python_abi_falls_back_without_soabi(monkeypatch
     assert cpp_module._python_abi_tag() == "cpython-3.13t"
 
 
+def test_torch_ops_jit_extension_python_abi_fallback_handles_missing_abiflags(monkeypatch):
+    monkeypatch.setattr(cpp_module.sysconfig, "get_config_var", lambda name: None)
+    monkeypatch.setattr(cpp_module.sys, "version_info", SimpleNamespace(major=3, minor=13))
+    monkeypatch.delattr(cpp_module.sys, "abiflags", raising=False)
+
+    assert cpp_module._python_abi_tag() == "cpython-3.13"
+
+
 def test_torch_ops_jit_extension_detects_conservative_python_abi_markers(tmp_path):
     markers = (
         "#include <Python.h>\n",
@@ -208,6 +216,18 @@ def test_torch_ops_jit_extension_stable_target_rejects_older_torch(monkeypatch, 
     assert prebuilt_calls == []
 
 
+def test_torch_ops_jit_extension_stable_target_rejects_unparseable_torch(monkeypatch, tmp_path):
+    loader = _make_loader(tmp_path, torch_stable_abi_target=(2, 10))
+    monkeypatch.setattr(cpp_module.torch, "__version__", "nightly")
+    prebuilt_calls = []
+
+    monkeypatch.setattr(loader, "_try_load_prebuilt_library", lambda _build_root: prebuilt_calls.append(True))
+
+    assert loader.load() is False
+    assert "cannot verify torch stable ABI requirement" in loader.last_error_message()
+    assert prebuilt_calls == []
+
+
 def test_torch_ops_jit_extension_resolves_angle_bracket_local_includes(tmp_path):
     source = tmp_path / "unit_test.cpp"
     include_root = tmp_path / "include"
@@ -245,6 +265,14 @@ def test_swordfish_static_runtime_error_rejects_older_torch(monkeypatch):
     error = swordfish._swordfish_static_runtime_error()
 
     assert "requires torch >= 2.10" in error
+
+
+def test_swordfish_static_runtime_error_rejects_unparseable_torch(monkeypatch):
+    monkeypatch.setattr(swordfish.torch, "__version__", "nightly")
+
+    error = swordfish._swordfish_static_runtime_error()
+
+    assert "cannot verify torch stable ABI requirement" in error
 
 
 def test_torch_stable_abi_target_define_matches_libtorch_encoding():

--- a/tests/test_torch_ops_jit_extension.py
+++ b/tests/test_torch_ops_jit_extension.py
@@ -8,11 +8,13 @@ import subprocess
 import sys
 import threading
 import time
+from types import SimpleNamespace
 from pathlib import Path
 
 import pytest
 
 from gptqmodel.utils import cpp as cpp_module
+from gptqmodel.utils import swordfish
 
 
 class _FakeSpinner:
@@ -58,6 +60,195 @@ def _make_loader(tmp_path: Path, **overrides) -> cpp_module.TorchOpsJitExtension
     }
     params.update(overrides)
     return cpp_module.TorchOpsJitExtension(**params)
+
+
+def test_torch_ops_jit_extension_fingerprint_uses_python_abi_only_when_dependent(monkeypatch, tmp_path):
+    source = tmp_path / "unit_test.cpp"
+    source.write_text("PYBIND11_MODULE(unit_test, m) {}\n", encoding="utf-8")
+    loader = _make_loader(tmp_path, sources=[str(source)])
+    payloads = []
+    real_sha256 = cpp_module.hashlib.sha256
+
+    def capture_sha256(data=b""):
+        payloads.append(data)
+        return real_sha256(data)
+
+    monkeypatch.setattr(cpp_module.hashlib, "sha256", capture_sha256)
+    monkeypatch.setattr(cpp_module.sys, "version_info", SimpleNamespace(major=3, minor=12, micro=9))
+    monkeypatch.setattr(
+        cpp_module.sysconfig,
+        "get_config_var",
+        lambda name: "cpython-312-x86_64-linux-gnu" if name == "SOABI" else None,
+    )
+
+    first_fingerprint = loader._cache_fingerprint()
+    first_payload = payloads[-1].decode()
+    monkeypatch.setattr(cpp_module.sys, "version_info", SimpleNamespace(major=3, minor=13, micro=1))
+    second_fingerprint = loader._cache_fingerprint()
+
+    assert first_fingerprint == second_fingerprint
+    assert "python_abi=cpython-312-x86_64-linux-gnu" in first_payload
+    assert "python=3." not in first_payload
+
+
+def test_torch_ops_jit_extension_agnostic_fingerprint_ignores_python_version(monkeypatch, tmp_path):
+    source = tmp_path / "unit_test.cpp"
+    source.write_text("int kernel() { return 1; }\n", encoding="utf-8")
+    loader = _make_loader(tmp_path, sources=[str(source)])
+
+    monkeypatch.setattr(cpp_module.sys, "version_info", SimpleNamespace(major=3, minor=12, micro=9))
+    first_fingerprint = loader._cache_fingerprint()
+    monkeypatch.setattr(cpp_module.sys, "version_info", SimpleNamespace(major=3, minor=13, micro=1))
+
+    assert loader._cache_fingerprint() == first_fingerprint
+
+
+def test_torch_ops_jit_extension_python_abi_falls_back_without_soabi(monkeypatch):
+    monkeypatch.setattr(cpp_module.sysconfig, "get_config_var", lambda name: None)
+    monkeypatch.setattr(cpp_module.sys, "version_info", SimpleNamespace(major=3, minor=13))
+    monkeypatch.setattr(cpp_module.sys, "abiflags", "t")
+
+    assert cpp_module._python_abi_tag() == "cpython-3.13t"
+
+
+def test_torch_ops_jit_extension_detects_conservative_python_abi_markers(tmp_path):
+    markers = (
+        "#include <Python.h>\n",
+        '#include "Python.h"\n',
+        "#include <pybind11/pybind11.h>\n",
+        '#include "pybind11/pybind11.h"\n',
+        "#include <torch/extension.h>\n",
+        '#include "torch/python.h"\n',
+        "PyObject *object;\n",
+        "PyErr_Clear();\n",
+        "py::handle object;\n",
+        'PYBIND11_TYPE_CASTER(int, _("int"));\n',
+    )
+    for index, marker in enumerate(markers):
+        source = tmp_path / f"marker_{index}.cpp"
+        source.write_text(marker, encoding="utf-8")
+        loader = _make_loader(tmp_path, sources=[str(source)])
+
+        assert loader._source_abi_flags([str(source)], []) == (True, False)
+
+
+@pytest.mark.parametrize("header", ("c10/util/SmallVector.h", "caffe2/utils/TypeCast.h"))
+def test_torch_ops_jit_extension_explicit_stable_abi_rejects_nonstable_headers(tmp_path, header):
+    source = tmp_path / "unit_test.cpp"
+    source.write_text(f"#include <{header}>\n", encoding="utf-8")
+    loader = _make_loader(tmp_path, sources=[str(source)], torch_stable_abi_target=(2, 10))
+
+    with pytest.raises(RuntimeError, match=header.replace("/", r"\/")):
+        loader._cache_fingerprint()
+
+
+def test_torch_ops_jit_extension_cpu_and_cuda_fingerprints_handle_wheel_switch(monkeypatch, tmp_path):
+    source = tmp_path / "unit_test.cpp"
+    source.write_text("int kernel() { return 1; }\n", encoding="utf-8")
+    cpu_loader = _make_loader(tmp_path, sources=[str(source)])
+    cuda_loader = _make_loader(tmp_path, sources=[str(source)], requires_cuda=True)
+
+    monkeypatch.setattr(cpp_module.torch, "__version__", "2.8.0+cpu")
+    cpu_fingerprint = cpu_loader._cache_fingerprint()
+    cuda_fingerprint = cuda_loader._cache_fingerprint()
+    for accelerator_tag in ("cu128", "rocm6.2", "xpu"):
+        monkeypatch.setattr(cpp_module.torch, "__version__", f"2.8.0+{accelerator_tag}")
+        assert cpu_loader._cache_fingerprint() == cpu_fingerprint
+        assert cuda_loader._cache_fingerprint() != cuda_fingerprint
+
+    monkeypatch.setattr(cpp_module.torch, "__version__", "2.8.0")
+    plain_fingerprint = cpu_loader._cache_fingerprint()
+    assert plain_fingerprint == cpu_fingerprint
+    monkeypatch.setattr(cpp_module.torch, "__version__", "2.8.0+gitabc1234")
+    assert cpu_loader._cache_fingerprint() != cpu_fingerprint
+
+
+def test_torch_ops_jit_extension_fingerprint_includes_stable_abi_target(tmp_path):
+    source = tmp_path / "unit_test.cpp"
+    source.write_text(
+        '#include <torch/csrc/stable/library.h>\nSTABLE_TORCH_LIBRARY(unit_test, m) {}\n',
+        encoding="utf-8",
+    )
+    loader = _make_loader(tmp_path, sources=[str(source)], torch_stable_abi_target=(2, 10))
+    first_fingerprint = loader._cache_fingerprint()
+    target_211_loader = _make_loader(tmp_path, sources=[str(source)], torch_stable_abi_target=(2, 11))
+
+    assert target_211_loader._cache_fingerprint() != first_fingerprint
+    assert "-DTORCH_TARGET_VERSION=0x020A000000000000" in loader._resolved_extra_cflags()
+    assert "-DTORCH_TARGET_VERSION=0x020A000000000000" in loader._resolved_extra_cuda_cflags()
+
+
+def test_torch_ops_jit_extension_auto_detected_stable_sources_keep_torch_version(monkeypatch, tmp_path):
+    source = tmp_path / "unit_test.cpp"
+    source.write_text(
+        '#include <torch/csrc/stable/library.h>\nSTABLE_TORCH_LIBRARY(unit_test, m) {}\n',
+        encoding="utf-8",
+    )
+    loader = _make_loader(tmp_path, sources=[str(source)])
+    monkeypatch.setattr(cpp_module.torch, "__version__", "2.8.0+cpu")
+    first_fingerprint = loader._cache_fingerprint()
+    monkeypatch.setattr(cpp_module.torch, "__version__", "2.13.0+cpu")
+
+    assert loader._cache_fingerprint() != first_fingerprint
+
+
+def test_torch_ops_jit_extension_stable_target_rejects_older_torch(monkeypatch, tmp_path):
+    loader = _make_loader(tmp_path, torch_stable_abi_target=(2, 10))
+    monkeypatch.setattr(cpp_module.torch, "__version__", "2.9.0")
+    prebuilt_calls = []
+
+    def unexpected_prebuilt_load(_build_root):
+        prebuilt_calls.append(True)
+        raise AssertionError("stable ABI floor must prevent cache lookup")
+
+    monkeypatch.setattr(loader, "_try_load_prebuilt_library", unexpected_prebuilt_load)
+
+    assert loader.load() is False
+    assert "requires torch >= 2.10" in loader.last_error_message()
+    assert prebuilt_calls == []
+
+
+def test_torch_ops_jit_extension_resolves_angle_bracket_local_includes(tmp_path):
+    source = tmp_path / "unit_test.cpp"
+    include_root = tmp_path / "include"
+    include_root.mkdir()
+    wrapper = include_root / "wrapper.h"
+    source.write_text(
+        "#include <wrapper.h>\n#include <nonexistent_sys.h>\nint kernel() { return 1; }\n",
+        encoding="utf-8",
+    )
+    wrapper.write_text("#include <Python.h>\n", encoding="utf-8")
+    loader = _make_loader(tmp_path, sources=[str(source)], extra_include_paths=[str(include_root)])
+
+    assert loader._source_abi_flags([str(source)], [str(include_root)]) == (True, False)
+    first_fingerprint = loader._cache_fingerprint()
+    first_payload = loader._source_cache_fingerprint_payload(str(source), [str(include_root)])
+    assert not any("missing_include" in entry and "nonexistent_sys.h" in entry for entry in first_payload)
+
+    wrapper.write_text("#include <c10/util/SmallVector.h>\n", encoding="utf-8")
+    second_fingerprint = loader._cache_fingerprint()
+
+    assert second_fingerprint != first_fingerprint
+    stable_loader = _make_loader(
+        tmp_path,
+        sources=[str(source)],
+        extra_include_paths=[str(include_root)],
+        torch_stable_abi_target=(2, 10),
+    )
+    with pytest.raises(RuntimeError, match=r"c10/util/SmallVector\.h"):
+        stable_loader._cache_fingerprint()
+
+
+def test_swordfish_static_runtime_error_rejects_older_torch(monkeypatch):
+    monkeypatch.setattr(swordfish.torch, "__version__", "2.9.1+cpu")
+
+    error = swordfish._swordfish_static_runtime_error()
+
+    assert "requires torch >= 2.10" in error
+
+
+def test_torch_stable_abi_target_define_matches_libtorch_encoding():
+    assert cpp_module.torch_stable_abi_target_define(2, 10) == "-DTORCH_TARGET_VERSION=0x020A000000000000"
 
 
 def test_default_jit_cflags_allow_noopt(monkeypatch):


### PR DESCRIPTION
## Summary

JIT extension cache fingerprints hash the exact Python version (`python=3.12.9`) and exact torch wheel version unconditionally, so every Python or torch env change forces a full recompile — even though all `TorchOpsJitExtension` binaries are loaded via `torch.ops.load_library` (`is_python_module=False`) and most have no CPython ABI dependence. This PR makes fingerprints reflect actual ABI requirements so compiled extensions are reused wherever the binary is genuinely compatible.

## What Changed

- `gptqmodel/utils/cpp.py`:
  - `TorchOpsJitExtension` gains `python_abi_dependent` / `torch_stable_abi_target` params. Python-ABI detection (default `None` = auto-detect by scanning sources + recursively resolved local includes) is deliberately conservative: `Python.h` / `pybind11/*` / `torch/extension.h` / `torch/python.h` includes and any `Py[A-Z]*` / `py::` / `PYBIND11_*` usage flag the extension as python-dependent; audited torch.ops-only loaders (pack_block, floatx, awq, qqq, exllamav2 gptq+awq, exllamav3, machete, marlin fp16+bf16, paroquant, hadamard) set explicit `python_abi_dependent=False` (only unused registration macros / incidental includes, no runtime Python usage in compiled TUs).
  - Torch stable-ABI cross-version reuse requires an explicit `torch_stable_abi_target=(major, minor)`. When set, the class injects `-DTORCH_TARGET_VERSION` into both host cflags and NVCC flags (so the two floors can't drift), fingerprints as `torch_abi=stable-{major}.{minor}`, validates the scanned sources (only `torch/csrc/stable/` / `torch/headeronly/` torch headers are stable; `ATen/`, `c10/`, `caffe2/` and other `torch/` headers raise a `RuntimeError` naming the offending include), and enforces the runtime floor itself: `load()` refuses to reuse a cached binary or compile when the running torch is below the target. Sources that auto-detect as stable but have no explicit target stay keyed to the current torch build.
  - Include recursion (both ABI scanning and source fingerprint hashing) now follows angle-bracket includes too, when they resolve under the including file's directory or an explicit `extra_include_paths` entry; unresolvable angle includes are treated as system headers and skipped.
  - Fingerprint payload pseudo-diff:
    ```diff
    - python=3.12.9
    + python_abi=agnostic            (or the interpreter SOABI, e.g. cpython-313t-x86_64-linux-gnu,
    +                                 when python-ABI dependent — free-threaded builds get distinct keys)
    - torch=2.8.0+cu128
    + torch_abi=stable-2.10          (extensions with an explicit stable-ABI target)
    + torch=2.8.0                    (non-stable CPU extensions: accelerator wheel tag stripped)
    + torch=2.8.0+cu128              (non-stable CUDA extensions: full wheel version kept)
    - torch_cuda=12.8                (now emitted only when requires_cuda)
    ```
  - Non-stable CPU normalization is allowlist-only (`_torch_cpu_cache_version()`): only `+cpu`, `+cuNNN`, `+rocmX.Y`, `+xpu` are stripped; source/vendor local identifiers (e.g. `+gitabc1234`) are preserved so different libtorch builds never collide in the cache.
  - New `torch_stable_abi_target_define(major, minor)` → `-DTORCH_TARGET_VERSION=0x020A000000000000` (libtorch encoding: major<<56 | minor<<48).
- `gptqmodel/utils/swordfish.py`: swordfish (written against the torch stable ABI) is pinned via `torch_stable_abi_target=(2, 10)`. 2.10 is the audited floor: `torch_get_current_cuda_blas_handle` (used by `libtorch_stable/torch_utils.h`) is gated at `TORCH_VERSION_2_10_0` in `torch/csrc/stable/c/shim.h`; no swordfish API needs 2.11+. `_swordfish_static_runtime_error()` also gates torch < 2.10 with an explicit error so expected incompatibility never enters JIT compilation.
- Behavior: CPU extensions no longer recompile when switching between `+cpu`/`+cu12x`/`+rocm*`/`+xpu` wheels of the same torch version; python-agnostic extensions share caches across Python versions (including free-threaded); swordfish shares caches across torch versions >= 2.10 and refuses cached-binary reuse below the floor.
- Out of scope: CUDA extensions built against non-stable libtorch APIs still key on the full torch wheel version (required for correctness); no migration of other kernels to the stable ABI.

## Tests

- [x] I added a new simple/fast unit test for this change, or documented why that is not applicable.
- [x] I ran the new targeted test locally before opening this PR.
- [x] I ran any other directly relevant local tests.

New tests in `tests/test_torch_ops_jit_extension.py` cover: python-agnostic fingerprint stability across Python versions, SOABI keying (incl. free-threaded fallback), conservative python-ABI marker detection, wheel-switch normalization (`+cpu` ↔ `+cu128`/`+rocm6.2`/`+xpu` reuse; `+gitabc1234` preserved), stable-target fingerprinting + define injection into both flag sets, explicit-stable-target rejection of non-stable headers, runtime floor refusal on torch 2.9 with target 2.10 (no cache lookup), angle-bracket include resolution (ABI detection + fingerprint invalidation + system-include skip), swordfish torch<2.10 gate, and the `TORCH_TARGET_VERSION` encoding.

```bash
$ python -m pytest -q tests/test_torch_ops_jit_extension.py
46 passed in 4.90s
$ ruff check gptqmodel/utils/cpp.py gptqmodel/utils/swordfish.py gptqmodel/utils/awq.py gptqmodel/utils/qqq.py gptqmodel/utils/exllamav2.py gptqmodel/exllamav3/ext.py gptqmodel/utils/hadamard.py gptqmodel/utils/machete.py gptqmodel/utils/marlin.py gptqmodel/utils/paroquant.py tests/test_torch_ops_jit_extension.py
All checks passed!
```

## Review Requirements

- [x] I personally reviewed every file in this diff.
- [x] I checked that the code matches existing project structure, APIs, and conventions.
- [x] I avoided unnecessary monkeypatching and used the project's normal extension points where possible.

## Notes

- Full swordfish CUDA JIT compilation/runtime was not exercised here (no CUDA toolkit/GPU on this box); a stable-shim syntax check with `TORCH_TARGET_VERSION=0x020A000000000000` confirms the required declarations are visible at the 2.10 floor. A real build/load on torch >= 2.10 + Blackwell is recommended before relying on cross-torch swordfish reuse.
- Cache-key changes mean existing JIT caches will be rebuilt once under the new fingerprints.

Link to Devin session: https://app.devin.ai/sessions/b1d3f556711a4711b7b82bd732c66de5
Open in Devin Desktop: https://app.devin.ai/desktop/session/b1d3f556711a4711b7b82bd732c66de5?variant=devin
Requested by: @Qubitium