### PR TITLE
[WIP] Input-source metadata for module tree definitions (shared-input groundwork)

### DIFF
--- a/gptqmodel/looper/input_source_validator.py
+++ b/gptqmodel/looper/input_source_validator.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+"""Capture and validate inputs shared by module-tree groups."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Iterable
+
+import torch
+
+from ..models.input_source import InputSourceId
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .named_module import NamedModule
+
+
+@dataclass
+class InputSourceMismatch:
+    """Describe one input-source group whose captured inputs differ."""
+
+    source: InputSourceId
+    module_names: list[str]
+    shapes: dict[str, list[tuple]]
+    dtypes: dict[str, list[torch.dtype]]
+    reason: str
+    differing: list[tuple[str, str]]
+
+
+class InputSourceValidationError(RuntimeError):
+    """Raised when modules declared to share an input source disagree."""
+
+    def __init__(self, mismatches: list[InputSourceMismatch]) -> None:
+        self.mismatches = mismatches
+        lines = ["input-source validation failed:"]
+        for mismatch in mismatches:
+            lines.append(
+                "source "
+                f"{mismatch.source.kind} scope={mismatch.source.scope!r}, "
+                f"modules={mismatch.module_names!r}, "
+                f"shapes={mismatch.shapes!r}, reason={mismatch.reason}"
+            )
+        super().__init__("\n".join(lines))
+
+
+class InputSourceCapture:
+    """Record the first positional or keyword tensor input to each module."""
+
+    def __init__(self, modules: Iterable[NamedModule], *, max_calls: int = 4) -> None:
+        self.modules = list(modules)
+        self.max_calls = max_calls
+        self.captured: dict[str, list[torch.Tensor]] = {
+            module.full_name: [] for module in self.modules
+        }
+        self._handles = []
+
+    def __enter__(self) -> "InputSourceCapture":
+        def make_capture(name: str):
+            def capture(module: torch.nn.Module, args, kwargs) -> None:
+                del module
+                tensor = args[0] if args and isinstance(args[0], torch.Tensor) else None
+                if tensor is None:
+                    tensor = next(
+                        (value for value in kwargs.values() if isinstance(value, torch.Tensor)),
+                        None,
+                    )
+                if tensor is None:
+                    return
+                values = self.captured[name]
+                if len(values) < self.max_calls:
+                    values.append(tensor)
+
+            return capture
+
+        for named_module in self.modules:
+            handle = named_module.module.register_forward_pre_hook(
+                make_capture(named_module.full_name),
+                with_kwargs=True,
+            )
+            self._handles.append(handle)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        for handle in self._handles:
+            handle.remove()
+        self._handles.clear()
+
+
+@dataclass
+class InputSourceValidationReport:
+    """Results from comparing captured inputs for declared source groups."""
+
+    checked_sources: int
+    checked_modules: int
+    mismatches: list[InputSourceMismatch]
+
+    @property
+    def ok(self) -> bool:
+        return not self.mismatches
+
+    def raise_if_failed(self) -> None:
+        if not self.ok:
+            raise InputSourceValidationError(self.mismatches)
+
+
+def _tensor_matches(left: torch.Tensor, right: torch.Tensor) -> tuple[bool, str | None]:
+    if left is right:
+        return True, None
+    if (
+        left.data_ptr() == right.data_ptr()
+        and left.shape == right.shape
+        and left.stride() == right.stride()
+        and left.dtype == right.dtype
+    ):
+        return True, None
+    if left.shape != right.shape:
+        return False, "shape"
+    if left.dtype != right.dtype:
+        return False, "dtype"
+    if torch.equal(left, right):
+        return True, None
+    return False, "value"
+
+
+def validate_input_sources(
+    input_sources: dict[InputSourceId, list[NamedModule]],
+    captured: dict[str, list[torch.Tensor]],
+    *,
+    atol: float = 0.0,
+    rtol: float = 0.0,
+) -> InputSourceValidationReport:
+    """Validate that every invoked module in each source group saw equal inputs."""
+
+    checked_sources = 0
+    checked_modules = 0
+    mismatches = []
+    for source, modules in input_sources.items():
+        invoked = [module for module in modules if captured.get(module.full_name)]
+        if len(invoked) < 2:
+            continue
+        checked_sources += 1
+        checked_modules += len(invoked)
+        shapes = {
+            module.full_name: [tuple(tensor.shape) for tensor in captured[module.full_name]]
+            for module in invoked
+        }
+        dtypes = {
+            module.full_name: [tensor.dtype for tensor in captured[module.full_name]]
+            for module in invoked
+        }
+        reference = invoked[0]
+        reference_calls = captured[reference.full_name]
+        differing = []
+        reason = None
+        for other in invoked[1:]:
+            other_calls = captured[other.full_name]
+            if len(reference_calls) != len(other_calls):
+                reason = reason or "call_count"
+                differing.append((reference.full_name, other.full_name))
+                continue
+            for left, right in zip(reference_calls, other_calls):
+                matches, difference = _tensor_matches(left, right)
+                if not matches:
+                    if difference == "value" and (atol != 0.0 or rtol != 0.0):
+                        matches = torch.allclose(left, right, atol=atol, rtol=rtol)
+                        difference = None if matches else "value"
+                    if not matches:
+                        reason = reason or difference
+                        differing.append((reference.full_name, other.full_name))
+                        break
+        if reason is not None:
+            mismatches.append(
+                InputSourceMismatch(
+                    source=source,
+                    module_names=[module.full_name for module in modules],
+                    shapes=shapes,
+                    dtypes=dtypes,
+                    reason=reason,
+                    differing=differing,
+                )
+            )
+    return InputSourceValidationReport(
+        checked_sources=checked_sources,
+        checked_modules=checked_modules,
+        mismatches=mismatches,
+    )
+
+
+def validate_plan_input_sources(plan, captured) -> InputSourceValidationReport:
+    """Validate the input-source groups attached to a subset plan."""
+
+    return validate_input_sources(plan.input_sources, captured)

--- a/gptqmodel/looper/module_looper.py
+++ b/gptqmodel/looper/module_looper.py
@@ -1653,8 +1653,7 @@ class ModuleLooper():
                 subset_id = None
                 input_spec = None
                 if not is_lm_head_module:
-                    resolver = getattr(type(self.gptq_model), "resolve_module_tree_entry", None)
-                    entry = resolver(name) if resolver is not None else None
+                    entry = type(self.gptq_model).resolve_module_tree_entry(name)
                     if entry is not None:
                         tree_scope_id = (
                             f"{layers_prefix}.{entry.scope}"

--- a/gptqmodel/looper/module_looper.py
+++ b/gptqmodel/looper/module_looper.py
@@ -34,7 +34,7 @@ from ..looper.loop_processor import LoopProcessor
 from ..looper.named_module import NamedModule
 from ..models import BaseQModel
 from ..models._const import SUPPORTS_MODULE_TYPES
-from ..models.base import CAPTURE_ONLY_FLAG
+from ..models.base import CAPTURE_ONLY_FLAG, BaseQModel
 from ..nn_modules.hooked_linear import HookedLinear, replace_module_with_hooked_legacy
 from ..quantization.config import METHOD, VramStrategy
 from ..utils.attn_mask import apply_keep_mask_bt
@@ -1652,7 +1652,7 @@ class ModuleLooper():
                 tree_scope_id = None
                 subset_id = None
                 input_spec = None
-                if not is_lm_head_module:
+                if not is_lm_head_module and isinstance(self.gptq_model, BaseQModel):
                     entry = type(self.gptq_model).resolve_module_tree_entry(name)
                     if entry is not None:
                         tree_scope_id = (

--- a/gptqmodel/looper/module_looper.py
+++ b/gptqmodel/looper/module_looper.py
@@ -1649,8 +1649,23 @@ class ModuleLooper():
 
             # gptq task is created and stored inside processor
             if not isinstance(subset[name], NamedModule):
+                tree_scope_id = None
+                subset_id = None
+                input_spec = None
+                if not is_lm_head_module:
+                    resolver = getattr(type(self.gptq_model), "resolve_module_tree_entry", None)
+                    entry = resolver(name) if resolver is not None else None
+                    if entry is not None:
+                        tree_scope_id = (
+                            f"{layers_prefix}.{entry.scope}"
+                            if entry.scope
+                            else layers_prefix
+                        )
+                        subset_id = entry.subset_id
+                        input_spec = entry.input_spec
                 named_module = NamedModule(subset[name], name=name, full_name=layer_name,
-                                           layer_index=layer_index)
+                                           layer_index=layer_index, tree_scope_id=tree_scope_id,
+                                           subset_id=subset_id, input_spec=input_spec)
                 if capture_only_flags.get(name, False):
                     named_module.state["capture_only"] = True
                 if isinstance(processor, EoraProcessor):

--- a/gptqmodel/looper/module_looper.py
+++ b/gptqmodel/looper/module_looper.py
@@ -34,7 +34,7 @@ from ..looper.loop_processor import LoopProcessor
 from ..looper.named_module import NamedModule
 from ..models import BaseQModel
 from ..models._const import SUPPORTS_MODULE_TYPES
-from ..models.base import CAPTURE_ONLY_FLAG, BaseQModel
+from ..models.base import CAPTURE_ONLY_FLAG
 from ..nn_modules.hooked_linear import HookedLinear, replace_module_with_hooked_legacy
 from ..quantization.config import METHOD, VramStrategy
 from ..utils.attn_mask import apply_keep_mask_bt

--- a/gptqmodel/looper/named_module.py
+++ b/gptqmodel/looper/named_module.py
@@ -11,6 +11,7 @@ from torch import Tensor, nn
 from torch.nn import Parameter
 from torch.nn.modules.conv import _ConvNd
 
+from ..models.input_source import InputSpec
 from ..utils.logger import setup_logger
 from ..utils.module_locks import get_parent_lock
 from ..utils.stream import stream_sync as stream_sync_events
@@ -23,7 +24,16 @@ log = setup_logger()
 class NamedModule(torch.nn.Module):
     """Thread-safe wrapper that adds stable names and scratch state to a module."""
 
-    def __init__(self, module: torch.nn.Module, name: str, full_name:str, layer_index: int) -> None:
+    def __init__(
+        self,
+        module: torch.nn.Module,
+        name: str,
+        full_name: str,
+        layer_index: int,
+        tree_scope_id: Optional[str] = None,
+        subset_id: Optional[int] = None,
+        input_spec: Optional[InputSpec] = None,
+    ) -> None:
         """Wraps a submodule with naming metadata used by the looper pipeline."""
 
         super().__init__()
@@ -34,6 +44,9 @@ class NamedModule(torch.nn.Module):
         self.name = name  # module name
         self.full_name = full_name  # full dotted path inside model
         self.layer_index = layer_index  # layer index for repeated blocks
+        self.tree_scope_id = tree_scope_id
+        self.subset_id = subset_id
+        self.input_spec = input_spec
 
         if hasattr(module, "module_name") and module.module_name is None:
             module.module_name = full_name
@@ -158,6 +171,9 @@ class NamedModule(torch.nn.Module):
             "name",
             "full_name",
             "layer_index",
+            "tree_scope_id",
+            "subset_id",
+            "input_spec",
             "state",
             "_parent_lock",
             "target_device",

--- a/gptqmodel/looper/stage_subset.py
+++ b/gptqmodel/looper/stage_subset.py
@@ -29,6 +29,10 @@ from .paroquant_processor import ParoQuantProcessor
 from .qqq_processor import QQQProcessor
 from .. import DEBUG_ON, DEVICE_THREAD_POOL
 from ..looper.gptq_processor import GPTQProcessor
+from ..looper.input_source_validator import (
+    InputSourceCapture,
+    validate_plan_input_sources,
+)
 from ..looper.loop_processor import LoopProcessor
 from ..looper.named_module import NamedModule
 from ..models._const import META
@@ -549,7 +553,16 @@ def build_subset_plan(
         "auto_forward_data_parallel",
         True,
     )
-    subset_forward_serial = subset_forward_serial or not auto_forward_data_parallel
+    validate_input_sources = getattr(
+        looper.gptq_model.quantize_config,
+        "validate_input_sources",
+        False,
+    )
+    subset_forward_serial = (
+        subset_forward_serial
+        or not auto_forward_data_parallel
+        or validate_input_sources
+    )
 
     # Forward progress is normalized here so the executor and any later replay
     # reuse the same batch and row accounting instead of recomputing it.
@@ -889,7 +902,20 @@ def _run_single_subset_pass(
         )
 
     forward_outputs = None
+    input_source_capture = None
     if execute_forward:
+        if (
+            getattr(looper.gptq_model.quantize_config, "validate_input_sources", False)
+            and any(len(group) >= 2 for group in plan.input_sources.values())
+        ):
+            capture_modules = [
+                named_module
+                for group in plan.input_sources.values()
+                if len(group) >= 2
+                for named_module in group
+            ]
+            input_source_capture = InputSourceCapture(capture_modules)
+            input_source_capture.__enter__()
         try:
             # MoE lifecycle hooks need to know which subset is currently active.
             # Replay-only passes can disable that when they only need outputs.
@@ -921,6 +947,8 @@ def _run_single_subset_pass(
                 preserve_module_devices=preserve_devices,
             )
         finally:
+            if input_source_capture is not None:
+                input_source_capture.__exit__(None, None, None)
             if forward_device_map and plan.restore_forward_device_overrides:
                 looper._restore_forward_device_overrides(
                     subset,
@@ -972,6 +1000,18 @@ def _run_single_subset_pass(
             if hasattr(subset[name], 'forward_hook'):
                 subset[name].forward_hook = None
                 subset[name].forward_hook_last = False
+
+    if input_source_capture is not None:
+        report = validate_plan_input_sources(plan, input_source_capture.captured)
+        logger.info(
+            "Input-source validation: layer=%s subset=%s/%s checked_sources=%s checked_modules=%s",
+            layer_index,
+            subset_index + 1,
+            subset_total,
+            report.checked_sources,
+            report.checked_modules,
+        )
+        report.raise_if_failed()
 
     forward_flush_device = _resolve_forward_flush_device(plan, cur_layer_device)
     if looper.gptq_model.quantize_config.gc_mode == GcMode.ON_STAGE_END:
@@ -1269,7 +1309,7 @@ def run_subset_stage(
 
         # Create progress bar for MOE chunks
         moe_chunk_pb = logger.pb(range(len(plan.module_chunks))).manual()
-        moe_chunk_pb.title(f"MoE Chunk")
+        moe_chunk_pb.title("MoE Chunk")
 
         for chunk_idx in moe_chunk_pb:
             chunk_plan = plan.for_modules(plan.module_chunks[chunk_idx])

--- a/gptqmodel/looper/stage_subset.py
+++ b/gptqmodel/looper/stage_subset.py
@@ -32,6 +32,7 @@ from ..looper.gptq_processor import GPTQProcessor
 from ..looper.loop_processor import LoopProcessor
 from ..looper.named_module import NamedModule
 from ..models._const import META
+from ..models.input_source import InputSourceId, group_input_sources
 from ..quantization.config import GcMode, ExpertsRoutingBypass, VramStrategy
 from ..utils.device_telemetry import emit_device_telemetry
 from ..utils.device import get_device
@@ -81,6 +82,7 @@ class SubsetPlan:
     - how MoE groups are arranged for scheduling
     - which modules are pinned to specific forward devices
     - how uncovered calibration modules are handled
+    - which modules share one logical input activation
     """
 
     modules: Dict[str, NamedModule]
@@ -98,12 +100,19 @@ class SubsetPlan:
     module_chunks: List[Dict[str, NamedModule]]
     ordered_module_names: List[str] = field(default_factory=list)
     restore_forward_device_overrides: bool = True
+    input_sources: Dict[InputSourceId, List[NamedModule]] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Freeze an explicit ordered module list for forward replay decisions."""
 
         if not self.ordered_module_names:
             self.ordered_module_names = list(self.modules.keys())
+        if not self.input_sources and self.modules:
+            self.input_sources = group_input_sources(
+                self.modules[name]
+                for name in self.ordered_module_names
+                if name in self.modules
+            )
 
     @property
     def subset_forward_serial(self) -> bool:
@@ -138,6 +147,7 @@ class SubsetPlan:
             modules=modules,
             ordered_module_names=ordered_names,
             module_chunks=[modules],
+            input_sources={},
         )
 
 

--- a/gptqmodel/looper/stage_subset.py
+++ b/gptqmodel/looper/stage_subset.py
@@ -553,11 +553,7 @@ def build_subset_plan(
         "auto_forward_data_parallel",
         True,
     )
-    validate_input_sources = getattr(
-        looper.gptq_model.quantize_config,
-        "validate_input_sources",
-        False,
-    )
+    validate_input_sources = looper.gptq_model.quantize_config.validate_input_sources
     subset_forward_serial = (
         subset_forward_serial
         or not auto_forward_data_parallel
@@ -905,7 +901,7 @@ def _run_single_subset_pass(
     input_source_capture = None
     if execute_forward:
         if (
-            getattr(looper.gptq_model.quantize_config, "validate_input_sources", False)
+            looper.gptq_model.quantize_config.validate_input_sources
             and any(len(group) >= 2 for group in plan.input_sources.values())
         ):
             capture_modules = [

--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -7,10 +7,12 @@ from __future__ import annotations
 import copy
 import json
 import os
+import re
 import threading
 import time
 from collections import defaultdict
 from contextlib import nullcontext
+from dataclasses import replace
 from itertools import count
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Type, Union
 
@@ -98,6 +100,7 @@ from ._const import (
     META,
 )
 from .loader import ModelLoader, _setup_rotation_online_had
+from .input_source import InputSpec, ModuleTreeEntry, parse_input_flag
 from .writer import ModelWriter
 
 
@@ -469,11 +472,19 @@ class BaseQModel(nn.Module):
         Parse a module specification into module name and flags.
         Example: "gate:moe:!" -> ("gate", ["moe", "!"])
         """
+        name, flags, _ = cls._parse_module_spec(module_spec)
+        return name, flags
+
+    @classmethod
+    def _parse_module_spec(cls, module_spec: str) -> tuple[str, List[str], Optional[InputSpec]]:
+        """Parse a module specification into its name, flags, and input source."""
+
         parts = module_spec.split(":") if isinstance(module_spec, str) else []
         aliases = cls._parse_module_aliases(module_spec) if isinstance(module_spec, str) else [module_spec]
         name = aliases[0] if aliases else module_spec
-        flags = [p for p in parts[1:] if p]
-        return name, flags
+        flags = [part for part in parts[1:] if part]
+        input_spec, flags = parse_input_flag(flags)
+        return name, flags, input_spec
 
     @classmethod
     def has_moe_flag(cls, module_spec: str) -> bool:
@@ -2896,7 +2907,12 @@ class BaseQModel(nn.Module):
     #     else:
     #         log.info(f"{self.__class__.__name__}: `MODEL switching to eval mode.")
     @classmethod
-    def _build_layer_modules_for_tree(cls, tree, include_capture_only: bool = False):
+    def _build_layer_modules_for_tree(
+        cls,
+        tree,
+        include_capture_only: bool = False,
+        entries_out: Optional[Dict[str, ModuleTreeEntry]] = None,
+    ):
         """
         tree format:
           [<model_name>, <submodule>, "#", { parent_module: ( "child[:!][:grp]", ... ), ... }]
@@ -2925,8 +2941,8 @@ class BaseQModel(nn.Module):
         alias_seq = count()
         group_seq = count()
 
-        def _parse_token(token: str) -> tuple[str, List[str]]:
-            return cls._parse_module_flags(token)
+        def _parse_token(token: str) -> tuple[str, List[str], Optional[InputSpec]]:
+            return cls._parse_module_spec(token)
 
         def _group_from_flags(flags: List[str]) -> int:
             for flag in flags:
@@ -2946,7 +2962,7 @@ class BaseQModel(nn.Module):
             """Process entries recursively to handle nested dict structures for MoE"""
             groups: defaultdict[int, List[tuple]] = defaultdict(list)
 
-            parent_name, parent_flags = _parse_token(parent_token)
+            parent_name, parent_flags, parent_input_spec = _parse_token(parent_token)
             parent_rel_group = _group_from_flags(parent_flags)
             parent_group = parent_group_offset + parent_rel_group
             parent_has_bang = "!" in parent_flags
@@ -2959,11 +2975,42 @@ class BaseQModel(nn.Module):
             def _make_entry(full_path: str, has_bang: bool, capture_only: bool, *, alias_base: int, alias_rel: int, alias_scope: str | None) -> tuple:
                 return (full_path, has_bang, capture_only, alias_scope, (alias_base, alias_rel))
 
+            def _record_tree_entry(
+                full_path: str,
+                scope: str,
+                subset_id: int,
+                input_spec: Optional[InputSpec],
+                has_bang: bool,
+                capture_only: bool,
+            ) -> None:
+                if entries_out is None or (capture_only and not include_capture_only):
+                    return
+                entries_out.setdefault(
+                    full_path,
+                    ModuleTreeEntry(
+                        full_path=full_path,
+                        scope=scope,
+                        subset_id=subset_id,
+                        input_spec=input_spec,
+                        not_quantized=has_bang,
+                        capture_only=capture_only,
+                    ),
+                )
+
             child_group_offset = parent_group_offset
             add_parent = parent_has_bang or (parent_capture_only and include_capture_only)
             if add_parent:
                 alias_base = parent_rel_group if parent_has_numeric else parent_group
                 parent_entry_scope = f"{parent_alias_scope}.__parent__" if parent_alias_scope is not None else None
+                parent_scope = parent_name.rsplit(".", 1)[0] if "." in parent_name else ""
+                _record_tree_entry(
+                    parent_name,
+                    parent_scope,
+                    parent_rel_group,
+                    parent_input_spec,
+                    parent_has_bang,
+                    parent_capture_only,
+                )
                 groups[parent_group].append(
                     _make_entry(
                         parent_name,
@@ -2979,7 +3026,7 @@ class BaseQModel(nn.Module):
             # Handle tuple/list of strings (traditional format)
             if isinstance(entries, (tuple, list)):
                 for ent in entries:
-                    child_name, child_flags = _parse_token(ent)
+                    child_name, child_flags, child_input_spec = _parse_token(ent)
 
                     has_bang = "!" in child_flags
                     capture_only = "?" in child_flags
@@ -2997,6 +3044,14 @@ class BaseQModel(nn.Module):
 
                     if capture_only and not include_capture_only:
                         continue
+                    _record_tree_entry(
+                        full_path,
+                        parent_name,
+                        child_rel_group,
+                        child_input_spec,
+                        has_bang,
+                        capture_only,
+                    )
                     alias_scope = scope if parent_has_numeric else parent_name
                     alias_base = parent_rel_group if parent_has_numeric else grp
                     alias_rel = child_rel_group if parent_has_numeric else 0
@@ -3017,7 +3072,7 @@ class BaseQModel(nn.Module):
                 for sub_parent, sub_entries in entries.items():
                     if isinstance(sub_entries, (tuple, list)):
                         for ent in sub_entries:
-                            _, ent_flags = _parse_token(ent)
+                            _, ent_flags, _ = _parse_token(ent)
                             max_current_group = max(max_current_group, _group_from_flags(ent_flags))
 
                 # Process nested entries with appropriate group offset
@@ -3043,6 +3098,15 @@ class BaseQModel(nn.Module):
                             # For ("#",) or "#" format, use the template_parent directly with default group 0
                             alias_scope = scope if parent_has_numeric else template_parent
                             alias_base = parent_rel_group if parent_has_numeric else expert_offset
+                            template_scope = template_parent.rsplit(".", 1)[0] if "." in template_parent else ""
+                            _record_tree_entry(
+                                template_parent,
+                                template_scope,
+                                0,
+                                None,
+                                False,
+                                False,
+                            )
                             groups[expert_offset].append(
                                 _make_entry(
                                     template_parent,
@@ -3133,6 +3197,59 @@ class BaseQModel(nn.Module):
                 seen.add(key)
                 blocks.append(block)
         return blocks
+
+    @classmethod
+    def build_module_tree_entries(
+        cls,
+        tree=None,
+        include_capture_only: bool = True,
+    ) -> Dict[str, ModuleTreeEntry]:
+        """Build first-seen metadata for every module-tree path."""
+
+        entries: Dict[str, ModuleTreeEntry] = {}
+        for tree_variant in cls._iter_module_tree_variants(tree):
+            cls._build_layer_modules_for_tree(
+                tree_variant,
+                include_capture_only=include_capture_only,
+                entries_out=entries,
+            )
+        return entries
+
+    @classmethod
+    def resolve_module_tree_entry(cls, module_name: str) -> Optional[ModuleTreeEntry]:
+        """Resolve exact or expert-template module-tree metadata."""
+
+        cache = cls.__dict__.get("_module_tree_entries_cache")
+        if cache is None:
+            cache = {}
+            setattr(cls, "_module_tree_entries_cache", cache)
+        entries = cache.get(cls)
+        if entries is None:
+            entries = cls.build_module_tree_entries(cls.module_tree)
+            cache[cls] = entries
+
+        name = module_name
+        if name.endswith(CAPTURE_ONLY_FLAG):
+            name = name[:-len(CAPTURE_ONLY_FLAG)]
+        entry = entries.get(name)
+        if entry is not None:
+            return entry
+
+        for template, template_entry in entries.items():
+            if EXPERT_INDEX_PLACEHOLDER not in template:
+                continue
+            pieces = template.split(EXPERT_INDEX_PLACEHOLDER)
+            pattern = "^" + "(\\d+)".join(re.escape(piece) for piece in pieces) + "$"
+            match = re.match(pattern, name)
+            if match is None:
+                continue
+            concrete_index = match.group(1)
+            return replace(
+                template_entry,
+                full_path=template_entry.full_path.replace(EXPERT_INDEX_PLACEHOLDER, concrete_index),
+                scope=template_entry.scope.replace(EXPERT_INDEX_PLACEHOLDER, concrete_index),
+            )
+        return None
 
     @classmethod
     def get_modules_with_direct_meta_tensors(cls, model: nn.Module):

--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -183,6 +183,8 @@ modeling_utils.check_support_param_buffer_assignment = check_support_param_buffe
 
 log = setup_logger()
 
+_MODULE_TREE_ENTRIES_CACHE: Dict[type, Dict[str, ModuleTreeEntry]] = {}
+
 class BaseQModel(nn.Module):
     # name of lm_head
     lm_head: str = "lm_head"
@@ -3219,14 +3221,10 @@ class BaseQModel(nn.Module):
     def resolve_module_tree_entry(cls, module_name: str) -> Optional[ModuleTreeEntry]:
         """Resolve exact or expert-template module-tree metadata."""
 
-        cache = cls.__dict__.get("_module_tree_entries_cache")
-        if cache is None:
-            cache = {}
-            setattr(cls, "_module_tree_entries_cache", cache)
-        entries = cache.get(cls)
+        entries = _MODULE_TREE_ENTRIES_CACHE.get(cls)
         if entries is None:
             entries = cls.build_module_tree_entries(cls.module_tree)
-            cache[cls] = entries
+            _MODULE_TREE_ENTRIES_CACHE[cls] = entries
 
         name = module_name
         if name.endswith(CAPTURE_ONLY_FLAG):

--- a/gptqmodel/models/definitions/axk2.py
+++ b/gptqmodel/models/definitions/axk2.py
@@ -43,8 +43,9 @@ class AXK2QModel(BaseQModel):
             "self_attn": (
                 "q_a_proj:0:q",
                 "kv_a_proj_with_mqa:0:k:v",
-                "q_gate_proj:1:q",
-                "kv_b_proj:1:k:v",
+                # The fused Q/gate projection consumes the compressed Q latent pair.
+                "q_gate_proj:1:q:input",
+                "kv_b_proj:1:k:v:input",
                 "o_proj:2",
             ),
             "post_attention_layernorm": ("post_attention_layernorm:!",),

--- a/gptqmodel/models/definitions/deepseek_v2.py
+++ b/gptqmodel/models/definitions/deepseek_v2.py
@@ -31,7 +31,15 @@ class DeepSeekV2QModel(BaseQModel):
         "#",
         {
             "input_layernorm": ("input_layernorm:!",),
-            "self_attn": ("q_a_proj:0", "q_b_proj:0", "q_proj:0", "kv_a_proj_with_mqa:0", "kv_b_proj:0", "o_proj:1"),
+            # The staged Q and KV expansion projections consume normalized latent inputs, not hidden_states.
+            "self_attn": (
+                "q_a_proj:0",
+                "q_b_proj:0:input",
+                "q_proj:0",
+                "kv_a_proj_with_mqa:0",
+                "kv_b_proj:0:input",
+                "o_proj:1",
+            ),
             "post_attention_layernorm": ("post_attention_layernorm:!",),
             "mlp:moe": {
                 "": ("gate_proj:0", "up_proj:0", "down_proj:1"),

--- a/gptqmodel/models/definitions/deepseek_v3.py
+++ b/gptqmodel/models/definitions/deepseek_v3.py
@@ -39,7 +39,15 @@ class DeepSeekV3QModel(BaseQModel):
             # Moonlight:
             #   self_attn uses a single Q projection:
             #     - q_proj
-            "self_attn": ("q_proj:0", "q_a_proj:0", "kv_a_proj_with_mqa:0", "q_b_proj:1", "kv_b_proj:1", "o_proj:2"),
+            # The post-LoRA Q and KV projections consume normalized latent inputs, not hidden_states.
+            "self_attn": (
+                "q_proj:0",
+                "q_a_proj:0",
+                "kv_a_proj_with_mqa:0",
+                "q_b_proj:1:input",
+                "kv_b_proj:1:input",
+                "o_proj:2",
+            ),
             "post_attention_layernorm": ("post_attention_layernorm:!",),
             "mlp:moe": {
                 "": ("gate_proj:0", "up_proj:0", "down_proj:1"),

--- a/gptqmodel/models/definitions/deepseek_v32.py
+++ b/gptqmodel/models/definitions/deepseek_v32.py
@@ -38,9 +38,10 @@ class DeepSeekV32QModel(BaseQModel):
                 "indexer.wk:0",
                 # DSA accumulates this projection's scores in float32; leave its weights unquantized.
                 "indexer.weights_proj:0:!",
-                "q_b_proj:1:q",
-                "kv_b_proj:1:k:v",
-                "indexer.wq_b:1",
+                # Q and the DSA query indexer consume the normalized Q latent; KV consumes its own latent.
+                "q_b_proj:1:q:input=q_latent",
+                "kv_b_proj:1:k:v:input",
+                "indexer.wq_b:1:input=q_latent",
                 "o_proj:2",
             ),
             "post_attention_layernorm": ("post_attention_layernorm:!",),

--- a/gptqmodel/models/definitions/deepseek_v4.py
+++ b/gptqmodel/models/definitions/deepseek_v4.py
@@ -19,7 +19,8 @@ class DeepSeekV4QModel(DeepSeekV3QModel):
                 "q_a_norm:!",
                 "q_a_proj:0",
                 "q_b_norm:!",
-                "q_b_proj:0",
+                # The staged Q projection consumes the normalized Q latent from q_a_proj.
+                "q_b_proj:0:input",
                 "o_a_proj:!",
                 "o_b_proj:1",
                 "kv_norm:!",

--- a/gptqmodel/models/definitions/deepseek_vl_v2.py
+++ b/gptqmodel/models/definitions/deepseek_vl_v2.py
@@ -41,7 +41,15 @@ class DeepSeekVLV2QModel(BaseQModel):
         "#",
         {
             "input_layernorm": ("input_layernorm:!",),
-            "self_attn": ("q_a_proj:0", "q_b_proj:0", "q_proj:0", "kv_a_proj_with_mqa:0", "kv_b_proj:0", "o_proj:1"),
+            # The staged Q and KV expansion projections consume normalized latent inputs, not hidden_states.
+            "self_attn": (
+                "q_a_proj:0",
+                "q_b_proj:0:input",
+                "q_proj:0",
+                "kv_a_proj_with_mqa:0",
+                "kv_b_proj:0:input",
+                "o_proj:1",
+            ),
             "post_attention_layernorm": ("post_attention_layernorm:!",),
             "mlp:moe": {
                 "": ("gate_proj:0", "up_proj:0", "down_proj:1"),

--- a/gptqmodel/models/definitions/glm4_moe_lite.py
+++ b/gptqmodel/models/definitions/glm4_moe_lite.py
@@ -22,7 +22,15 @@ class Glm4MoeLiteQModel(BaseQModel):
         "#",
         {
             "input_layernorm": ("input_layernorm:!",),
-            "self_attn": ("q_proj:0", "q_a_proj:0", "kv_a_proj_with_mqa:0", "q_b_proj:1", "kv_b_proj:1", "o_proj:2"),
+            # The post-LoRA Q and KV projections consume normalized latent inputs, not hidden_states.
+            "self_attn": (
+                "q_proj:0",
+                "q_a_proj:0",
+                "kv_a_proj_with_mqa:0",
+                "q_b_proj:1:input",
+                "kv_b_proj:1:input",
+                "o_proj:2",
+            ),
             "post_attention_layernorm": ("post_attention_layernorm:!",),
             "mlp:moe:?": {
                 "gate": ("gate:!",),

--- a/gptqmodel/models/definitions/glm5_next.py
+++ b/gptqmodel/models/definitions/glm5_next.py
@@ -50,8 +50,9 @@ class Glm5NextQModel(BaseQModel):
                 "indexer.wq_b:!",
                 "indexer.wk:!",
                 "indexer.weights_proj:!",
-                "q_b_proj:0:q",
-                "kv_b_proj:0:k:v",
+                # Post-LoRA Q and KV projections consume normalized latent inputs, not hidden_states.
+                "q_b_proj:0:q:input",
+                "kv_b_proj:0:k:v:input",
                 "o_proj:1",
             ),
             "post_attention_layernorm": ("post_attention_layernorm:!",),

--- a/gptqmodel/models/definitions/glm_moe_dsa.py
+++ b/gptqmodel/models/definitions/glm_moe_dsa.py
@@ -35,9 +35,10 @@ class GlmMoeDsaQModel(BaseQModel):
                 "q_a_proj:0",
                 "kv_a_proj_with_mqa:0",
                 "indexer.wk:0",
-                "q_b_proj:1",
-                "kv_b_proj:1",
-                "indexer.wq_b:1",
+                # Q and the DSA query indexer consume the normalized Q latent; KV consumes its own latent.
+                "q_b_proj:1:input=q_latent",
+                "kv_b_proj:1:input",
+                "indexer.wq_b:1:input=q_latent",
                 "o_proj:2",
             ),
             "post_attention_layernorm": ("post_attention_layernorm:!",),

--- a/gptqmodel/models/definitions/kimi_k25.py
+++ b/gptqmodel/models/definitions/kimi_k25.py
@@ -30,7 +30,15 @@ class KimiK25QModel(BaseQModel):
         "#",
         {
             "input_layernorm": ("input_layernorm:!",),
-            "self_attn": ("q_proj:0", "q_a_proj:0", "kv_a_proj_with_mqa:0", "q_b_proj:1", "kv_b_proj:1", "o_proj:2"),
+            # The post-LoRA Q and KV projections consume normalized latent inputs, not hidden_states.
+            "self_attn": (
+                "q_proj:0",
+                "q_a_proj:0",
+                "kv_a_proj_with_mqa:0",
+                "q_b_proj:1:input",
+                "kv_b_proj:1:input",
+                "o_proj:2",
+            ),
             "post_attention_layernorm": ("post_attention_layernorm:!",),
             "mlp:moe": {
                 "": ("gate_proj:0", "up_proj:0", "down_proj:1"),

--- a/gptqmodel/models/definitions/longcat_flash.py
+++ b/gptqmodel/models/definitions/longcat_flash.py
@@ -22,8 +22,21 @@ class LongCatFlashQModel(BaseQModel):
         {
             "input_layernorm": ("input_layernorm:!",),
             "self_attn": {
-                "0": ("q_a_proj:0", "q_b_proj:0", "kv_a_proj_with_mqa:0", "kv_b_proj:0", "o_proj:1"),
-                "1": ("q_a_proj:0", "q_b_proj:0", "kv_a_proj_with_mqa:0", "kv_b_proj:0", "o_proj:1")
+                # Each staged Q and KV expansion projection consumes a normalized latent input.
+                "0": (
+                    "q_a_proj:0",
+                    "q_b_proj:0:input",
+                    "kv_a_proj_with_mqa:0",
+                    "kv_b_proj:0:input",
+                    "o_proj:1",
+                ),
+                "1": (
+                    "q_a_proj:0",
+                    "q_b_proj:0:input",
+                    "kv_a_proj_with_mqa:0",
+                    "kv_b_proj:0:input",
+                    "o_proj:1",
+                ),
             },
             "post_attention_layernorm": ("post_attention_layernorm:!",),
             "mlps": {

--- a/gptqmodel/models/definitions/minicpm3.py
+++ b/gptqmodel/models/definitions/minicpm3.py
@@ -15,7 +15,14 @@ class MiniCpm3QModel(BaseQModel):
         "#",
         {
             "input_layernorm": ("input_layernorm:!",),
-            "self_attn": ("q_a_proj:0", "kv_a_proj_with_mqa:0", "q_b_proj:1", "kv_b_proj:1", "o_proj:2"),
+            # The post-LoRA Q and KV projections consume normalized latent inputs, not hidden_states.
+            "self_attn": (
+                "q_a_proj:0",
+                "kv_a_proj_with_mqa:0",
+                "q_b_proj:1:input",
+                "kv_b_proj:1:input",
+                "o_proj:2",
+            ),
             "post_attention_layernorm": ("post_attention_layernorm:!",),
             "mlp": ("gate_proj:0", "up_proj:0", "down_proj:1"),
         }

--- a/gptqmodel/models/input_source.py
+++ b/gptqmodel/models/input_source.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic metadata for grouping modules that consume the same input."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ..looper.named_module import NamedModule
+
+
+@dataclass(frozen=True)
+class UniqueInput:
+    """Identify an input source that belongs only to one module."""
+
+
+@dataclass(frozen=True)
+class NamedInput:
+    """Identify an explicitly named input source within a structural scope."""
+
+    name: str
+
+
+InputSpec = UniqueInput | NamedInput
+INPUT_FLAG = "input"
+
+
+def parse_input_flag(flags: Sequence[str]) -> tuple[InputSpec | None, list[str]]:
+    """Extract one input-source flag from a raw module flag sequence."""
+
+    input_flags = [
+        flag
+        for flag in flags
+        if flag == INPUT_FLAG or flag.startswith(f"{INPUT_FLAG}=")
+    ]
+    if len(input_flags) > 1:
+        raise ValueError("duplicate input flags")
+
+    remaining = [flag for flag in flags if flag not in input_flags]
+    if not input_flags:
+        return None, remaining
+
+    flag = input_flags[0]
+    if flag == INPUT_FLAG:
+        return UniqueInput(), remaining
+
+    name = flag[len(INPUT_FLAG) + 1:]
+    if not name:
+        raise ValueError("input name cannot be empty")
+    if ":" in name or any(character.isspace() for character in name):
+        raise ValueError("input name cannot contain ':' or whitespace")
+    return NamedInput(name), remaining
+
+
+@dataclass(frozen=True)
+class ModuleTreeEntry:
+    """Metadata describing one module-tree path."""
+
+    full_path: str
+    scope: str
+    subset_id: int
+    input_spec: InputSpec | None
+    not_quantized: bool
+    capture_only: bool
+
+
+@dataclass(frozen=True)
+class InputSourceId:
+    """Hashable identity for a module input source."""
+
+    scope: str
+    subset_id: int | None = None
+    name: str | None = None
+    module: str | None = None
+
+    def __post_init__(self) -> None:
+        values = (self.subset_id, self.name, self.module)
+        if sum(value is not None for value in values) != 1:
+            raise ValueError("exactly one of subset_id, name, or module must be set")
+
+    @property
+    def kind(self) -> str:
+        """Return the input-source identity kind."""
+
+        if self.subset_id is not None:
+            return "subset"
+        if self.name is not None:
+            return "named"
+        return "unique"
+
+
+def resolve_input_source(module: NamedModule) -> InputSourceId:
+    """Resolve the logical input source for one named module."""
+
+    scope = module.tree_scope_id
+    if scope is None or module.subset_id is None:
+        parent = module.full_name.rsplit(".", 1)[0] if "." in module.full_name else ""
+        return InputSourceId(scope=parent, module=module.full_name)
+
+    spec = module.input_spec
+    if isinstance(spec, UniqueInput):
+        return InputSourceId(scope=scope, module=module.full_name)
+    if isinstance(spec, NamedInput):
+        return InputSourceId(scope=scope, name=spec.name)
+    return InputSourceId(scope=scope, subset_id=module.subset_id)
+
+
+def group_input_sources(
+    modules: Iterable[NamedModule],
+) -> dict[InputSourceId, list[NamedModule]]:
+    """Group modules by input-source identity while preserving iteration order."""
+
+    grouped: dict[InputSourceId, list[NamedModule]] = {}
+    for module in modules:
+        grouped.setdefault(resolve_input_source(module), []).append(module)
+    return grouped

--- a/gptqmodel/quantization/config.py
+++ b/gptqmodel/quantization/config.py
@@ -2519,6 +2519,10 @@ class BaseQuantizeConfig(metaclass=QuantizeConfigMeta):
         "to speed up quantization forwarding. This causes extra time spent (especially for MoE layers) and vram pressure, "
         "leading in some cases to slower forwarding or vram OOM"}
     )
+    validate_input_sources: bool = field(
+        default=False,
+        metadata={"help": "Validate that modules declared to share an input source receive identical activations"},
+    )
 
     # User-facing dense-pool strategy. The dense pool owns the serial path:
     # qkv, z, out_proj, norms, router, shared expert, and dense MLP modules.
@@ -2951,6 +2955,7 @@ class BaseQuantizeConfig(metaclass=QuantizeConfigMeta):
             "gc_mode": "gc_mode",
             "wait_for_submodule_finalizers": "wait_for_submodule_finalizers",
             "auto_forward_data_parallel": "auto_forward_data_parallel",
+            "validate_input_sources": "validate_input_sources",
             "dense_vram_strategy": "dense_vram_strategy",
             "dense_vram_strategy_devices": "dense_vram_strategy_devices",
             "moe_vram_strategy": "moe_vram_strategy",
@@ -3086,6 +3091,7 @@ class BaseQuantizeConfig(metaclass=QuantizeConfigMeta):
         meta_payload["gc_mode"] = self.gc_mode.value if isinstance(self.gc_mode, GcMode) else self.gc_mode
         meta_payload["wait_for_submodule_finalizers"] = self.wait_for_submodule_finalizers
         meta_payload["auto_forward_data_parallel"] = self.auto_forward_data_parallel
+        meta_payload["validate_input_sources"] = self.validate_input_sources
         meta_payload["dense_vram_strategy"] = (
             self.dense_vram_strategy.value
             if isinstance(self.dense_vram_strategy, VramStrategy)
@@ -4067,6 +4073,7 @@ class GGUFConfig(PreProcessorConfig):
                 "gc_mode",
                 "wait_for_submodule_finalizers",
                 "auto_forward_data_parallel",
+                "validate_input_sources",
                 "dense_vram_strategy",
                 "dense_vram_strategy_devices",
                 "moe_vram_strategy",

--- a/tests/module_tree/test_input_source.py
+++ b/tests/module_tree/test_input_source.py
@@ -1,0 +1,314 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from torch import nn
+
+from gptqmodel.looper.named_module import NamedModule
+from gptqmodel.looper.stage_subset import CalibrationCoveragePolicy, SubsetPlan
+from gptqmodel.models import MODEL_MAP, BaseQModel
+from gptqmodel.models.definitions.deepseek_v3 import DeepSeekV3QModel
+from gptqmodel.models.definitions.deepseek_v32 import DeepSeekV32QModel
+from gptqmodel.models.definitions.llama import LlamaQModel
+from gptqmodel.models.definitions.qwen2_moe import Qwen2MoeQModel
+from gptqmodel.models.definitions.qwen3_moe import Qwen3MoeQModel
+from gptqmodel.models.input_source import (
+    InputSourceId,
+    NamedInput,
+    UniqueInput,
+    group_input_sources,
+    parse_input_flag,
+    resolve_input_source,
+)
+
+
+def test_input_flag_parser_preserves_non_input_flags():
+    cases = [
+        ("q_proj:0", "q_proj", ["0"], None),
+        ("q_proj:0:input", "q_proj", ["0"], UniqueInput()),
+        ("q_proj:0:input=foo", "q_proj", ["0"], NamedInput("foo")),
+        ("q_proj:0:q", "q_proj", ["0", "q"], None),
+        ("q_proj:0:q:input", "q_proj", ["0", "q"], UniqueInput()),
+        ("q_proj:0:q:input=foo", "q_proj", ["0", "q"], NamedInput("foo")),
+        ("x:!:input", "x", ["!"], UniqueInput()),
+        ("x:?:1:input=a", "x", ["?", "1"], NamedInput("a")),
+    ]
+
+    for spec, expected_name, expected_flags, expected_input in cases:
+        assert BaseQModel._parse_module_spec(spec) == (
+            expected_name,
+            expected_flags,
+            expected_input,
+        )
+        assert BaseQModel._parse_module_flags(spec) == (expected_name, expected_flags)
+
+    assert BaseQModel.has_moe_flag("mlp:moe:input")
+    assert BaseQModel._parse_module_flags("mlp:moe:input") == ("mlp", ["moe"])
+    assert BaseQModel._parse_module_spec("x:input=a:b") == ("x", ["b"], NamedInput("a"))
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        ["input="],
+        ["input=a", "input=b"],
+        ["input=a:b"],
+        ["input=a b"],
+    ],
+)
+def test_input_flag_parser_rejects_invalid_names(flags):
+    with pytest.raises(ValueError):
+        parse_input_flag(flags)
+
+
+def test_build_layer_modules_strips_input_tokens_without_changing_blocks():
+    expected_deepseek_v3 = [
+        ["input_layernorm:!"],
+        ["self_attn.q_proj", "self_attn.q_a_proj", "self_attn.kv_a_proj_with_mqa"],
+        ["self_attn.q_b_proj", "self_attn.kv_b_proj"],
+        ["self_attn.o_proj"],
+        ["post_attention_layernorm:!"],
+        ["mlp.gate_proj", "mlp.up_proj"],
+        ["mlp.down_proj"],
+        ["mlp.experts.{expert_index}.gate_proj", "mlp.experts.{expert_index}.up_proj"],
+        ["mlp.experts.{expert_index}.down_proj"],
+        ["mlp.shared_experts.gate_proj", "mlp.shared_experts.up_proj"],
+        ["mlp.shared_experts.down_proj"],
+    ]
+    expected_deepseek_v32_attention = [
+        "self_attn.q_a_proj",
+        "self_attn.kv_a_proj_with_mqa",
+        "self_attn.indexer.wk",
+        "self_attn.indexer.weights_proj:!",
+    ]
+
+    assert (
+        DeepSeekV3QModel.build_layer_modules(DeepSeekV3QModel.module_tree)
+        == expected_deepseek_v3
+    )
+    deepseek_v32_blocks = DeepSeekV32QModel.build_layer_modules(
+        DeepSeekV32QModel.module_tree
+    )
+    assert expected_deepseek_v32_attention in deepseek_v32_blocks
+    assert [
+        "self_attn.q_b_proj",
+        "self_attn.kv_b_proj",
+        "self_attn.indexer.wq_b",
+    ] in deepseek_v32_blocks
+
+    classes = {
+        model_cls
+        for model_cls in MODEL_MAP.values()
+        if isinstance(model_cls, type)
+        and issubclass(model_cls, BaseQModel)
+        and model_cls.module_tree is not None
+    }
+    for model_cls in classes:
+        blocks = model_cls.build_layer_modules(model_cls.module_tree)
+        assert all(
+            "input" not in flag
+            for block in blocks
+            for token in block
+            for flag in token.split(":")[1:]
+        )
+
+
+def test_module_tree_entries_resolve_scopes_and_expert_templates():
+    llama_entries = LlamaQModel.build_module_tree_entries()
+    assert llama_entries["self_attn.q_proj"].scope == "self_attn"
+    assert llama_entries["self_attn.q_proj"].subset_id == 0
+    assert llama_entries["self_attn.q_proj"].input_spec is None
+    assert llama_entries["mlp.down_proj"].subset_id == 1
+
+    deepseek_entries = DeepSeekV3QModel.build_module_tree_entries()
+    assert isinstance(deepseek_entries["self_attn.q_b_proj"].input_spec, UniqueInput)
+    assert (
+        deepseek_entries["mlp.experts.{expert_index}.gate_proj"].scope
+        == "mlp.experts.{expert_index}"
+    )
+    assert deepseek_entries["mlp.shared_experts.up_proj"].scope == "mlp.shared_experts"
+
+    assert (
+        DeepSeekV32QModel.build_module_tree_entries()["self_attn.indexer.wq_b"].input_spec
+        == NamedInput("q_latent")
+    )
+    expert_entry = DeepSeekV3QModel.resolve_module_tree_entry("mlp.experts.7.up_proj")
+    assert expert_entry is not None
+    assert expert_entry.scope == "mlp.experts.7"
+    assert expert_entry.full_path == "mlp.experts.7.up_proj"
+    assert DeepSeekV3QModel.resolve_module_tree_entry("self_attn.q_proj:?") is not None
+    assert DeepSeekV3QModel.resolve_module_tree_entry("not_a_module") is None
+
+
+def _named(name, full_name, scope=None, subset_id=None, input_spec=None):
+    return NamedModule(
+        nn.Linear(4, 4, bias=False),
+        name=name,
+        full_name=full_name,
+        layer_index=0,
+        tree_scope_id=scope,
+        subset_id=subset_id,
+        input_spec=input_spec,
+    )
+
+
+def test_input_source_grouping_defaults_to_scope_and_subset():
+    modules = [
+        _named(
+            "q_proj", "model.layers.0.self_attn.q_proj", "model.layers.0.self_attn", 0
+        ),
+        _named(
+            "k_proj", "model.layers.0.self_attn.k_proj", "model.layers.0.self_attn", 0
+        ),
+        _named(
+            "v_proj", "model.layers.0.self_attn.v_proj", "model.layers.0.self_attn", 0
+        ),
+        _named(
+            "o_proj", "model.layers.0.self_attn.o_proj", "model.layers.0.self_attn", 1
+        ),
+        _named(
+            "gate_proj", "model.layers.0.mlp.gate_proj", "model.layers.0.mlp", 0
+        ),
+        _named("up_proj", "model.layers.0.mlp.up_proj", "model.layers.0.mlp", 0),
+    ]
+    grouped = group_input_sources(modules)
+    subset_zero = next(
+        group for key, group in grouped.items() if key.subset_id == 0
+    )
+    assert [module.name for module in subset_zero] == ["q_proj", "k_proj", "v_proj"]
+    assert len(grouped) == 3
+    assert all(key.kind == "subset" for key in grouped)
+
+
+def test_input_source_grouping_handles_unique_named_and_unknown_modules():
+    unique = _named(
+        "q_b_proj",
+        "model.layers.0.self_attn.q_b_proj",
+        "scope",
+        1,
+        UniqueInput(),
+    )
+    named = _named(
+        "wq_b",
+        "model.layers.0.self_attn.indexer.wq_b",
+        "scope",
+        1,
+        NamedInput("q_latent"),
+    )
+    named_again = _named(
+        "other",
+        "model.layers.0.self_attn.other",
+        "scope",
+        1,
+        NamedInput("q_latent"),
+    )
+    unknown = _named("lm_head", "lm_head")
+    grouped = group_input_sources([unique, named, named_again, unknown])
+
+    assert resolve_input_source(unique).kind == "unique"
+    assert resolve_input_source(named).kind == "named"
+    assert grouped[resolve_input_source(named)] == [named, named_again]
+    assert resolve_input_source(unknown).module == "lm_head"
+    assert len(
+        {
+            InputSourceId(scope="scope", subset_id=0),
+            InputSourceId(scope="scope", name="x"),
+        }
+    ) == 2
+
+
+def test_deepseek_v3_input_source_grouping_separates_latents_and_experts():
+    def module_for(path):
+        entry = DeepSeekV3QModel.resolve_module_tree_entry(path)
+        assert entry is not None
+        return _named(
+            path.rsplit(".", 1)[-1],
+            f"model.layers.0.{path}",
+            f"model.layers.0.{entry.scope}" if entry.scope else "model.layers.0",
+            entry.subset_id,
+            entry.input_spec,
+        )
+
+    modules = [
+        module_for("self_attn.q_a_proj"),
+        module_for("self_attn.kv_a_proj_with_mqa"),
+        module_for("self_attn.q_b_proj"),
+        module_for("self_attn.kv_b_proj"),
+        module_for("mlp.experts.0.gate_proj"),
+        module_for("mlp.experts.0.up_proj"),
+        module_for("mlp.experts.1.gate_proj"),
+        module_for("mlp.experts.1.up_proj"),
+        module_for("mlp.shared_experts.gate_proj"),
+        module_for("mlp.shared_experts.up_proj"),
+    ]
+    grouped = group_input_sources(modules)
+    source_by_path = {
+        module.full_name.rsplit("model.layers.0.", 1)[-1]: resolve_input_source(module)
+        for module in modules
+    }
+
+    assert source_by_path["self_attn.q_a_proj"] == source_by_path[
+        "self_attn.kv_a_proj_with_mqa"
+    ]
+    assert source_by_path["self_attn.q_b_proj"] != source_by_path["self_attn.kv_b_proj"]
+    assert source_by_path["mlp.experts.0.gate_proj"] == source_by_path[
+        "mlp.experts.0.up_proj"
+    ]
+    assert source_by_path["mlp.experts.1.gate_proj"] == source_by_path[
+        "mlp.experts.1.up_proj"
+    ]
+    assert source_by_path["mlp.experts.0.gate_proj"] != source_by_path[
+        "mlp.experts.1.gate_proj"
+    ]
+    assert source_by_path["mlp.shared_experts.gate_proj"] != source_by_path[
+        "mlp.experts.0.gate_proj"
+    ]
+    assert len(grouped) == 6
+
+
+def test_moe_expert_scopes_are_distinct_for_qwen_definitions():
+    for model_cls in (Qwen2MoeQModel, Qwen3MoeQModel):
+        first = model_cls.resolve_module_tree_entry("mlp.experts.0.gate_proj")
+        second = model_cls.resolve_module_tree_entry("mlp.experts.1.gate_proj")
+        assert first is not None and second is not None
+        assert first.scope == "mlp.experts.0"
+        assert second.scope == "mlp.experts.1"
+        assert first.scope != second.scope
+
+
+def test_subset_plan_groups_modules_and_recomputes_for_chunks():
+    modules = {
+        "q_proj": _named("q_proj", "model.layers.0.self_attn.q_proj", "self_attn", 0),
+        "k_proj": _named("k_proj", "model.layers.0.self_attn.k_proj", "self_attn", 0),
+        "o_proj": _named("o_proj", "model.layers.0.self_attn.o_proj", "self_attn", 1),
+    }
+    plan = SubsetPlan(
+        modules=modules,
+        subset_index=0,
+        subset_total=1,
+        execute_forward=True,
+        replay_after_process=False,
+        forward_mode="serial",
+        batch_count=1,
+        forward_row_counts=[1],
+        forward_total_rows=1,
+        moe_groups={},
+        forward_device_map={},
+        calibration_coverage_policy=CalibrationCoveragePolicy(
+            validate_input_coverage=False,
+            fallback_enabled=False,
+            prune_uncovered_modules=False,
+            record_dynamic_exclusions=False,
+        ),
+        module_chunks=[modules],
+    )
+    subset_zero = next(
+        key for key in plan.input_sources if key.subset_id == 0
+    )
+    assert [module.name for module in plan.input_sources[subset_zero]] == [
+        "q_proj",
+        "k_proj",
+    ]
+    chunk = plan.for_modules({"o_proj": modules["o_proj"]})
+    assert len(chunk.input_sources) == 1
+    assert list(next(iter(chunk.input_sources.values()))) == [modules["o_proj"]]

--- a/tests/module_tree/test_input_source_forward.py
+++ b/tests/module_tree/test_input_source_forward.py
@@ -1,0 +1,564 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+
+import pytest
+import torch
+from torch import nn
+from transformers import (
+    DeepseekV3Config,
+    DeepseekV3ForCausalLM,
+    LlamaConfig,
+    LlamaForCausalLM,
+    MixtralConfig,
+    MixtralForCausalLM,
+    MiniCPM3Config,
+    MiniCPM3ForCausalLM,
+    Qwen2MoeConfig,
+    Qwen2MoeForCausalLM,
+    Qwen3MoeConfig,
+    Qwen3MoeForCausalLM,
+)
+
+from gptqmodel.looper.input_source_validator import (
+    InputSourceCapture,
+    validate_input_sources,
+)
+from gptqmodel.looper.named_module import NamedModule
+from gptqmodel.models.input_source import InputSourceId, group_input_sources
+from gptqmodel.models.definitions.deepseek_v3 import DeepSeekV3QModel
+from gptqmodel.models.definitions.llama import LlamaQModel
+from gptqmodel.models.definitions.mixtral import MixtralQModel
+from gptqmodel.models.definitions.minicpm3 import MiniCpm3QModel
+from gptqmodel.models.definitions.qwen2_moe import Qwen2MoeQModel
+from gptqmodel.models.definitions.qwen3_moe import Qwen3MoeQModel
+from gptqmodel.quantization.config import QuantizeConfig
+from gptqmodel.utils.model import get_module
+
+
+def _layer_prefix(qmodel_cls, layer_index):
+    prefix = []
+    for part in qmodel_cls.module_tree:
+        if part == "#":
+            break
+        prefix.append(part)
+    return ".".join(prefix + [str(layer_index)])
+
+
+def simulate(qmodel_cls, model, layer_index=0, seq=6, batch=2):
+    """Run one tiny model forward while capturing module-tree inputs."""
+
+    torch.manual_seed(0)
+    quantize_config = QuantizeConfig(bits=4, group_size=16)
+    layer_modules = qmodel_cls.simple_layer_modules(model.config, quantize_config)
+    prefix = _layer_prefix(qmodel_cls, layer_index)
+    layer = get_module(model, prefix)
+    assert layer is not None
+
+    named_modules = []
+    seen = set()
+    for block in layer_modules:
+        for token in block:
+            name = token.split(":", 1)[0]
+            name = name.split("|", 1)[0]
+            submodule = get_module(layer, name)
+            if not isinstance(submodule, nn.Linear):
+                continue
+            if name in seen:
+                continue
+            seen.add(name)
+            entry = qmodel_cls.resolve_module_tree_entry(name)
+            assert entry is not None, name
+            scope = f"{prefix}.{entry.scope}" if entry.scope else prefix
+            named_modules.append(
+                NamedModule(
+                    submodule,
+                    name=name,
+                    full_name=f"{prefix}.{name}",
+                    layer_index=layer_index,
+                    tree_scope_id=scope,
+                    subset_id=entry.subset_id,
+                    input_spec=entry.input_spec,
+                )
+            )
+
+    groups = group_input_sources(named_modules)
+    input_ids = torch.randint(
+        0,
+        model.config.vocab_size,
+        (batch, seq),
+    )
+    with InputSourceCapture(named_modules) as capture:
+        model(input_ids=input_ids)
+    return validate_input_sources(groups, capture.captured), groups, capture.captured
+
+
+def _tiny_llama():
+    config = LlamaConfig(
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        use_cache=False,
+        attn_implementation="eager",
+    )
+    return LlamaForCausalLM(config)
+
+
+def _tiny_qwen2_moe():
+    config = Qwen2MoeConfig(
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        moe_intermediate_size=16,
+        shared_expert_intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        num_experts=4,
+        num_experts_per_tok=2,
+        use_cache=False,
+        attn_implementation="eager",
+    )
+    return Qwen2MoeForCausalLM(config)
+
+
+def _tiny_qwen3_moe():
+    config = Qwen3MoeConfig(
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        moe_intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        num_experts=4,
+        num_experts_per_tok=2,
+        use_cache=False,
+        attn_implementation="eager",
+    )
+    return Qwen3MoeForCausalLM(config)
+
+
+def _tiny_mixtral():
+    config = MixtralConfig(
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        use_cache=False,
+        attn_implementation="eager",
+    )
+    return MixtralForCausalLM(config)
+
+
+def _tiny_deepseek_v3():
+    config = DeepseekV3Config(
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        moe_intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        first_k_dense_replace=0,
+        n_group=1,
+        topk_group=1,
+        q_lora_rank=16,
+        kv_lora_rank=16,
+        qk_rope_head_dim=8,
+        qk_nope_head_dim=8,
+        v_head_dim=8,
+        use_cache=False,
+        attn_implementation="eager",
+    )
+    return DeepseekV3ForCausalLM(config)
+
+
+def _tiny_minicpm3():
+    config = MiniCPM3Config(
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        q_lora_rank=16,
+        kv_lora_rank=16,
+        qk_nope_head_dim=8,
+        qk_rope_head_dim=8,
+        v_head_dim=8,
+        use_cache=False,
+        attn_implementation="eager",
+    )
+    return MiniCPM3ForCausalLM(config)
+
+
+def _assert_routed_expert_gate_up(groups, captured):
+    routed = []
+    for source, modules in groups.items():
+        names = {module.full_name.rsplit(".", 1)[-1] for module in modules}
+        if {"gate_proj", "up_proj"} <= names and all(captured[module.full_name] for module in modules):
+            routed.append(source)
+    assert routed
+
+
+def test_llama_cpu_forward_validates_qkv_and_gate_up_inputs():
+    report, groups, _ = simulate(LlamaQModel, _tiny_llama())
+    assert report.ok
+    assert report.checked_sources >= 2
+    qkv = next(
+        modules
+        for source, modules in groups.items()
+        if source.scope.endswith("self_attn") and source.subset_id == 0
+    )
+    assert {module.name.rsplit(".", 1)[-1] for module in qkv} == {
+        "q_proj",
+        "k_proj",
+        "v_proj",
+    }
+
+
+@pytest.mark.parametrize(
+    ("qmodel_cls", "model_factory"),
+    [
+        (Qwen2MoeQModel, _tiny_qwen2_moe),
+        (Qwen3MoeQModel, _tiny_qwen3_moe),
+        (MixtralQModel, _tiny_mixtral),
+    ],
+)
+def test_moe_cpu_forward_validates_routed_expert_inputs(qmodel_cls, model_factory):
+    report, groups, captured = simulate(qmodel_cls, model_factory())
+    assert report.ok
+    assert report.checked_sources >= 1
+    if any("experts." in module.full_name for modules in groups.values() for module in modules):
+        _assert_routed_expert_gate_up(groups, captured)
+
+
+def test_deepseek_v3_cpu_forward_validates_mla_inputs():
+    report, groups, captured = simulate(DeepSeekV3QModel, _tiny_deepseek_v3())
+    assert report.ok
+    assert report.checked_sources >= 2
+    q_a = next(
+        source for source, modules in groups.items()
+        if {module.name.rsplit(".", 1)[-1] for module in modules}
+        == {"q_a_proj", "kv_a_proj_with_mqa"}
+    )
+    assert q_a.kind == "subset"
+    assert captured["model.layers.0.self_attn.q_a_proj"]
+    assert captured["model.layers.0.self_attn.kv_a_proj_with_mqa"]
+    for name in ("q_b_proj", "kv_b_proj"):
+        module = next(
+            module
+            for modules in groups.values()
+            for module in modules
+            if module.name.endswith(name)
+        )
+        assert len(
+            groups[next(source for source, modules in groups.items() if module in modules)]
+        ) == 1
+
+
+def test_minicpm3_cpu_forward_validates_mla_inputs():
+    report, groups, _ = simulate(MiniCpm3QModel, _tiny_minicpm3())
+    assert report.ok
+    assert report.checked_sources >= 2
+    assert any(
+        {module.name.rsplit(".", 1)[-1] for module in modules}
+        == {"q_a_proj", "kv_a_proj_with_mqa"}
+        for modules in groups.values()
+    )
+
+
+def test_negative_deepseek_v3_group_detects_distinct_latent_inputs():
+    _, groups, captured = simulate(DeepSeekV3QModel, _tiny_deepseek_v3())
+    q_b = next(
+        module
+        for modules in groups.values()
+        for module in modules
+        if module.name.endswith("q_b_proj")
+    )
+    kv_b = next(
+        module
+        for modules in groups.values()
+        for module in modules
+        if module.name.endswith("kv_b_proj")
+    )
+    source = InputSourceId(scope="model.layers.0.self_attn", subset_id=1)
+    report = validate_input_sources({source: [q_b, kv_b]}, captured)
+    assert not report.ok
+    assert report.mismatches[0].reason in {"shape", "value"}
+
+
+def test_negative_qwen2_expert_group_detects_different_expert_calls():
+    _, groups, captured = simulate(Qwen2MoeQModel, _tiny_qwen2_moe())
+    expert_gates = [
+        module
+        for modules in groups.values()
+        for module in modules
+        if ".experts." in module.full_name and module.full_name.endswith("gate_proj")
+    ]
+    if len(expert_gates) < 2:
+        pytest.skip(
+            "Transformers 5.16 Qwen2MoeExperts exposes fused gate_up_proj, "
+            "not per-expert gate_proj modules"
+        )
+    gate_zero, gate_one = expert_gates[:2]
+    captured[gate_zero.full_name] = [torch.ones(2, 32)]
+    captured[gate_one.full_name] = [torch.zeros(2, 32)]
+    source = InputSourceId(scope="model.layers.0.mlp.experts", subset_id=0)
+    report = validate_input_sources({source: [gate_zero, gate_one]}, captured)
+    assert not report.ok
+    assert report.mismatches[0].reason in {"value", "call_count"}
+
+
+def test_negative_groups_produce_useful_mismatch_diagnostics():
+    model = _tiny_llama()
+    report, groups, captured = simulate(LlamaQModel, model)
+    assert report.ok
+    q_proj = next(
+        module
+        for modules in groups.values()
+        for module in modules
+        if module.name.endswith("q_proj")
+    )
+    o_proj = next(
+        module
+        for modules in groups.values()
+        for module in modules
+        if module.name.endswith("o_proj")
+    )
+    source = InputSourceId(scope="model.layers.0.self_attn", subset_id=0)
+    negative = validate_input_sources({source: [q_proj, o_proj]}, captured)
+    assert not negative.ok
+    assert negative.mismatches[0].reason in {"shape", "value"}
+    assert any(name.endswith("q_proj") for name in negative.mismatches[0].module_names)
+    assert any(name.endswith("o_proj") for name in negative.mismatches[0].module_names)
+
+
+def _try_optional_forward(
+    *,
+    transformers_module,
+    config_name,
+    model_name,
+    qmodel_module,
+    qmodel_name,
+    config_kwargs,
+):
+    try:
+        transformers_models = importlib.import_module(transformers_module)
+        qmodel_models = importlib.import_module(qmodel_module)
+        config = getattr(transformers_models, config_name)(**config_kwargs)
+        model = getattr(transformers_models, model_name)(config)
+        qmodel_cls = getattr(qmodel_models, qmodel_name)
+    except Exception as error:
+        pytest.skip(f"tiny CPU model construction unavailable: {type(error).__name__}: {error}")
+    try:
+        report, groups, captured = simulate(qmodel_cls, model)
+    except Exception as error:
+        pytest.skip(f"tiny CPU forward unavailable: {type(error).__name__}: {error}")
+    assert report.ok
+    assert report.checked_sources >= 1
+    return report, groups, captured
+
+
+def test_deepseek_v32_cpu_forward_validates_dsa_latent_inputs():
+    _, groups, _ = _try_optional_forward(
+        transformers_module="transformers.models.deepseek_v32",
+        config_name="DeepseekV32Config",
+        model_name="DeepseekV32ForCausalLM",
+        qmodel_module="gptqmodel.models.definitions.deepseek_v32",
+        qmodel_name="DeepSeekV32QModel",
+        config_kwargs={
+            "vocab_size": 128,
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "moe_intermediate_size": 16,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "n_routed_experts": 4,
+            "n_shared_experts": 1,
+            "num_experts_per_tok": 2,
+            "first_k_dense_replace": 0,
+            "q_lora_rank": 16,
+            "kv_lora_rank": 16,
+            "qk_rope_head_dim": 8,
+            "qk_nope_head_dim": 8,
+            "v_head_dim": 8,
+            "index_topk": 4,
+            "index_head_dim": 8,
+            "index_n_heads": 2,
+            "head_dim": 8,
+            "n_group": 1,
+            "topk_group": 1,
+            "use_cache": False,
+            "attn_implementation": "eager",
+        },
+    )
+    assert any(
+        {module.name.rsplit(".", 1)[-1] for module in modules}
+        >= {"q_b_proj", "wq_b"}
+        and source.name == "q_latent"
+        for source, modules in groups.items()
+    )
+    assert any(
+        len(modules) == 1
+        and modules[0].name.endswith("kv_b_proj")
+        for modules in groups.values()
+    )
+
+
+def test_deepseek_v4_cpu_forward_validates_staged_query_inputs():
+    _, groups, _ = _try_optional_forward(
+        transformers_module="transformers.models.deepseek_v4",
+        config_name="DeepseekV4Config",
+        model_name="DeepseekV4ForCausalLM",
+        qmodel_module="gptqmodel.models.definitions.deepseek_v4",
+        qmodel_name="DeepSeekV4QModel",
+        config_kwargs={
+            "vocab_size": 128,
+            "hidden_size": 32,
+            "moe_intermediate_size": 16,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 1,
+            "head_dim": 8,
+            "q_lora_rank": 16,
+            "o_lora_rank": 16,
+            "n_routed_experts": 4,
+            "n_shared_experts": 1,
+            "num_experts_per_tok": 2,
+            "layer_types": ["full_attention"],
+            "index_topk": 4,
+            "index_head_dim": 8,
+            "index_n_heads": 2,
+            "use_cache": False,
+            "attn_implementation": "eager",
+        },
+    )
+    assert any(
+        len(modules) == 1 and modules[0].name.endswith("q_a_proj")
+        for modules in groups.values()
+    )
+    assert any(
+        len(modules) == 1 and modules[0].name.endswith("q_b_proj")
+        for modules in groups.values()
+    )
+
+
+def test_glm_moe_dsa_cpu_forward_validates_dsa_latent_inputs():
+    _, groups, _ = _try_optional_forward(
+        transformers_module="transformers.models.glm_moe_dsa",
+        config_name="GlmMoeDsaConfig",
+        model_name="GlmMoeDsaForCausalLM",
+        qmodel_module="gptqmodel.models.definitions.glm_moe_dsa",
+        qmodel_name="GlmMoeDsaQModel",
+        config_kwargs={
+            "vocab_size": 128,
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "moe_intermediate_size": 16,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "n_routed_experts": 4,
+            "n_shared_experts": 1,
+            "num_experts_per_tok": 2,
+            "first_k_dense_replace": 0,
+            "q_lora_rank": 16,
+            "kv_lora_rank": 16,
+            "qk_rope_head_dim": 8,
+            "qk_nope_head_dim": 8,
+            "v_head_dim": 8,
+            "index_topk": 4,
+            "index_head_dim": 8,
+            "index_n_heads": 2,
+            "head_dim": 8,
+            "n_group": 1,
+            "topk_group": 1,
+            "use_cache": False,
+            "attn_implementation": "eager",
+        },
+    )
+    assert any(
+        {module.name.rsplit(".", 1)[-1] for module in modules}
+        >= {"q_b_proj", "wq_b"}
+        and source.name == "q_latent"
+        for source, modules in groups.items()
+    )
+    assert any(
+        len(modules) == 1
+        and modules[0].name.endswith("kv_b_proj")
+        for modules in groups.values()
+    )
+
+
+def test_glm4_moe_lite_cpu_forward_validates_mla_inputs():
+    _try_optional_forward(
+        transformers_module="transformers.models.glm4_moe_lite",
+        config_name="Glm4MoeLiteConfig",
+        model_name="Glm4MoeLiteForCausalLM",
+        qmodel_module="gptqmodel.models.definitions.glm4_moe_lite",
+        qmodel_name="Glm4MoeLiteQModel",
+        config_kwargs={
+            "vocab_size": 128,
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "moe_intermediate_size": 16,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "n_routed_experts": 4,
+            "n_shared_experts": 1,
+            "num_experts_per_tok": 2,
+            "q_lora_rank": 16,
+            "kv_lora_rank": 16,
+            "qk_rope_head_dim": 8,
+            "qk_nope_head_dim": 8,
+            "v_head_dim": 8,
+            "use_cache": False,
+            "attn_implementation": "eager",
+        },
+    )
+
+
+def test_glm5_next_cpu_forward_is_attempted_or_skipped_with_reason():
+    _try_optional_forward(
+        transformers_module="transformers.models.glm5_next",
+        config_name="Glm5NextConfig",
+        model_name="Glm5NextForConditionalGeneration",
+        qmodel_module="gptqmodel.models.definitions.glm5_next",
+        qmodel_name="Glm5NextQModel",
+        config_kwargs={
+            "text_config": {
+                "vocab_size": 128,
+                "hidden_size": 32,
+                "intermediate_size": 64,
+                "moe_intermediate_size": 16,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 4,
+                "n_routed_experts": 4,
+                "n_shared_experts": 1,
+                "num_experts_per_tok": 2,
+                "q_lora_rank": 16,
+                "kv_lora_rank": 16,
+                "qk_rope_head_dim": 8,
+                "qk_nope_head_dim": 8,
+                "v_head_dim": 8,
+                "use_cache": False,
+                "attn_implementation": "eager",
+            }
+        },
+    )

--- a/tests/module_tree/test_input_source_forward.py
+++ b/tests/module_tree/test_input_source_forward.py
@@ -3,6 +3,7 @@
 
 import importlib
 
+import defuser
 import pytest
 import torch
 from torch import nn
@@ -50,6 +51,12 @@ def simulate(qmodel_cls, model, layer_index=0, seq=6, batch=2):
     """Run one tiny model forward while capturing module-tree inputs."""
 
     torch.manual_seed(0)
+    try:
+        defuser_converted = defuser.convert_model(model, cleanup_original=True)
+        defuser_reason = None if defuser_converted else "defuser returned no conversion"
+    except Exception as error:
+        defuser_converted = False
+        defuser_reason = f"defuser conversion failed: {type(error).__name__}: {error}"
     quantize_config = QuantizeConfig(bits=4, group_size=16)
     layer_modules = qmodel_cls.simple_layer_modules(model.config, quantize_config)
     prefix = _layer_prefix(qmodel_cls, layer_index)
@@ -91,7 +98,13 @@ def simulate(qmodel_cls, model, layer_index=0, seq=6, batch=2):
     )
     with InputSourceCapture(named_modules) as capture:
         model(input_ids=input_ids)
-    return validate_input_sources(groups, capture.captured), groups, capture.captured
+    return (
+        validate_input_sources(groups, capture.captured),
+        groups,
+        capture.captured,
+        defuser_converted,
+        defuser_reason,
+    )
 
 
 def _tiny_llama():
@@ -213,8 +226,18 @@ def _assert_routed_expert_gate_up(groups, captured):
     assert routed
 
 
+def _assert_shared_expert_gate_up(groups, captured):
+    assert any(
+        source.scope.endswith("mlp.shared_experts")
+        and {"gate_proj", "up_proj"}
+        <= {module.full_name.rsplit(".", 1)[-1] for module in modules}
+        and all(captured[module.full_name] for module in modules)
+        for source, modules in groups.items()
+    )
+
+
 def test_llama_cpu_forward_validates_qkv_and_gate_up_inputs():
-    report, groups, _ = simulate(LlamaQModel, _tiny_llama())
+    report, groups, _, _, _ = simulate(LlamaQModel, _tiny_llama())
     assert report.ok
     assert report.checked_sources >= 2
     qkv = next(
@@ -238,15 +261,20 @@ def test_llama_cpu_forward_validates_qkv_and_gate_up_inputs():
     ],
 )
 def test_moe_cpu_forward_validates_routed_expert_inputs(qmodel_cls, model_factory):
-    report, groups, captured = simulate(qmodel_cls, model_factory())
+    report, groups, captured, defuser_converted, defuser_reason = simulate(qmodel_cls, model_factory())
     assert report.ok
     assert report.checked_sources >= 1
-    if any("experts." in module.full_name for modules in groups.values() for module in modules):
-        _assert_routed_expert_gate_up(groups, captured)
+    if not defuser_converted:
+        pytest.skip(f"defuser did not expose per-expert modules: {defuser_reason}")
+    assert any("experts." in module.full_name for modules in groups.values() for module in modules)
+    _assert_routed_expert_gate_up(groups, captured)
 
 
 def test_deepseek_v3_cpu_forward_validates_mla_inputs():
-    report, groups, captured = simulate(DeepSeekV3QModel, _tiny_deepseek_v3())
+    report, groups, captured, defuser_converted, defuser_reason = simulate(
+        DeepSeekV3QModel,
+        _tiny_deepseek_v3(),
+    )
     assert report.ok
     assert report.checked_sources >= 2
     q_a = next(
@@ -267,10 +295,14 @@ def test_deepseek_v3_cpu_forward_validates_mla_inputs():
         assert len(
             groups[next(source for source, modules in groups.items() if module in modules)]
         ) == 1
+    if not defuser_converted:
+        pytest.skip(f"defuser did not expose per-expert modules: {defuser_reason}")
+    _assert_routed_expert_gate_up(groups, captured)
+    _assert_shared_expert_gate_up(groups, captured)
 
 
 def test_minicpm3_cpu_forward_validates_mla_inputs():
-    report, groups, _ = simulate(MiniCpm3QModel, _tiny_minicpm3())
+    report, groups, _, _, _ = simulate(MiniCpm3QModel, _tiny_minicpm3())
     assert report.ok
     assert report.checked_sources >= 2
     assert any(
@@ -281,7 +313,7 @@ def test_minicpm3_cpu_forward_validates_mla_inputs():
 
 
 def test_negative_deepseek_v3_group_detects_distinct_latent_inputs():
-    _, groups, captured = simulate(DeepSeekV3QModel, _tiny_deepseek_v3())
+    _, groups, captured, _, _ = simulate(DeepSeekV3QModel, _tiny_deepseek_v3())
     q_b = next(
         module
         for modules in groups.values()
@@ -301,19 +333,19 @@ def test_negative_deepseek_v3_group_detects_distinct_latent_inputs():
 
 
 def test_negative_qwen2_expert_group_detects_different_expert_calls():
-    _, groups, captured = simulate(Qwen2MoeQModel, _tiny_qwen2_moe())
+    _, groups, captured, defuser_converted, defuser_reason = simulate(Qwen2MoeQModel, _tiny_qwen2_moe())
+    if not defuser_converted:
+        pytest.skip(f"defuser did not expose per-expert modules: {defuser_reason}")
     expert_gates = [
         module
         for modules in groups.values()
         for module in modules
         if ".experts." in module.full_name and module.full_name.endswith("gate_proj")
     ]
-    if len(expert_gates) < 2:
-        pytest.skip(
-            "Transformers 5.16 Qwen2MoeExperts exposes fused gate_up_proj, "
-            "not per-expert gate_proj modules"
-        )
+    assert len(expert_gates) >= 2
     gate_zero, gate_one = expert_gates[:2]
+    assert captured[gate_zero.full_name]
+    assert captured[gate_one.full_name]
     captured[gate_zero.full_name] = [torch.ones(2, 32)]
     captured[gate_one.full_name] = [torch.zeros(2, 32)]
     source = InputSourceId(scope="model.layers.0.mlp.experts", subset_id=0)
@@ -324,7 +356,7 @@ def test_negative_qwen2_expert_group_detects_different_expert_calls():
 
 def test_negative_groups_produce_useful_mismatch_diagnostics():
     model = _tiny_llama()
-    report, groups, captured = simulate(LlamaQModel, model)
+    report, groups, captured, _, _ = simulate(LlamaQModel, model)
     assert report.ok
     q_proj = next(
         module
@@ -364,16 +396,16 @@ def _try_optional_forward(
     except Exception as error:
         pytest.skip(f"tiny CPU model construction unavailable: {type(error).__name__}: {error}")
     try:
-        report, groups, captured = simulate(qmodel_cls, model)
+        report, groups, captured, defuser_converted, defuser_reason = simulate(qmodel_cls, model)
     except Exception as error:
         pytest.skip(f"tiny CPU forward unavailable: {type(error).__name__}: {error}")
     assert report.ok
     assert report.checked_sources >= 1
-    return report, groups, captured
+    return report, groups, captured, defuser_converted, defuser_reason
 
 
 def test_deepseek_v32_cpu_forward_validates_dsa_latent_inputs():
-    _, groups, _ = _try_optional_forward(
+    _, groups, captured, defuser_converted, defuser_reason = _try_optional_forward(
         transformers_module="transformers.models.deepseek_v32",
         config_name="DeepseekV32Config",
         model_name="DeepseekV32ForCausalLM",
@@ -417,10 +449,14 @@ def test_deepseek_v32_cpu_forward_validates_dsa_latent_inputs():
         and modules[0].name.endswith("kv_b_proj")
         for modules in groups.values()
     )
+    if not defuser_converted:
+        pytest.skip(f"defuser did not expose per-expert modules: {defuser_reason}")
+    _assert_routed_expert_gate_up(groups, captured)
+    _assert_shared_expert_gate_up(groups, captured)
 
 
 def test_deepseek_v4_cpu_forward_validates_staged_query_inputs():
-    _, groups, _ = _try_optional_forward(
+    _, groups, _, _, _ = _try_optional_forward(
         transformers_module="transformers.models.deepseek_v4",
         config_name="DeepseekV4Config",
         model_name="DeepseekV4ForCausalLM",
@@ -458,7 +494,7 @@ def test_deepseek_v4_cpu_forward_validates_staged_query_inputs():
 
 
 def test_glm_moe_dsa_cpu_forward_validates_dsa_latent_inputs():
-    _, groups, _ = _try_optional_forward(
+    _, groups, captured, defuser_converted, defuser_reason = _try_optional_forward(
         transformers_module="transformers.models.glm_moe_dsa",
         config_name="GlmMoeDsaConfig",
         model_name="GlmMoeDsaForCausalLM",
@@ -502,10 +538,14 @@ def test_glm_moe_dsa_cpu_forward_validates_dsa_latent_inputs():
         and modules[0].name.endswith("kv_b_proj")
         for modules in groups.values()
     )
+    if not defuser_converted:
+        pytest.skip(f"defuser did not expose per-expert modules: {defuser_reason}")
+    _assert_routed_expert_gate_up(groups, captured)
+    _assert_shared_expert_gate_up(groups, captured)
 
 
 def test_glm4_moe_lite_cpu_forward_validates_mla_inputs():
-    _try_optional_forward(
+    _, groups, captured, defuser_converted, defuser_reason = _try_optional_forward(
         transformers_module="transformers.models.glm4_moe_lite",
         config_name="Glm4MoeLiteConfig",
         model_name="Glm4MoeLiteForCausalLM",
@@ -522,6 +562,7 @@ def test_glm4_moe_lite_cpu_forward_validates_mla_inputs():
             "n_routed_experts": 4,
             "n_shared_experts": 1,
             "num_experts_per_tok": 2,
+            "mlp_layer_types": ["sparse"],
             "q_lora_rank": 16,
             "kv_lora_rank": 16,
             "qk_rope_head_dim": 8,
@@ -531,6 +572,11 @@ def test_glm4_moe_lite_cpu_forward_validates_mla_inputs():
             "attn_implementation": "eager",
         },
     )
+    if not defuser_converted:
+        pytest.skip(f"defuser did not expose per-expert modules: {defuser_reason}")
+    assert any("experts." in module.full_name for modules in groups.values() for module in modules)
+    _assert_routed_expert_gate_up(groups, captured)
+    _assert_shared_expert_gate_up(groups, captured)
 
 
 def test_glm5_next_cpu_forward_is_attempted_or_skipped_with_reason():

--- a/tests/module_tree/test_input_source_quantize.py
+++ b/tests/module_tree/test_input_source_quantize.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock, patch
+
+import pytest
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from tokenizers.pre_tokenizers import Whitespace
+from tokenizers.trainers import WordLevelTrainer
+from transformers import LlamaConfig, LlamaForCausalLM, PreTrainedTokenizerFast
+
+from gptqmodel import BACKEND, GPTQModel
+from gptqmodel.quantization.config import QuantizeConfig
+
+
+def _write_tiny_llama(model_dir):
+    texts = [
+        "tiny input source validation sample one with enough tokens for calibration data",
+        "tiny input source validation sample two with enough tokens for calibration data",
+        "tiny input source validation sample three with enough tokens for calibration data",
+    ]
+    tokenizer = Tokenizer(WordLevel(unk_token="[UNK]"))
+    tokenizer.pre_tokenizer = Whitespace()
+    tokenizer.train_from_iterator(
+        texts,
+        trainer=WordLevelTrainer(
+            special_tokens=["[PAD]", "[UNK]", "[BOS]", "[EOS]"]
+        ),
+    )
+    fast_tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer,
+        bos_token="[BOS]",
+        eos_token="[EOS]",
+        unk_token="[UNK]",
+        pad_token="[PAD]",
+    )
+    fast_tokenizer.save_pretrained(model_dir)
+    model = LlamaForCausalLM(
+        LlamaConfig(
+            vocab_size=128,
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=64,
+            pad_token_id=0,
+            bos_token_id=2,
+            eos_token_id=3,
+            use_cache=False,
+            attn_implementation="eager",
+        )
+    )
+    model.save_pretrained(model_dir)
+    return texts
+
+
+@pytest.mark.slow
+def test_cpu_quantize_validates_input_sources_and_logs_summary(tmp_path):
+    model_dir = tmp_path / "native"
+    model_dir.mkdir()
+    texts = _write_tiny_llama(model_dir)
+
+    quantize_config = QuantizeConfig(
+        bits=4,
+        group_size=16,
+        validate_input_sources=True,
+        device="cpu",
+    )
+    model = GPTQModel.load(
+        str(model_dir),
+        quantize_config=quantize_config,
+        backend=BACKEND.TORCH,
+    )
+    import gptqmodel.looper.module_looper as module_looper
+
+    logger = module_looper.log
+    logger_info = Mock(wraps=logger.info)
+    logger_spy = Mock(wraps=logger)
+    logger_spy.info = logger_info
+    with patch.object(module_looper, "log", logger_spy):
+        model.quantize(
+            calibration=texts,
+            batch_size=1,
+            backend=BACKEND.TORCH,
+            calibration_data_min_length=1,
+        )
+    assert any(
+        call.args and str(call.args[0]).startswith("Input-source validation:")
+        for call in logger_info.call_args_list
+    )

--- a/tests/module_tree/test_input_source_validator.py
+++ b/tests/module_tree/test_input_source_validator.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: 2024-2025 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from torch import nn
+
+from gptqmodel.looper.input_source_validator import (
+    InputSourceCapture,
+    InputSourceValidationError,
+    validate_input_sources,
+)
+from gptqmodel.looper.named_module import NamedModule
+from gptqmodel.models.input_source import InputSourceId, NamedInput, UniqueInput
+from gptqmodel.quantization.config import QuantizeConfig
+
+
+def _named(name, module=None):
+    return NamedModule(
+        module or nn.Linear(4, 4, bias=False),
+        name=name,
+        full_name=name,
+        layer_index=0,
+        tree_scope_id="scope",
+        subset_id=0,
+    )
+
+
+def _source(*modules):
+    return {
+        InputSourceId(scope="scope", subset_id=0): list(modules),
+    }
+
+
+def _report(first, second, first_values, second_values, *, atol=0.0, rtol=0.0):
+    return validate_input_sources(
+        _source(first, second),
+        {
+            first.full_name: first_values,
+            second.full_name: second_values,
+        },
+        atol=atol,
+        rtol=rtol,
+    )
+
+
+def test_validator_accepts_identity_and_equal_values():
+    first = _named("first")
+    second = _named("second")
+    shared = torch.randn(2, 4)
+    first_values = [shared]
+    second_values = [shared]
+    assert _report(first, second, first_values, second_values).ok
+
+    first_values = [torch.ones(2, 4)]
+    second_values = [torch.ones(2, 4)]
+    assert _report(first, second, first_values, second_values).ok
+
+
+def test_validator_reports_shape_dtype_value_and_call_count():
+    first = _named("first")
+    second = _named("second")
+
+    first_values = [torch.ones(2, 4)]
+    second_values = [torch.ones(3, 4)]
+    report = _report(first, second, first_values, second_values)
+    assert not report.ok
+    assert report.mismatches[0].reason == "shape"
+
+    first_values = [torch.ones(2, 4)]
+    second_values = [torch.ones(2, 4, dtype=torch.float64)]
+    report = _report(first, second, first_values, second_values)
+    assert report.mismatches[0].reason == "dtype"
+
+    first_values = [torch.ones(2, 4)]
+    second_values = [torch.zeros(2, 4)]
+    report = _report(first, second, first_values, second_values)
+    assert report.mismatches[0].reason == "value"
+
+    first_values = [torch.ones(2, 4), torch.ones(2, 4)]
+    second_values = [torch.ones(2, 4)]
+    report = _report(first, second, first_values, second_values)
+    assert report.mismatches[0].reason == "call_count"
+
+    first_values = [torch.ones(2, 4)]
+    second_values = [torch.ones(2, 4) + 1e-5]
+    assert _report(
+        first,
+        second,
+        first_values,
+        second_values,
+        atol=1e-4,
+        rtol=1e-4,
+    ).ok
+
+
+def test_validator_ignores_uninvoked_modules_and_reports_diagnostics():
+    first = _named("first")
+    second = _named("second")
+    first_values = [torch.ones(2, 4)]
+    second_values = []
+    assert _report(first, second, first_values, second_values).ok
+
+    second_values = [torch.zeros(2, 4)]
+    report = _report(first, second, first_values, second_values)
+    with torch.no_grad():
+        try:
+            report.raise_if_failed()
+        except InputSourceValidationError as error:
+            message = str(error)
+        else:
+            raise AssertionError("expected validation failure")
+    assert "first" in message
+    assert "second" in message
+    assert "(2, 4)" in message
+
+
+class _KwargModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(1))
+
+    def forward(self, hidden_states=None, **kwargs):
+        return hidden_states if hidden_states is not None else kwargs["hidden_states"]
+
+
+def test_capture_records_first_tensor_input_and_limits_calls():
+    named = _named("module", _KwargModule())
+    value = torch.randn(2, 4)
+    with InputSourceCapture([named], max_calls=4) as capture:
+        for _ in range(6):
+            named.module(hidden_states=value)
+    assert capture.captured[named.full_name] == [value] * 4
+
+
+def test_capture_prefers_first_positional_tensor_and_removes_hooks():
+    named = _named("module")
+    positional = torch.randn(2, 4)
+    with InputSourceCapture([named]) as capture:
+        named.module(positional)
+    assert capture.captured[named.full_name] == [positional]
+    assert not named.module._forward_pre_hooks
+
+    named.module(positional)
+    assert capture.captured[named.full_name] == [positional]
+
+
+def test_named_and_unique_source_specs_are_hashable():
+    assert InputSourceId(scope="scope", name="latent").kind == "named"
+    assert InputSourceId(scope="scope", module="module").kind == "unique"
+    assert NamedInput("latent") != UniqueInput()
+
+
+def test_quantize_config_round_trips_input_source_validation():
+    config = QuantizeConfig(validate_input_sources=True)
+    payload = config.to_dict()
+    assert payload["meta"]["validate_input_sources"] is True
+    restored = QuantizeConfig.from_quant_config(payload)
+    assert restored.validate_input_sources is True


### PR DESCRIPTION
## Summary

Groundwork for deduplicating Hessian / activation-statistic collection across modules that consume the exact same input activation. This PR adds the **generic metadata layer + a forward-time validator** (no GPTQ math or hook-sharing changes yet):

- numeric flag `:N` keeps meaning "calculation/replay subset"
- new `:input` = this module has its own unique input source
- new `:input=<name>` = named alternate input shared by same-named modules in the same structural scope
- default rule: same structural container (tree scope) + same subset id ⇒ same input source

Existing definition strings (`"q_proj:0"`, roles `:q/:k/:v/:gate/:up`, `:!`, `:?`, `:moe`) are unchanged and `build_layer_modules()` output is byte-identical (input tokens are metadata-only and never emitted).

## What Changed

- `gptqmodel/models/input_source.py` (new, GPTQ-agnostic):
  ```python
  UniqueInput() | NamedInput(name)            # InputSpec; None == default rule
  parse_input_flag(flags) -> (InputSpec|None, remaining_flags)
  ModuleTreeEntry(full_path, scope, subset_id, input_spec, not_quantized, capture_only)
  InputSourceId(scope, subset_id=None | name=None | module=None)   # frozen/hashable, .kind
  resolve_input_source(NamedModule) -> InputSourceId
  group_input_sources(Iterable[NamedModule]) -> dict[InputSourceId, list[NamedModule]]
  ```
- `BaseQModel`: `_parse_module_spec()` (name, flags, input_spec); `_parse_module_flags()` now hides input tokens from all existing flag consumers. `_build_layer_modules_for_tree(..., entries_out=)` records a `ModuleTreeEntry` per path; `build_module_tree_entries()` / `resolve_module_tree_entry(name)` (cached per class; `mlp.experts.{expert_index}.up_proj` matches `mlp.experts.7.up_proj` and yields scope `mlp.experts.7`, so expert 0 and expert 1 never share a source).
- `NamedModule` gains `tree_scope_id`, `subset_id`, `input_spec`; `ModuleLooper.create_named_modules` fills them from the model definition (`tree_scope_id = f"{layer_prefix}.{entry.scope}"`). Unknown/lm_head modules resolve to a unique (never-merged) source.
- `SubsetPlan.input_sources: dict[InputSourceId, list[NamedModule]]`, recomputed by `for_modules()` chunks.
- `gptqmodel/looper/input_source_validator.py` (new): `InputSourceCapture` (forward pre-hooks recording each module's input tensor), `validate_input_sources(groups, captured) -> InputSourceValidationReport` (identity/storage fast path → shape → dtype → `torch.equal`; reasons `call_count|shape|dtype|value`), `InputSourceValidationError` naming source, modules and shapes.
- `QuantizeConfig.validate_input_sources: bool = False` (debug mode, serialized like `auto_forward_data_parallel`). When on, `build_subset_plan` forces serial forward and `_run_single_subset_pass` captures + validates every multi-module input-source group of the subset, logs `Input-source validation: layer=… checked_sources=… checked_modules=…` and raises on mismatch.
- Model definitions annotated where equal subset id ≠ equal input (verified against the transformers modeling code by CPU forward simulation where the family exists in transformers 5.16): DeepSeek V2/V3/V3.2/V4, DeepSeek-VL2, GLM4-MoE-Lite, GLM-MoE-DSA, GLM5-Next, Kimi-K2.5, LongCat-Flash, MiniCPM3, AXK2. Pattern: `q_b_proj`/`kv_b_proj` consume normalized latents → `:input`; DSA `indexer.wq_b` shares the Q latent with `q_b_proj` → `:input=q_latent` on both. Dense Llama/Qwen definitions untouched.

Out of scope (later PRs): shared Hessian accumulator per `InputSourceId`, hook dedup (one capture owner per source), lifecycle/ownership, placement optimizations.

## Tests

- [x] I added a new simple/fast unit test for this change, or documented why that is not applicable.
- [x] I ran the new targeted test locally before opening this PR.
- [x] I ran any other directly relevant local tests.

All CPU-only, tiny synthetic configs (hidden 32, 1 layer, 4 experts), real transformers modeling code, experts unfused via `defuser.convert_model` exactly as the loader does:

- `tests/module_tree/test_input_source.py` — parser cases (`q_proj:0`, `:input`, `:input=foo`, with/without role tags, `!`/`?`, error cases), block-output back-compat, entry/scope resolution incl. expert templates, `InputSourceId` grouping on tiny Llama / DeepSeek-V3 / Qwen2-MoE / Qwen3-MoE, `SubsetPlan.input_sources` + chunk recomputation.
- `tests/module_tree/test_input_source_validator.py` — validator unit tests (identity fast path, equal values, shape/dtype/value/call_count reasons, `max_calls`, kwargs capture).
- `tests/module_tree/test_input_source_forward.py` — full tiny-model forward with capture hooks, asserting every declared group actually receives identical inputs: Llama (q/k/v, gate/up), Qwen2-MoE, Qwen3-MoE, Mixtral (per-expert gate/up + shared expert), DeepSeek-V3, MiniCPM3, DeepSeek-V3.2, GLM-MoE-DSA (`q_b_proj`+`indexer.wq_b` share `q_latent`, `kv_b_proj` alone), GLM4-MoE-Lite. Negative tests prove the validator catches the pre-annotation groupings (`q_b_proj`+`kv_b_proj`, expert0+expert1 `gate_proj`, `q_proj`+`o_proj`). DeepSeek-V4 and GLM5-Next are skipped with reason (tiny-config constraints in transformers 5.16).
- `tests/module_tree/test_input_source_quantize.py` — end-to-end CPU GPTQ quantize of a tiny Llama with `validate_input_sources=True`; asserts the validation log lines and config round-trip.

```bash
cd tests && python -m pytest module_tree/test_input_source*.py module_tree/test_subset.py -q \
  --deselect module_tree/test_subset.py::test_qwen3_5_moe_subset_early_stop_follows_module_tree_execution_order
# 44 passed, 2 skipped, 1 deselected   (deselected test is CUDA-only; env is CPU torch)
python -m pytest module_tree -q   # 1 pre-existing failure on main: test_moe_flag_parsing::test_get_moe_module_name_none_tree
```

## Review Requirements

- [ ] I personally reviewed every file in this diff.
- [ ] I checked that the code matches existing project structure, APIs, and conventions.
- [ ] I avoided unnecessary monkeypatching and used the project's normal extension points where possible.

## Notes

WIP. Semantics are additive; nothing consumes `SubsetPlan.input_sources` for Hessian sharing yet — that is the next phase. `deepseek_vl_v2` annotation follows the DeepSeek-V2 MLA pattern but could not be validated by forward simulation (no modeling code in transformers 5.16).
