### PR TITLE
fix: isolate JIT extension cache fingerprint from unrelated kernel changes

### DIFF
--- a/gptqmodel/utils/cpp.py
+++ b/gptqmodel/utils/cpp.py
@@ -451,6 +451,30 @@ def _dedupe_path_strings(paths: Sequence[str]) -> list[str]:
     return deduped
 
 
+# Directory that contains the ``gptqmodel`` package.  In editable installs this
+# is the repository root; in wheel installs it is the site-packages root.
+# Fingerprint paths below this root are emitted as relative POSIX strings so the
+# cache key does not depend on checkout location or unrelated sibling files.
+_FINGERPRINT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _fingerprint_path_key(path: Path) -> str:
+    """Return a stable, location-independent key for *path*.
+
+    Paths inside the package/project root are returned relative to that root so
+    the cache key is not tied to where the repository is cloned or installed.
+    Paths outside the project root (system CUDA headers, third-party wheels,
+    etc.) are kept absolute because they are toolchain/dependency inputs.
+    """
+
+    normalized = path.expanduser().resolve(strict=False)
+    try:
+        relative = normalized.relative_to(_FINGERPRINT_ROOT)
+    except ValueError:
+        return str(normalized)
+    return relative.as_posix()
+
+
 def detected_cuda_wheel_include_paths() -> list[str]:
     """Discover CUDA developer headers shipped via NVIDIA Python wheels."""
 
@@ -907,7 +931,7 @@ class TorchOpsJitExtension:
             if normalized in visited:
                 return
             visited.add(normalized)
-            payload.append(str(normalized))
+            payload.append(_fingerprint_path_key(normalized))
 
             if not normalized.exists():
                 payload.append("missing")
@@ -923,14 +947,21 @@ class TorchOpsJitExtension:
 
             source_text = source_bytes.decode("utf-8", errors="ignore")
             for delimiter, include_name in _SOURCE_INCLUDE_PATTERN.findall(source_text):
+                # Only quoted includes are part of the extension's source graph.
+                # Angle-bracket includes name system/dependency headers whose
+                # precise content is captured by the ABI/toolchain flags in the
+                # cache key; resolving them against local search roots would let
+                # unrelated sibling files (e.g. a new kernel dropping a ``torch/``
+                # header) leak into this extension's fingerprint.
+                if delimiter != '"':
+                    continue
                 included_path = _resolve_local_include_path(
                     include_name,
                     including_path=normalized,
                     include_search_roots=include_search_roots,
                 )
                 if included_path is None:
-                    if delimiter == '"':
-                        payload.append(f"missing_include={normalized}:{include_name}")
+                    payload.append(f"missing_include={_fingerprint_path_key(normalized)}:{include_name}")
                     continue
                 visit(included_path)
 
@@ -954,7 +985,11 @@ class TorchOpsJitExtension:
             except OSError:
                 return
             texts.append((normalized, source_text))
-            for _, include_name in _SOURCE_INCLUDE_PATTERN.findall(source_text):
+            for delimiter, include_name in _SOURCE_INCLUDE_PATTERN.findall(source_text):
+                # ABI detection only needs the extension's own source graph.
+                # System headers use angle brackets and are covered by ABI/toolchain flags.
+                if delimiter != '"':
+                    continue
                 included_path = _resolve_local_include_path(
                     include_name,
                     including_path=normalized,
@@ -979,7 +1014,7 @@ class TorchOpsJitExtension:
             for item in self._source_texts(source, include_paths)
         ]
         source_key = tuple(
-            (str(path), hashlib.sha256(text.encode("utf-8")).hexdigest())
+            (_fingerprint_path_key(path), hashlib.sha256(text.encode("utf-8")).hexdigest())
             for path, text in source_texts
         )
         cache_key = (source_key, tuple(include_paths))
@@ -1079,7 +1114,7 @@ class TorchOpsJitExtension:
 
         payload.extend(extra_cflags)
         payload.extend(_cuda_cache_relevant_flags(extra_cuda_cflags))
-        payload.extend(include_paths)
+        payload.extend(_fingerprint_path_key(Path(include_path)) for include_path in include_paths)
         payload.extend(self._resolve_sequence(self.extra_ldflags))
         digest = hashlib.sha256("\0".join(payload).encode("utf-8")).hexdigest()
         return digest[:16]

--- a/gptqmodel/utils/cpp.py
+++ b/gptqmodel/utils/cpp.py
@@ -25,6 +25,7 @@ except ImportError:  # pragma: no cover - non-POSIX hosts fall back to process-l
     fcntl = None
 
 from contextlib import contextmanager
+from functools import lru_cache
 from pathlib import Path
 from typing import Callable, Optional, Sequence
 
@@ -473,6 +474,64 @@ def _fingerprint_path_key(path: Path) -> str:
     except ValueError:
         return str(normalized)
     return relative.as_posix()
+
+
+@lru_cache(maxsize=None)
+def _system_include_roots() -> tuple[Path, ...]:
+    """Return system/dependency include directories used by the toolchain.
+
+    These roots identify headers (e.g. ``torch/``, ``ATen/``, ``c10/``,
+    ``Python.h``, ``cuda*.h``) whose contents are captured by the ABI/toolchain
+    portion of the cache key rather than by hashing the header files directly.
+    """
+
+    roots: list[Path] = []
+    try:
+        from torch.utils.cpp_extension import include_paths as _torch_include_paths
+
+        roots.extend(Path(p).expanduser().resolve(strict=False) for p in _torch_include_paths())
+    except Exception:
+        pass
+    try:
+        import sysconfig
+
+        roots.append(Path(sysconfig.get_paths()["include"]).expanduser().resolve(strict=False))
+    except Exception:
+        pass
+    try:
+        roots.extend(Path(p).expanduser().resolve(strict=False) for p in detected_local_cuda_include_paths())
+    except Exception:
+        pass
+    try:
+        roots.extend(Path(p).expanduser().resolve(strict=False) for p in detected_cuda_wheel_include_paths())
+    except Exception:
+        pass
+
+    seen: set[Path] = set()
+    deduped: list[Path] = []
+    for root in roots:
+        if root in seen:
+            continue
+        seen.add(root)
+        deduped.append(root)
+    return tuple(deduped)
+
+
+def _is_system_or_dependency_header(include_name: str) -> bool:
+    """Return True if *include_name* names a system/dependency header.
+
+    The check is conservative: only headers that actually exist under a known
+    system include directory (torch, Python, CUDA, etc.) are skipped. This lets
+    legitimate local angle-bracket headers (e.g. ``<wrapper.h>`` under an
+    extension-specific include root) still be hashed while preventing files
+    dropped by unrelated kernels (e.g. ``gptqmodel_ext/torch/all.h``) from
+    leaking into an extension's cache key.
+    """
+
+    for root in _system_include_roots():
+        if (root / include_name).is_file():
+            return True
+    return False
 
 
 def detected_cuda_wheel_include_paths() -> list[str]:
@@ -947,23 +1006,31 @@ class TorchOpsJitExtension:
 
             source_text = source_bytes.decode("utf-8", errors="ignore")
             for delimiter, include_name in _SOURCE_INCLUDE_PATTERN.findall(source_text):
-                # Only quoted includes are part of the extension's source graph.
-                # Angle-bracket includes name system/dependency headers whose
-                # precise content is captured by the ABI/toolchain flags in the
-                # cache key; resolving them against local search roots would let
-                # unrelated sibling files (e.g. a new kernel dropping a ``torch/``
-                # header) leak into this extension's fingerprint.
-                if delimiter != '"':
-                    continue
-                included_path = _resolve_local_include_path(
-                    include_name,
-                    including_path=normalized,
-                    include_search_roots=include_search_roots,
-                )
-                if included_path is None:
-                    payload.append(f"missing_include={_fingerprint_path_key(normalized)}:{include_name}")
-                    continue
-                visit(included_path)
+                if delimiter == '"':
+                    included_path = _resolve_local_include_path(
+                        include_name,
+                        including_path=normalized,
+                        include_search_roots=include_search_roots,
+                    )
+                    if included_path is None:
+                        payload.append(f"missing_include={_fingerprint_path_key(normalized)}:{include_name}")
+                        continue
+                    visit(included_path)
+                else:
+                    # Angle-bracket headers name system/dependency headers whose
+                    # contents are captured by ABI/toolchain flags. Do not hash
+                    # them when they are part of the installed toolchain; only
+                    # follow local angle-bracket headers that are not shadowing
+                    # a system header (e.g. the synthetic ``<wrapper.h>`` in tests).
+                    if _is_system_or_dependency_header(include_name):
+                        continue
+                    included_path = _resolve_local_include_path(
+                        include_name,
+                        including_path=normalized,
+                        include_search_roots=include_search_roots,
+                    )
+                    if included_path is not None:
+                        visit(included_path)
 
         visit(Path(source))
         return payload
@@ -987,8 +1054,9 @@ class TorchOpsJitExtension:
             texts.append((normalized, source_text))
             for delimiter, include_name in _SOURCE_INCLUDE_PATTERN.findall(source_text):
                 # ABI detection only needs the extension's own source graph.
-                # System headers use angle brackets and are covered by ABI/toolchain flags.
-                if delimiter != '"':
+                # Installed system/dependency headers are captured by the
+                # ABI/toolchain flags rather than by reading their contents.
+                if delimiter != '"' and _is_system_or_dependency_header(include_name):
                     continue
                 included_path = _resolve_local_include_path(
                     include_name,

--- a/gptqmodel/utils/cpp.py
+++ b/gptqmodel/utils/cpp.py
@@ -490,22 +490,22 @@ def _system_include_roots() -> tuple[Path, ...]:
         from torch.utils.cpp_extension import include_paths as _torch_include_paths
 
         roots.extend(Path(p).expanduser().resolve(strict=False) for p in _torch_include_paths())
-    except Exception:
-        pass
+    except Exception as exc:
+        log.debug("Torch include roots unavailable; continuing without them: %s", exc, exc_info=True)
     try:
         import sysconfig
 
         roots.append(Path(sysconfig.get_paths()["include"]).expanduser().resolve(strict=False))
-    except Exception:
-        pass
+    except Exception as exc:
+        log.debug("Python include root unavailable; continuing without it: %s", exc, exc_info=True)
     try:
         roots.extend(Path(p).expanduser().resolve(strict=False) for p in detected_local_cuda_include_paths())
-    except Exception:
-        pass
+    except Exception as exc:
+        log.debug("Local CUDA include roots unavailable; continuing without them: %s", exc, exc_info=True)
     try:
         roots.extend(Path(p).expanduser().resolve(strict=False) for p in detected_cuda_wheel_include_paths())
-    except Exception:
-        pass
+    except Exception as exc:
+        log.debug("CUDA wheel include roots unavailable; continuing without them: %s", exc, exc_info=True)
 
     seen: set[Path] = set()
     deduped: list[Path] = []

--- a/tests/test_torch_ops_jit_extension.py
+++ b/tests/test_torch_ops_jit_extension.py
@@ -1009,6 +1009,64 @@ def test_torch_ops_jit_extension_fingerprint_tracks_transitive_local_includes(tm
     assert first_build_root != second_build_root
 
 
+def test_torch_ops_jit_extension_fingerprint_ignores_unrelated_sibling_files(monkeypatch, tmp_path):
+    """One kernel's source/header shadow must not change an unrelated extension's cache key."""
+
+    project_root = tmp_path / "project"
+    src_dir = project_root / "src"
+    src_dir.mkdir(parents=True)
+    include_dir = project_root / "includes"
+    include_dir.mkdir(parents=True)
+    other_kernel_dir = project_root / "other_kernel"
+    other_kernel_dir.mkdir(parents=True)
+
+    source = src_dir / "unit_test.cpp"
+    source.write_text(
+        '#include "local.h"\n#include <torch/all.h>\n',
+        encoding="utf-8",
+    )
+    (src_dir / "local.h").write_text("int local_value = 1;\n", encoding="utf-8")
+
+    loader = _make_loader(
+        tmp_path,
+        sources=[str(source)],
+        extra_include_paths=[str(src_dir), str(include_dir)],
+        python_abi_dependent=False,
+    )
+    monkeypatch.setattr(cpp_module, "_FINGERPRINT_ROOT", project_root)
+    monkeypatch.setattr(cpp_module.torch, "__version__", "2.8.0+cpu")
+
+    first_fingerprint = loader._cache_fingerprint()
+
+    # Simulate an unrelated kernel dropping a header that would shadow the
+    # angle-bracket ``<torch/all.h>`` include if the cache scanner resolved
+    # system-style includes against local search roots.
+    shadow = include_dir / "torch" / "all.h"
+    shadow.parent.mkdir(parents=True)
+    shadow.write_text("// unrelated shadow header\n", encoding="utf-8")
+    (other_kernel_dir / "kernel.cu").write_text(
+        "__global__ void unrelated() {}\n",
+        encoding="utf-8",
+    )
+
+    second_fingerprint = loader._cache_fingerprint()
+    assert second_fingerprint == first_fingerprint
+
+    # Ensure the final payload does not embed the temporary absolute path so the
+    # cache key is independent of checkout/install location.
+    payloads = []
+    real_sha256 = cpp_module.hashlib.sha256
+
+    def capture_sha256(data=b""):
+        payloads.append(data)
+        return real_sha256(data)
+
+    monkeypatch.setattr(cpp_module.hashlib, "sha256", capture_sha256)
+    loader._cache_fingerprint()
+    final_payload = payloads[-1].decode("utf-8")
+    assert str(tmp_path) not in final_payload
+
+
 def _spawn_flock_holder(lock_path: Path) -> subprocess.Popen:
     """Start a child process that holds an exclusive flock on `lock_path` until killed."""
 


### PR DESCRIPTION
## Summary

The JIT extension cache fingerprint in `TorchOpsJitExtension` leaked repository-wide state into each extension's build identity:

1. Absolute resolved paths for source files and include roots were hashed directly, so the cache key depended on checkout/install location.
2. Angle-bracket `#include` directives were resolved against broad local include roots (e.g. `gptqmodel_ext`), so an unrelated kernel dropping a file that shadows a system/dependency header (e.g. `torch/all.h`) could change the cache directory for Marlin and Machete.

## What Changed

- In `gptqmodel/utils/cpp.py`:
  - Added `_FINGERPRINT_ROOT` and `_fingerprint_path_key()` so paths inside the package are emitted as relative POSIX strings in the cache payload.
  - Added `_system_include_roots()` and `_is_system_or_dependency_header()` to identify installed toolchain/dependency headers.
  - `_source_cache_fingerprint_payload()` now skips angle-bracket includes that name installed system/dependency headers, and only falls back to local resolution for genuine local angle-bracket headers.
  - `_source_texts()` uses the same system-header detection for ABI text collection, so ABI detection still works without being poisoned by shadowed system headers.
  - `_source_abi_details()` and `_cache_fingerprint()` use stable `_fingerprint_path_key()` for source and include paths.
- Added `test_torch_ops_jit_extension_fingerprint_ignores_unrelated_sibling_files` in `tests/test_torch_ops_jit_extension.py` to ensure one kernel's files do not alter an unrelated extension's cache key.

## Tests

- `python -m pytest tests/test_torch_ops_jit_extension.py -v` (executed via a local `sys.modules` bootstrap because the sandbox cannot install `defuser` from PyPI) — **50 passed, 0 failed**.
- `uvx ruff check gptqmodel/utils/cpp.py tests/test_torch_ops_jit_extension.py` — reports only pre-existing lint issues (I001, UP045, BLE001, PIE807, PIE810, RUF046) unrelated to the changed lines; no new issues in the modified ranges.

```
============================== 50 passed in 0.90s ==============================
```

## Review Requirements

- [x] I personally reviewed every file in this diff.
- [x] I checked that the code matches existing project structure, APIs, and conventions.
- [x] I avoided unnecessary monkeypatching and used the project's normal extension points where possible.

## Notes

This change intentionally keeps local angle-bracket headers (e.g. `<wrapper.h>` under an extension-specific include root) in the source graph while excluding installed system/dependency headers that are already captured by ABI/toolchain flags. If a kernel deliberately intends to override a system header, it should use a dedicated, narrowly scoped include path rather than relying on the broad `gptqmodel_ext` include root.

Link to Devin session: https://app.devin.ai/sessions/3456e9f28c1f42839eb3d2a13f9a8226
Open in Devin Desktop: https://app.devin.ai/desktop/session/3456e9f28c1f42839eb3d2a13f9a8226?variant=devin
Requested by: @Qubitium