### PR TITLE
Sync native GGUF support with current upstream types

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Marlin uses `GPTQMODEL_MARLIN_USE_FP32` (default: enabled) to control fp32 accum
 * ✨ Native integration with HF [Transformers](https://github.com/huggingface/transformers), [Optimum](https://github.com/huggingface/optimum), and [Peft](https://github.com/huggingface/peft)
 * 🚀 [vLLM](https://github.com/vllm-project/vllm) and [SGLang](https://github.com/sgl-project/sglang) inference integration for quantized models with format = `FORMAT.[GPTQ/AWQ]`
 * ✨ GPTQ, AWQ, ParoQuant, QQQ, GGUF, FP8, EXL3, GPTAQ, and FOEM quantization support.
-* ✨ Prism Bonsai `Q1_0_g128` GGUF checkpoints can be loaded for post-quantized inference through the normal `model_id_or_path` argument. GPT-QModel normalizes the GGUF artifact internally for HF Transformers via its native GGUF runtime, and does not support Prism Bonsai quantization or export.
+* ✨ Current GGUF tensor assignments are supported, with native quantization and dequantization for `Q1_0`, `Q2_0`, `TQ1_0`, `TQ2_0`, and `MXFP4`, plus native `NVFP4` dequantization. Prism Bonsai `Q1_0_g128` remains accepted as a compatibility alias for the official 128-element `Q1_0` layout.
 * 🚀 Quantize MoE models with ease even with extreme routing activation bias via `Moe.Routing` and/or `FailSafe`.
 * 🚀 Data Parallelism for 80%+ quantization speed reduction with Multi-GPU.
 * 🚀 Optimized for Python >= 3.13t (free threading) with lock-free threading.

--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -333,10 +333,10 @@ def _resolve_native_gguf_profile(
 
     if (
         native_gguf_qspec is not None
-        and native_gguf_qspec.tensor_qtype == internal_gguf.GGMLQuantizationType.Q1_0_g128
+        and native_gguf_qspec.tensor_qtype == internal_gguf.GGMLQuantizationType.Q1_0
         and profile == PROFILE.AUTO
     ):
-        log.info("Loader: Bonsai/Prism Q1_0_g128 PROFILE.AUTO resolved to PROFILE.FAST.")
+        log.info("Loader: Q1_0 PROFILE.AUTO resolved to PROFILE.FAST.")
         return PROFILE.FAST
     return profile
 
@@ -350,7 +350,7 @@ def _should_use_dense_native_gguf_path(
 
     return (
         native_gguf_qspec is not None
-        and native_gguf_qspec.tensor_qtype == internal_gguf.GGMLQuantizationType.Q1_0_g128
+        and native_gguf_qspec.tensor_qtype == internal_gguf.GGMLQuantizationType.Q1_0
         and profile == PROFILE.FAST
     )
 
@@ -768,7 +768,7 @@ def ModelLoader(cls):
             hf_model_init_kwargs.update(hf_gguf_load_kwargs)
             if (
                 native_gguf_qspec is not None
-                and native_gguf_qspec.tensor_qtype == internal_gguf.GGMLQuantizationType.Q1_0_g128
+                and native_gguf_qspec.tensor_qtype == internal_gguf.GGMLQuantizationType.Q1_0
                 and atten_impl in {None, "auto"}
                 and _is_accelerated_attention_device(resolved_device)
                 and (config.model_type == "qwen3" or _supports_flash_attn_2(config))
@@ -1096,29 +1096,26 @@ def ModelLoader(cls):
         format_code = resolve_quant_format(qcfg.format, qcfg.method)
         backend = normalize_backend(backend, quant_method=export_quant_method)
 
-        # Prism/Bonsai sign-only GGUF tensors only have a torch runtime today.
-        # Bypass higher-priority GGUF backends that either do not support 1-bit
-        # formats or depend on optional external runtimes.
         if (
             native_gguf_qspec is not None
             and native_gguf_qspec.tensor_qtype == internal_gguf.GGMLQuantizationType.Q1_0
+            and backend not in {BACKEND.AUTO, BACKEND.GGUF_TORCH, BACKEND.GGUF_TRITON}
+        ):
+            raise ValueError(
+                "Native Q1_0 GGUF checkpoints support BACKEND.AUTO, BACKEND.GGUF_TORCH, or BACKEND.GGUF_TRITON. "
+                f"Actual backend: `{backend}`."
+            )
+        elif (
+            native_gguf_qspec is not None
+            and native_gguf_qspec.tensor_qtype == internal_gguf.GGMLQuantizationType.Q2_0
         ):
             if backend == BACKEND.AUTO:
                 backend = BACKEND.GGUF_TORCH
             elif backend != BACKEND.GGUF_TORCH:
                 raise ValueError(
-                    "Native Q1_0 GGUF checkpoints currently require BACKEND.GGUF_TORCH. "
+                    "Native Q2_0 GGUF checkpoints currently require BACKEND.GGUF_TORCH. "
                     f"Actual backend: `{backend}`."
                 )
-        elif (
-            native_gguf_qspec is not None
-            and native_gguf_qspec.tensor_qtype == internal_gguf.GGMLQuantizationType.Q1_0_g128
-            and backend not in {BACKEND.AUTO, BACKEND.GGUF_TORCH, BACKEND.GGUF_TRITON}
-        ):
-            raise ValueError(
-                "Native Q1_0_g128 GGUF checkpoints support BACKEND.AUTO, BACKEND.GGUF_TORCH, or BACKEND.GGUF_TRITON. "
-                f"Actual backend: `{backend}`."
-            )
 
         if format_code == FORMAT.EXL3:
             if backend not in (BACKEND.AUTO, BACKEND.EXL3_EXLLAMA_V3, BACKEND.EXL3_TORCH):

--- a/gptqmodel/nn_modules/qlinear/gguf.py
+++ b/gptqmodel/nn_modules/qlinear/gguf.py
@@ -202,7 +202,9 @@ def _gguf_quantize_sign_only(blocks: np.ndarray, *, block_size: int) -> np.ndarr
 
 
 def _gguf_roundf(values: np.ndarray) -> np.ndarray:
-    return np.sign(values) * np.floor(np.abs(values) + 0.5)
+    absolute = np.abs(values)
+    floored = np.floor(absolute)
+    return np.sign(values) * (floored + np.floor(2 * (absolute - floored)))
 
 
 def _gguf_quantize_q2_0(blocks: np.ndarray) -> np.ndarray:

--- a/gptqmodel/nn_modules/qlinear/gguf.py
+++ b/gptqmodel/nn_modules/qlinear/gguf.py
@@ -210,8 +210,8 @@ def _gguf_quantize_q2_0(blocks: np.ndarray) -> np.ndarray:
     with np.errstate(divide="ignore"):
         inv_d = np.where(d == 0, 0, 1.0 / d)
     qs = np.clip(_gguf_roundf(blocks * inv_d).astype(np.int8) + 1, 0, 3).astype(np.uint8)
-    qs = qs.reshape(blocks.shape[0], 4, 16)
-    packed = qs[:, 0] | (qs[:, 1] << 2) | (qs[:, 2] << 4) | (qs[:, 3] << 6)
+    qs = qs.reshape(blocks.shape[0], 16, 4)
+    packed = qs[..., 0] | (qs[..., 1] << 2) | (qs[..., 2] << 4) | (qs[..., 3] << 6)
     return np.concatenate([d.astype(np.float16).view(np.uint8), packed], axis=-1)
 
 
@@ -667,17 +667,28 @@ def _dequantize_q4_k_numpy(qweight: np.ndarray) -> np.ndarray:
     return (d * q - dm).reshape(rows, -1)
 
 
+def _gguf_dequantized_shape(qweight: np.ndarray, tensor_qtype: str) -> tuple[int, ...]:
+    block_size = _GGUF_TYPE_INFO[tensor_qtype]["block_size"]
+    type_size = _GGUF_TYPE_INFO[tensor_qtype]["type_size"]
+    if qweight.ndim == 0 or qweight.shape[-1] % type_size != 0:
+        raise ValueError(
+            f"GGUF {tensor_qtype} row byte width must be divisible by {type_size}, got "
+            f"{qweight.shape[-1] if qweight.ndim else 0} for shape {qweight.shape}."
+        )
+    return (*qweight.shape[:-1], qweight.shape[-1] // type_size * block_size)
+
+
 def _dequantize_q2_0_numpy(qweight: np.ndarray) -> np.ndarray:
-    rows = qweight.shape[0]
+    output_shape = _gguf_dequantized_shape(qweight, "Q2_0")
     blocks = qweight.reshape(-1, _GGUF_TYPE_INFO["Q2_0"]["type_size"])
     d = blocks[:, :2].view(np.float16).astype(np.float32)
-    qs = blocks[:, 2:].reshape(-1, 1, 16)
-    values = ((qs >> np.array([0, 2, 4, 6], dtype=np.uint8).reshape(1, 4, 1)) & 0x03).reshape(-1, 64)
-    return (d * (values.astype(np.int8) - 1).astype(np.float32)).reshape(rows, -1)
+    qs = blocks[:, 2:].reshape(-1, 16, 1)
+    values = ((qs >> np.array([0, 2, 4, 6], dtype=np.uint8).reshape(1, 1, 4)) & 0x03).reshape(-1, 64)
+    return (d * (values.astype(np.int8) - 1).astype(np.float32)).reshape(output_shape)
 
 
 def _dequantize_tq1_0_numpy(qweight: np.ndarray) -> np.ndarray:
-    rows = qweight.shape[0]
+    output_shape = _gguf_dequantized_shape(qweight, "TQ1_0")
     blocks = qweight.reshape(-1, _GGUF_TYPE_INFO["TQ1_0"]["type_size"])
     qs, qh, d = blocks[:, :48], blocks[:, 48:52], blocks[:, 52:]
     d = d.view(np.float16).astype(np.float32)
@@ -693,25 +704,25 @@ def _dequantize_tq1_0_numpy(qweight: np.ndarray) -> np.ndarray:
         axis=-1,
     )
     values = ((values.astype(np.uint16) * 3) >> 8).astype(np.int8) - 1
-    return (d * values.astype(np.float32)).reshape(rows, -1)
+    return (d * values.astype(np.float32)).reshape(output_shape)
 
 
 def _dequantize_tq2_0_numpy(qweight: np.ndarray) -> np.ndarray:
-    rows = qweight.shape[0]
+    output_shape = _gguf_dequantized_shape(qweight, "TQ2_0")
     blocks = qweight.reshape(-1, _GGUF_TYPE_INFO["TQ2_0"]["type_size"])
     qs, d = blocks[:, :64], blocks[:, 64:]
     d = d.view(np.float16).astype(np.float32)
     values = ((qs.reshape(-1, 2, 1, 32) >> np.array([0, 2, 4, 6], dtype=np.uint8).reshape(1, 1, 4, 1)) & 0x03)
-    return (d * (values.reshape(-1, 256).astype(np.int8) - 1).astype(np.float32)).reshape(rows, -1)
+    return (d * (values.reshape(-1, 256).astype(np.int8) - 1).astype(np.float32)).reshape(output_shape)
 
 
 def _dequantize_mxfp4_numpy(qweight: np.ndarray) -> np.ndarray:
-    rows = qweight.shape[0]
+    output_shape = _gguf_dequantized_shape(qweight, "MXFP4")
     blocks = qweight.reshape(-1, _GGUF_TYPE_INFO["MXFP4"]["type_size"])
     d = _gguf_e8m0_to_fp32_half(blocks[:, :1])
     qs = ((blocks[:, 1:].reshape(-1, 1, 16) >> np.array([0, 4], dtype=np.uint8).reshape(1, 2, 1)) & 0x0F)
     values = _GGUF_FP4_VALUES[qs].reshape(-1, 32)
-    return (d * values.astype(np.float32)).reshape(rows, -1)
+    return (d * values.astype(np.float32)).reshape(output_shape)
 
 
 def _gguf_ue4m3_to_fp32(values: np.ndarray) -> np.ndarray:
@@ -726,13 +737,13 @@ def _gguf_ue4m3_to_fp32(values: np.ndarray) -> np.ndarray:
 
 
 def _dequantize_nvfp4_numpy(qweight: np.ndarray) -> np.ndarray:
-    rows = qweight.shape[0]
+    output_shape = _gguf_dequantized_shape(qweight, "NVFP4")
     blocks = qweight.reshape(-1, _GGUF_TYPE_INFO["NVFP4"]["type_size"])
     scales = _gguf_ue4m3_to_fp32(blocks[:, :4]).reshape(-1, 4, 1)
     qs = blocks[:, 4:].reshape(-1, 4, 8)
     values = np.concatenate([qs & 0x0F, qs >> 4], axis=-1)
     values = _GGUF_FP4_VALUES[values].reshape(-1, 64)
-    return (scales * values.reshape(-1, 4, 16).astype(np.float32)).reshape(rows, -1)
+    return (scales * values.reshape(-1, 4, 16).astype(np.float32)).reshape(output_shape)
 
 
 def _dequantize_q5_k_numpy(qweight: np.ndarray) -> np.ndarray:

--- a/gptqmodel/nn_modules/qlinear/gguf.py
+++ b/gptqmodel/nn_modules/qlinear/gguf.py
@@ -43,17 +43,23 @@ except Exception:  # pragma: no cover - optional dependency
 setup_logger()
 
 _GGUF_TYPE_INFO = {
-    "Q1_0": {"bits": 1, "block_size": 32, "type_size": 6},
+    "Q1_0": {"bits": 1, "block_size": 128, "type_size": 18},
     "Q1_0_g128": {"bits": 1, "block_size": 128, "type_size": 18},
+    "Q2_0": {"bits": 2, "block_size": 64, "type_size": 18},
     "Q4_0": {"bits": 4, "block_size": 32, "type_size": 18},
     "Q8_0": {"bits": 8, "block_size": 32, "type_size": 34},
     "Q4_K": {"bits": 4, "block_size": 256, "type_size": 144},
     "Q5_K": {"bits": 5, "block_size": 256, "type_size": 176},
     "Q6_K": {"bits": 6, "block_size": 256, "type_size": 210},
+    "TQ1_0": {"bits": 1, "block_size": 256, "type_size": 54},
+    "TQ2_0": {"bits": 2, "block_size": 256, "type_size": 66},
+    "MXFP4": {"bits": 4, "block_size": 32, "type_size": 17},
+    "NVFP4": {"bits": 4, "block_size": 64, "type_size": 36},
 }
 _GGUF_BITS_ALIAS_TO_TENSOR_QTYPE = {
     "q1_0": "Q1_0",
     "q1_0_g128": "Q1_0_g128",
+    "q2_0": "Q2_0",
     "q4_0": "Q4_0",
     "q8_0": "Q8_0",
     "q4_k": "Q4_K",
@@ -72,7 +78,10 @@ PRISM_Q1_0_G128_VALUE = 41
 PRISM_Q1_0_G128_BLOCK_SIZE = 128
 PRISM_Q1_0_G128_TYPE_SIZE = 18
 _GGUF_SIGN_ONLY_TYPE_INFO = {
-    "Q1_0": {"block_size": 32, "type_size": 6},
+    "Q1_0": {
+        "block_size": PRISM_Q1_0_G128_BLOCK_SIZE,
+        "type_size": PRISM_Q1_0_G128_TYPE_SIZE,
+    },
     PRISM_Q1_0_G128_NAME: {
         "block_size": PRISM_Q1_0_G128_BLOCK_SIZE,
         "type_size": PRISM_Q1_0_G128_TYPE_SIZE,
@@ -87,8 +96,12 @@ _GGUF_TENSOR_QTYPE_BY_VALUE = {
     13: "Q5_K",
     14: "Q6_K",
     30: "BF16",
-    40: "Q1_0",
+    34: "TQ1_0",
+    35: "TQ2_0",
+    39: "MXFP4",
+    40: "NVFP4",
     PRISM_Q1_0_G128_VALUE: PRISM_Q1_0_G128_NAME,
+    42: "Q2_0",
 }
 _GGUF_SIGN_ONLY_LUT = (
     np.unpackbits(np.arange(256, dtype=np.uint8)[:, None], axis=1, bitorder="little").astype(np.int8) * 2 - 1
@@ -186,6 +199,78 @@ def _gguf_quantize_sign_only(blocks: np.ndarray, *, block_size: int) -> np.ndarr
     packed[:, :2] = scales.view(np.uint8).reshape(-1, 2)
     packed[:, 2:] = sign_bits
     return packed
+
+
+def _gguf_roundf(values: np.ndarray) -> np.ndarray:
+    return np.sign(values) * np.floor(np.abs(values) + 0.5)
+
+
+def _gguf_quantize_q2_0(blocks: np.ndarray) -> np.ndarray:
+    d = np.abs(blocks).max(axis=-1, keepdims=True)
+    with np.errstate(divide="ignore"):
+        inv_d = np.where(d == 0, 0, 1.0 / d)
+    qs = np.clip(_gguf_roundf(blocks * inv_d).astype(np.int8) + 1, 0, 3).astype(np.uint8)
+    qs = qs.reshape(blocks.shape[0], 4, 16)
+    packed = qs[:, 0] | (qs[:, 1] << 2) | (qs[:, 2] << 4) | (qs[:, 3] << 6)
+    return np.concatenate([d.astype(np.float16).view(np.uint8), packed], axis=-1)
+
+
+def _gguf_quantize_tq1_0(blocks: np.ndarray) -> np.ndarray:
+    d = np.abs(blocks).max(axis=-1, keepdims=True)
+    with np.errstate(divide="ignore"):
+        inv_d = np.where(d == 0, 0, 1.0 / d)
+    qs = (_gguf_roundf(blocks * inv_d).astype(np.int8) + 1).astype(np.uint8)
+
+    qs0, qs1, qh = qs[..., :160], qs[..., 160:240], qs[..., 240:]
+    qs0 = qs0.reshape(blocks.shape[0], -1, 5, 32) * np.array([81, 27, 9, 3, 1], dtype=np.uint8).reshape(1, 1, 5, 1)
+    qs1 = qs1.reshape(blocks.shape[0], -1, 5, 16) * np.array([81, 27, 9, 3, 1], dtype=np.uint8).reshape(1, 1, 5, 1)
+    qh = qh.reshape(blocks.shape[0], -1, 4, 4) * np.array([81, 27, 9, 3], dtype=np.uint8).reshape(1, 1, 4, 1)
+    qs = np.concatenate(
+        [
+            np.sum(qs0, axis=-2).reshape(blocks.shape[0], -1),
+            np.sum(qs1, axis=-2).reshape(blocks.shape[0], -1),
+            np.sum(qh, axis=-2).reshape(blocks.shape[0], -1),
+        ],
+        axis=-1,
+    )
+    qs = ((qs.astype(np.uint16) * 256 + 242) // 243).astype(np.uint8)
+    return np.concatenate([qs, d.astype(np.float16).view(np.uint8)], axis=-1)
+
+
+def _gguf_quantize_tq2_0(blocks: np.ndarray) -> np.ndarray:
+    d = np.abs(blocks).max(axis=-1, keepdims=True)
+    with np.errstate(divide="ignore"):
+        inv_d = np.where(d == 0, 0, 1.0 / d)
+    qs = (_gguf_roundf(blocks * inv_d).astype(np.int8) + 1).astype(np.uint8)
+    qs = qs.reshape(blocks.shape[0], -1, 4, 32)
+    packed = qs[..., 0, :] | (qs[..., 1, :] << 2) | (qs[..., 2, :] << 4) | (qs[..., 3, :] << 6)
+    return np.concatenate([packed.reshape(blocks.shape[0], -1), d.astype(np.float16).view(np.uint8)], axis=-1)
+
+
+_GGUF_FP4_VALUES = np.array((0, 1, 2, 3, 4, 6, 8, 12, 0, -1, -2, -3, -4, -6, -8, -12), dtype=np.int8)
+
+
+def _gguf_e8m0_to_fp32_half(values: np.ndarray) -> np.ndarray:
+    bits = np.where(
+        values < 2,
+        np.uint32(0x00200000) << values.astype(np.uint32),
+        (values.astype(np.uint32) - 1) << np.uint32(23),
+    )
+    return bits.view(np.float32)
+
+
+def _gguf_quantize_mxfp4(blocks: np.ndarray) -> np.ndarray:
+    d = np.abs(blocks).max(axis=-1, keepdims=True)
+    with np.errstate(divide="ignore"):
+        e = np.where(d > 0, np.floor(np.log2(d)) - 2 + 127, 0).astype(np.uint8)
+    scales = _gguf_e8m0_to_fp32_half(e)
+    errors = np.abs(
+        scales.reshape(blocks.shape[0], 1, 1) * _GGUF_FP4_VALUES.astype(np.float32).reshape(1, 1, 16)
+        - blocks.reshape(blocks.shape[0], 32, 1)
+    )
+    best = np.argmin(errors, axis=-1).reshape(blocks.shape[0], 2, 16).astype(np.uint8)
+    packed = best[:, 0] | (best[:, 1] << 4)
+    return np.concatenate([e, packed], axis=-1)
 
 
 def _pack_q4_k_scale_min(scales: np.ndarray, mins: np.ndarray) -> np.ndarray:
@@ -395,6 +480,8 @@ def _fallback_gguf_quantize(weight: np.ndarray, tensor_qtype: str) -> np.ndarray
     blocks = weight.reshape(-1, block_size)
     if tensor_qtype in _GGUF_SIGN_ONLY_TYPE_INFO:
         quantized_blocks = _gguf_quantize_sign_only(blocks, block_size=block_size)
+    elif tensor_qtype == "Q2_0":
+        quantized_blocks = _gguf_quantize_q2_0(blocks)
     elif tensor_qtype == "Q4_0":
         quantized_blocks = _gguf_quantize_q4_0(blocks)
     elif tensor_qtype == "Q8_0":
@@ -405,6 +492,12 @@ def _fallback_gguf_quantize(weight: np.ndarray, tensor_qtype: str) -> np.ndarray
         quantized_blocks = _gguf_quantize_q5_k(blocks)
     elif tensor_qtype == "Q6_K":
         quantized_blocks = _gguf_quantize_q6_k(blocks)
+    elif tensor_qtype == "TQ1_0":
+        quantized_blocks = _gguf_quantize_tq1_0(blocks)
+    elif tensor_qtype == "TQ2_0":
+        quantized_blocks = _gguf_quantize_tq2_0(blocks)
+    elif tensor_qtype == "MXFP4":
+        quantized_blocks = _gguf_quantize_mxfp4(blocks)
     else:  # pragma: no cover - guarded by class SUPPORTS_BITS
         raise NotImplementedError(f"Unsupported GGUF qtype: {tensor_qtype}")
 
@@ -443,7 +536,7 @@ def _resolve_gguf_tensor_qtype(tensor_type) -> str:
 
 
 def _is_prism_q1_0_g128(tensor_type) -> bool:
-    return _resolve_gguf_tensor_qtype(tensor_type) == PRISM_Q1_0_G128_NAME
+    return _resolve_gguf_tensor_qtype(tensor_type) in {"Q1_0", PRISM_Q1_0_G128_NAME}
 
 
 def _dequantize_sign_only_numpy(
@@ -574,6 +667,74 @@ def _dequantize_q4_k_numpy(qweight: np.ndarray) -> np.ndarray:
     return (d * q - dm).reshape(rows, -1)
 
 
+def _dequantize_q2_0_numpy(qweight: np.ndarray) -> np.ndarray:
+    rows = qweight.shape[0]
+    blocks = qweight.reshape(-1, _GGUF_TYPE_INFO["Q2_0"]["type_size"])
+    d = blocks[:, :2].view(np.float16).astype(np.float32)
+    qs = blocks[:, 2:].reshape(-1, 1, 16)
+    values = ((qs >> np.array([0, 2, 4, 6], dtype=np.uint8).reshape(1, 4, 1)) & 0x03).reshape(-1, 64)
+    return (d * (values.astype(np.int8) - 1).astype(np.float32)).reshape(rows, -1)
+
+
+def _dequantize_tq1_0_numpy(qweight: np.ndarray) -> np.ndarray:
+    rows = qweight.shape[0]
+    blocks = qweight.reshape(-1, _GGUF_TYPE_INFO["TQ1_0"]["type_size"])
+    qs, qh, d = blocks[:, :48], blocks[:, 48:52], blocks[:, 52:]
+    d = d.view(np.float16).astype(np.float32)
+    qs0 = qs[:, :32].reshape(-1, 1, 1, 32) * np.array([1, 3, 9, 27, 81], dtype=np.uint8).reshape(1, 1, 5, 1)
+    qs1 = qs[:, 32:].reshape(-1, 1, 1, 16) * np.array([1, 3, 9, 27, 81], dtype=np.uint8).reshape(1, 1, 5, 1)
+    qh = qh.reshape(-1, 1, 1, 4) * np.array([1, 3, 9, 27], dtype=np.uint8).reshape(1, 1, 4, 1)
+    values = np.concatenate(
+        [
+            qs0.reshape(blocks.shape[0], -1),
+            qs1.reshape(blocks.shape[0], -1),
+            qh.reshape(blocks.shape[0], -1),
+        ],
+        axis=-1,
+    )
+    values = ((values.astype(np.uint16) * 3) >> 8).astype(np.int8) - 1
+    return (d * values.astype(np.float32)).reshape(rows, -1)
+
+
+def _dequantize_tq2_0_numpy(qweight: np.ndarray) -> np.ndarray:
+    rows = qweight.shape[0]
+    blocks = qweight.reshape(-1, _GGUF_TYPE_INFO["TQ2_0"]["type_size"])
+    qs, d = blocks[:, :64], blocks[:, 64:]
+    d = d.view(np.float16).astype(np.float32)
+    values = ((qs.reshape(-1, 2, 1, 32) >> np.array([0, 2, 4, 6], dtype=np.uint8).reshape(1, 1, 4, 1)) & 0x03)
+    return (d * (values.reshape(-1, 256).astype(np.int8) - 1).astype(np.float32)).reshape(rows, -1)
+
+
+def _dequantize_mxfp4_numpy(qweight: np.ndarray) -> np.ndarray:
+    rows = qweight.shape[0]
+    blocks = qweight.reshape(-1, _GGUF_TYPE_INFO["MXFP4"]["type_size"])
+    d = _gguf_e8m0_to_fp32_half(blocks[:, :1])
+    qs = ((blocks[:, 1:].reshape(-1, 1, 16) >> np.array([0, 4], dtype=np.uint8).reshape(1, 2, 1)) & 0x0F)
+    values = _GGUF_FP4_VALUES[qs].reshape(-1, 32)
+    return (d * values.astype(np.float32)).reshape(rows, -1)
+
+
+def _gguf_ue4m3_to_fp32(values: np.ndarray) -> np.ndarray:
+    exponent = ((values >> 3) & 0x0F).astype(np.int32)
+    mantissa = (values & 0x07).astype(np.float32)
+    decoded = np.where(
+        exponent == 0,
+        mantissa * (2.0**-9),
+        (1.0 + mantissa / 8.0) * (2.0 ** (exponent.astype(np.float32) - 7)),
+    )
+    return np.where((values == 0) | (values == 0x7F), 0.0, decoded * 0.5)
+
+
+def _dequantize_nvfp4_numpy(qweight: np.ndarray) -> np.ndarray:
+    rows = qweight.shape[0]
+    blocks = qweight.reshape(-1, _GGUF_TYPE_INFO["NVFP4"]["type_size"])
+    scales = _gguf_ue4m3_to_fp32(blocks[:, :4]).reshape(-1, 4, 1)
+    qs = blocks[:, 4:].reshape(-1, 4, 8)
+    values = np.concatenate([qs & 0x0F, qs >> 4], axis=-1)
+    values = _GGUF_FP4_VALUES[values].reshape(-1, 64)
+    return (scales * values.reshape(-1, 4, 16).astype(np.float32)).reshape(rows, -1)
+
+
 def _dequantize_q5_k_numpy(qweight: np.ndarray) -> np.ndarray:
     rows = qweight.shape[0]
     type_size = _GGUF_TYPE_INFO["Q5_K"]["type_size"]
@@ -648,12 +809,22 @@ def _dequantize_gguf_tensor_numpy(data: np.ndarray, tensor_type) -> np.ndarray:
         d = blocks[:, :2].view(np.float16).astype(np.float32)
         q = blocks[:, 2:].view(np.int8).astype(np.float32)
         return (d * q).reshape(rows.shape[0], -1)
+    if resolved_qtype == "Q2_0":
+        return _dequantize_q2_0_numpy(np.asarray(data, dtype=np.uint8))
     if resolved_qtype == "Q4_K":
         return _dequantize_q4_k_numpy(np.asarray(data, dtype=np.uint8))
     if resolved_qtype == "Q5_K":
         return _dequantize_q5_k_numpy(np.asarray(data, dtype=np.uint8))
     if resolved_qtype == "Q6_K":
         return _dequantize_q6_k_numpy(np.asarray(data, dtype=np.uint8))
+    if resolved_qtype == "TQ1_0":
+        return _dequantize_tq1_0_numpy(np.asarray(data, dtype=np.uint8))
+    if resolved_qtype == "TQ2_0":
+        return _dequantize_tq2_0_numpy(np.asarray(data, dtype=np.uint8))
+    if resolved_qtype == "MXFP4":
+        return _dequantize_mxfp4_numpy(np.asarray(data, dtype=np.uint8))
+    if resolved_qtype == "NVFP4":
+        return _dequantize_nvfp4_numpy(np.asarray(data, dtype=np.uint8))
     if resolved_qtype == "Q1_0":
         return _dequantize_sign_only_numpy(
             data,
@@ -670,7 +841,7 @@ class GGUFTorchLinear(WeightOnlyQuantLinear):
     SUPPORTS_BACKENDS = [BACKEND.GGUF_TORCH]
     SUPPORTS_METHODS = [METHOD.GGUF]
     SUPPORTS_FORMATS = {FORMAT.GGUF: 15}
-    SUPPORTS_BITS = [1, 4, 5, 6, 8]
+    SUPPORTS_BITS = [1, 2, 4, 5, 6, 8]
     SUPPORTS_SHARDS = True
     SUPPORTS_TRAINING = True
     SUPPORTS_AUTO_PADDING = True
@@ -1069,6 +1240,8 @@ class GGUFTorchLinear(WeightOnlyQuantLinear):
             weight = self._dequantize_q8_0(device=device, dtype=dtype)
         elif self.gguf_tensor_qtype in _GGUF_SIGN_ONLY_TYPE_INFO:
             weight = self._dequantize_sign_only(device=device, dtype=dtype)
+        elif self.gguf_tensor_qtype == "Q2_0":
+            weight = self._dequantize_numpy(_dequantize_q2_0_numpy, device=device, dtype=dtype)
         elif self.gguf_tensor_qtype == "Q4_K":
             target_device, target_dtype = self._resolve_dequant_target(device=device, dtype=dtype)
             blocks, _, _ = self._reshape_blocks(device=target_device)

--- a/gptqmodel/nn_modules/qlinear/gguf_triton.py
+++ b/gptqmodel/nn_modules/qlinear/gguf_triton.py
@@ -1403,10 +1403,10 @@ class GGUFTritonKernel(GGUFTorchLinear):
             register_buffers=register_buffers,
             **kwargs,
         )
-        if self.gguf_tensor_qtype not in {"Q1_0_g128", "Q4_K", "Q5_K", "Q6_K"}:
+        if self.gguf_tensor_qtype not in {"Q1_0", "Q1_0_g128", "Q4_K", "Q5_K", "Q6_K"}:
             raise NotImplementedError(
                 f"{self.__class__.__name__} only supports fused GGUF Triton formats "
-                f"(Q1_0_g128, Q4_K, Q5_K, Q6_K). Actual GGUF qtype: {self.gguf_tensor_qtype}. "
+                f"(Q1_0, Q4_K, Q5_K, Q6_K). Actual GGUF qtype: {self.gguf_tensor_qtype}. "
                 "Use BACKEND.GGUF_TORCH for unsupported GGUF formats."
             )
         self._gguf_triton_cache: dict[tuple[int, str], dict[str, Any]] = {}
@@ -1435,7 +1435,7 @@ class GGUFTritonKernel(GGUFTorchLinear):
     def _build_triton_cache(self, device: torch.device) -> dict[str, Any]:
         blocks, _, _ = self._reshape_blocks(device=device)
 
-        if self.gguf_tensor_qtype == "Q1_0_g128":
+        if self.gguf_tensor_qtype in {"Q1_0", "Q1_0_g128"}:
             scale = blocks[..., :2].contiguous().view(torch.float16).squeeze(-1).permute(1, 0).contiguous()
             capability = _cuda_device_capability(device)
             if _select_q1_0_g128_u32_layout(
@@ -1543,7 +1543,7 @@ class GGUFTritonKernel(GGUFTorchLinear):
 
         cache = self._get_triton_cache(x_work.device)
 
-        if self.gguf_tensor_qtype == "Q1_0_g128":
+        if self.gguf_tensor_qtype in {"Q1_0", "Q1_0_g128"}:
             if cache.get("use_u32"):
                 fixed_u32_config = _select_q1_0_g128_u32_fixed_launch_config(
                     capability=_cuda_device_capability(x_work.device),

--- a/gptqmodel/quantization/config.py
+++ b/gptqmodel/quantization/config.py
@@ -200,6 +200,7 @@ class PreProcessorCode(str, Enum):
 _GGUF_BITS_ALIAS_INFO = {
     "q1_0": {"bits": 1, "version": "q", "variant": "0", "quality": None},
     "q1_0_g128": {"bits": 1, "version": "q", "variant": "0", "quality": "g128"},
+    "q2_0": {"bits": 2, "version": "q", "variant": "0", "quality": None},
     "q4_0": {"bits": 4, "version": "q", "variant": "0", "quality": None},
     "q8_0": {"bits": 8, "version": "q", "variant": "0", "quality": None},
     "q4_k": {"bits": 4, "version": "q", "variant": "k", "quality": None},
@@ -212,14 +213,16 @@ _GGUF_BITS_ALIAS_INFO = {
 }
 _GGUF_DEFAULT_BITS_ALIAS_BY_WIDTH = {
     1: "q1_0",
+    2: "q2_0",
     4: "q4_0",
     5: "q5_k_m",
     6: "q6_k",
     8: "q8_0",
 }
 _GGUF_APPROX_BITS_PER_WEIGHT_BY_ALIAS = {
-    "q1_0": 1.5,
+    "q1_0": 1.125,
     "q1_0_g128": 1.125,
+    "q2_0": 2.25,
     "q4_0": 4.5,
     "q8_0": 8.5,
     "q4_k": 4.5,

--- a/gptqmodel/utils/internal_gguf.py
+++ b/gptqmodel/utils/internal_gguf.py
@@ -21,7 +21,7 @@ from ..nn_modules.qlinear.gguf import (
 )
 
 
-__version__ = "0.10.0"
+__version__ = "0.19.0"
 _INTERNAL_GGUF_DEQUANT_DEVICE_ENV = "GPTQMODEL_INTERNAL_GGUF_DEQUANT_DEVICE"
 _INTERNAL_GGUF_DEQUANT_MAX_BYTES_ENV = "GPTQMODEL_INTERNAL_GGUF_DEQUANT_MAX_BYTES"
 _INTERNAL_GGUF_DEQUANT_DEFAULT_MAX_BYTES = 256 * 1024 * 1024
@@ -67,8 +67,10 @@ class GGMLQuantizationType(IntEnum):
     TQ1_0 = 34
     TQ2_0 = 35
     MXFP4 = 39
-    Q1_0 = 40
-    Q1_0_g128 = 41
+    NVFP4 = 40
+    Q1_0 = 41
+    Q1_0_g128 = Q1_0
+    Q2_0 = 42
 
 
 class GGUFEndian(IntEnum):
@@ -125,12 +127,12 @@ GGML_QUANT_SIZES: dict[GGMLQuantizationType, tuple[int, int]] = {
     GGMLQuantizationType.TQ1_0: (256, 2 + 4 * 13),
     GGMLQuantizationType.TQ2_0: (256, 2 + 64),
     GGMLQuantizationType.MXFP4: (32, 1 + 16),
-    GGMLQuantizationType.Q1_0: (32, 2 + 4),
-    GGMLQuantizationType.Q1_0_g128: (128, 2 + 16),
+    GGMLQuantizationType.NVFP4: (64, 4 + 32),
+    GGMLQuantizationType.Q1_0: (128, 2 + 16),
+    GGMLQuantizationType.Q2_0: (64, 2 + 16),
 }
 _TORCH_SIGN_ONLY_QTYPES: dict[GGMLQuantizationType, tuple[int, int]] = {
     GGMLQuantizationType.Q1_0: GGML_QUANT_SIZES[GGMLQuantizationType.Q1_0],
-    GGMLQuantizationType.Q1_0_g128: GGML_QUANT_SIZES[GGMLQuantizationType.Q1_0_g128],
 }
 
 MODEL_ARCH_QWEN3 = "qwen3"
@@ -174,7 +176,7 @@ _QWEN3_LINEAR_TENSOR_RE = pcre.compile(
 )
 _GGUF_BITS_ALIAS_BY_QTYPE: dict[GGMLQuantizationType, str] = {
     GGMLQuantizationType.Q1_0: "q1_0",
-    GGMLQuantizationType.Q1_0_g128: "q1_0_g128",
+    GGMLQuantizationType.Q2_0: "q2_0",
     GGMLQuantizationType.Q4_0: "q4_0",
     GGMLQuantizationType.Q8_0: "q8_0",
     GGMLQuantizationType.Q4_K: "q4_k",

--- a/tests/test_internal_gguf.py
+++ b/tests/test_internal_gguf.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 import torch
 
+from gptqmodel.nn_modules.qlinear import gguf as gguf_qlinear
 from gptqmodel.utils import internal_gguf
 
 
@@ -82,6 +83,40 @@ def test_internal_gguf_quantizes_and_dequantizes_official_q2_0_blocks():
 
     np.testing.assert_array_equal(actual_packed, expected_packed)
     np.testing.assert_allclose(actual_values, values, rtol=0.0, atol=0.0)
+
+
+@pytest.mark.parametrize(
+    ("tensor_qtype", "block_size"),
+    [
+        (internal_gguf.GGMLQuantizationType.Q2_0, 64),
+        (internal_gguf.GGMLQuantizationType.TQ1_0, 256),
+        (internal_gguf.GGMLQuantizationType.TQ2_0, 256),
+    ],
+)
+def test_internal_gguf_fallback_rounds_float32_half_thresholds(monkeypatch, tensor_qtype, block_size):
+    monkeypatch.setattr(gguf_qlinear, "_GGUF_AVAILABLE", False)
+    positive_below = np.nextafter(np.float32(0.5), np.float32(0.0))
+    positive_above = np.nextafter(np.float32(0.5), np.float32(1.0))
+    negative_below = np.nextafter(np.float32(-0.5), np.float32(-1.0))
+    negative_above = np.nextafter(np.float32(-0.5), np.float32(0.0))
+
+    values = np.zeros((1, block_size), dtype=np.float32)
+    values[0, :7] = [
+        1.0,
+        positive_below,
+        0.5,
+        positive_above,
+        negative_below,
+        -0.5,
+        negative_above,
+    ]
+    expected = np.zeros_like(values)
+    expected[0, :7] = [1.0, 0.0, 1.0, 1.0, -1.0, -1.0, 0.0]
+
+    packed = internal_gguf.quantize(values, tensor_qtype)
+    actual = internal_gguf.dequantize(packed, tensor_qtype)
+
+    np.testing.assert_array_equal(actual, expected)
 
 
 def test_internal_gguf_dequantizes_nvfp4_blocks():

--- a/tests/test_internal_gguf.py
+++ b/tests/test_internal_gguf.py
@@ -2,14 +2,46 @@ import struct
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 import torch
 
 from gptqmodel.utils import internal_gguf
 
 
+def test_internal_gguf_types_match_current_upstream_assignments():
+    assert int(internal_gguf.GGMLQuantizationType.NVFP4) == 40
+    assert int(internal_gguf.GGMLQuantizationType.Q1_0) == 41
+    assert int(internal_gguf.GGMLQuantizationType.Q2_0) == 42
+    assert internal_gguf.GGMLQuantizationType.Q1_0_g128 is internal_gguf.GGMLQuantizationType.Q1_0
+
+    assert internal_gguf.GGML_QUANT_SIZES[internal_gguf.GGMLQuantizationType.NVFP4] == (64, 36)
+    assert internal_gguf.GGML_QUANT_SIZES[internal_gguf.GGMLQuantizationType.Q1_0] == (128, 18)
+    assert internal_gguf.GGML_QUANT_SIZES[internal_gguf.GGMLQuantizationType.Q2_0] == (64, 18)
+
+
 def _encode_gguf_string(value: str) -> bytes:
     data = value.encode("utf-8")
     return struct.pack("<Q", len(data)) + data
+
+
+def _write_minimal_gguf_tensor(tmp_path, *, tensor_type, shape, data):
+    payload = bytearray()
+    payload.extend(struct.pack("<I", internal_gguf.GGUF_MAGIC))
+    payload.extend(struct.pack("<I", internal_gguf.GGUF_VERSION))
+    payload.extend(struct.pack("<Q", 1))
+    payload.extend(struct.pack("<Q", 0))
+    payload.extend(_encode_gguf_string("weight"))
+    payload.extend(struct.pack("<I", len(shape)))
+    for dimension in shape:
+        payload.extend(struct.pack("<Q", dimension))
+    payload.extend(struct.pack("<I", int(tensor_type)))
+    payload.extend(struct.pack("<Q", 0))
+    payload.extend(b"\x00" * ((-len(payload)) % internal_gguf.GGUF_DEFAULT_ALIGNMENT))
+    payload.extend(data)
+
+    path = tmp_path / f"minimal-{tensor_type.name.lower()}.gguf"
+    path.write_bytes(payload)
+    return path
 
 
 def test_internal_gguf_dequantizes_prism_q1_0_g128_blocks():
@@ -20,6 +52,42 @@ def test_internal_gguf_dequantizes_prism_q1_0_g128_blocks():
 
     actual = internal_gguf.dequantize(row, internal_gguf.GGMLQuantizationType.Q1_0_g128)
     expected = np.where(sign_bits == 1, np.float32(1.5), np.float32(-1.5)).reshape(1, 128)
+
+    np.testing.assert_allclose(actual, expected, rtol=0.0, atol=0.0)
+
+
+def test_internal_gguf_quantizes_official_q1_0_blocks():
+    values = np.linspace(-2.0, 2.0, 128, dtype=np.float32).reshape(1, -1)
+
+    packed = internal_gguf.quantize(values, internal_gguf.GGMLQuantizationType.Q1_0)
+    actual = internal_gguf.dequantize(packed, internal_gguf.GGMLQuantizationType.Q1_0)
+
+    expected_scale = np.mean(np.abs(values)).astype(np.float16).astype(np.float32)
+    expected = np.where(values >= 0, expected_scale, -expected_scale)
+    assert packed.shape == (1, 18)
+    np.testing.assert_allclose(actual, expected, rtol=0.0, atol=0.0)
+
+
+def test_internal_gguf_dequantizes_official_q2_0_blocks():
+    scale = np.array([2.0], dtype=np.float16).view(np.uint8)
+    codes = np.tile(np.array([0, 1, 2, 3], dtype=np.uint8).reshape(4, 1), (1, 16))
+    packed_codes = codes[0] | (codes[1] << 2) | (codes[2] << 4) | (codes[3] << 6)
+    packed = np.concatenate([scale, packed_codes]).reshape(1, -1)
+
+    actual = internal_gguf.dequantize(packed, internal_gguf.GGMLQuantizationType.Q2_0)
+    expected = np.repeat(np.array([[-2.0], [0.0], [2.0], [4.0]], dtype=np.float32), 16, axis=1).reshape(1, -1)
+
+    np.testing.assert_allclose(actual, expected, rtol=0.0, atol=0.0)
+
+
+def test_internal_gguf_dequantizes_nvfp4_blocks():
+    scales = np.full(4, 64, dtype=np.uint8)
+    packed_values = np.full(32, 0x91, dtype=np.uint8)
+    packed = np.concatenate([scales, packed_values]).reshape(1, -1)
+
+    actual = internal_gguf.dequantize(packed, internal_gguf.GGMLQuantizationType.NVFP4)
+    expected_group = np.concatenate([np.ones(8, dtype=np.float32), -np.ones(8, dtype=np.float32)])
+    expected = np.tile(expected_group, 4).reshape(1, -1)
 
     np.testing.assert_allclose(actual, expected, rtol=0.0, atol=0.0)
 
@@ -69,25 +137,12 @@ def test_internal_gguf_dequantize_to_torch_returns_exact_prism_tensor():
 
 def test_internal_gguf_reader_reads_minimal_f32_tensor(tmp_path):
     tensor = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
-
-    payload = bytearray()
-    payload.extend(struct.pack("<I", internal_gguf.GGUF_MAGIC))
-    payload.extend(struct.pack("<I", internal_gguf.GGUF_VERSION))
-    payload.extend(struct.pack("<Q", 1))  # tensor_count
-    payload.extend(struct.pack("<Q", 0))  # kv_count
-    payload.extend(_encode_gguf_string("weight"))
-    payload.extend(struct.pack("<I", 2))  # n_dims
-    payload.extend(struct.pack("<Q", 2))
-    payload.extend(struct.pack("<Q", 2))
-    payload.extend(struct.pack("<I", int(internal_gguf.GGMLQuantizationType.F32)))
-    payload.extend(struct.pack("<Q", 0))
-
-    padding = (-len(payload)) % internal_gguf.GGUF_DEFAULT_ALIGNMENT
-    payload.extend(b"\x00" * padding)
-    payload.extend(tensor.tobytes())
-
-    path = tmp_path / "minimal.gguf"
-    path.write_bytes(payload)
+    path = _write_minimal_gguf_tensor(
+        tmp_path,
+        tensor_type=internal_gguf.GGMLQuantizationType.F32,
+        shape=(2, 2),
+        data=tensor.tobytes(),
+    )
 
     reader = internal_gguf.GGUFReader(path)
 
@@ -97,7 +152,31 @@ def test_internal_gguf_reader_reads_minimal_f32_tensor(tmp_path):
     np.testing.assert_allclose(reader.tensors[0].data, tensor, rtol=0.0, atol=0.0)
 
 
-def test_internal_gguf_inspect_quantized_checkpoint_detects_qwen3_prism_spec():
+def test_internal_gguf_reader_uses_current_nvfp4_storage_size(tmp_path):
+    packed = np.arange(36, dtype=np.uint8)
+    path = _write_minimal_gguf_tensor(
+        tmp_path,
+        tensor_type=internal_gguf.GGMLQuantizationType.NVFP4,
+        shape=(64,),
+        data=packed.tobytes(),
+    )
+
+    tensor = internal_gguf.GGUFReader(path).tensors[0]
+
+    assert tensor.tensor_type == internal_gguf.GGMLQuantizationType.NVFP4
+    assert tensor.n_elements == 64
+    assert tensor.n_bytes == 36
+    np.testing.assert_array_equal(tensor.data, packed)
+
+
+@pytest.mark.parametrize(
+    ("tensor_qtype", "bits_alias"),
+    [
+        (internal_gguf.GGMLQuantizationType.Q1_0, "q1_0"),
+        (internal_gguf.GGMLQuantizationType.Q2_0, "q2_0"),
+    ],
+)
+def test_internal_gguf_inspect_quantized_checkpoint_detects_qwen3_spec(tensor_qtype, bits_alias):
     class _Field:
         def __init__(self, value):
             self._value = value
@@ -110,15 +189,15 @@ def test_internal_gguf_inspect_quantized_checkpoint_detects_qwen3_prism_spec():
         tensors=[
             SimpleNamespace(
                 name="blk.0.attn_q.weight",
-                tensor_type=internal_gguf.GGMLQuantizationType.Q1_0_g128,
+                tensor_type=tensor_qtype,
             ),
             SimpleNamespace(
                 name="blk.0.ffn_gate.weight",
-                tensor_type=internal_gguf.GGMLQuantizationType.Q1_0_g128,
+                tensor_type=tensor_qtype,
             ),
             SimpleNamespace(
                 name="output.weight",
-                tensor_type=internal_gguf.GGMLQuantizationType.Q1_0_g128,
+                tensor_type=tensor_qtype,
             ),
         ],
         get_field=lambda key: _Field("qwen3") if key == "general.architecture" else None,
@@ -128,6 +207,6 @@ def test_internal_gguf_inspect_quantized_checkpoint_detects_qwen3_prism_spec():
 
     assert spec is not None
     assert spec.model_type == internal_gguf.MODEL_ARCH_QWEN3
-    assert spec.bits_alias == "q1_0_g128"
-    assert spec.tensor_qtype == internal_gguf.GGMLQuantizationType.Q1_0_g128
+    assert spec.bits_alias == bits_alias
+    assert spec.tensor_qtype == tensor_qtype
     assert spec.lm_head_quantized is True

--- a/tests/test_internal_gguf.py
+++ b/tests/test_internal_gguf.py
@@ -68,16 +68,20 @@ def test_internal_gguf_quantizes_official_q1_0_blocks():
     np.testing.assert_allclose(actual, expected, rtol=0.0, atol=0.0)
 
 
-def test_internal_gguf_dequantizes_official_q2_0_blocks():
-    scale = np.array([2.0], dtype=np.float16).view(np.uint8)
-    codes = np.tile(np.array([0, 1, 2, 3], dtype=np.uint8).reshape(4, 1), (1, 16))
-    packed_codes = codes[0] | (codes[1] << 2) | (codes[2] << 4) | (codes[3] << 6)
-    packed = np.concatenate([scale, packed_codes]).reshape(1, -1)
+def test_internal_gguf_quantizes_and_dequantizes_official_q2_0_blocks():
+    values = np.tile(np.array([-1.0, 0.0, 1.0, 0.0], dtype=np.float32), 16).reshape(1, -1)
+    expected_packed = np.concatenate(
+        [
+            np.array([1.0], dtype=np.float16).view(np.uint8),
+            np.full(16, 0x64, dtype=np.uint8),
+        ]
+    ).reshape(1, -1)
 
-    actual = internal_gguf.dequantize(packed, internal_gguf.GGMLQuantizationType.Q2_0)
-    expected = np.repeat(np.array([[-2.0], [0.0], [2.0], [4.0]], dtype=np.float32), 16, axis=1).reshape(1, -1)
+    actual_packed = internal_gguf.quantize(values, internal_gguf.GGMLQuantizationType.Q2_0)
+    actual_values = internal_gguf.dequantize(expected_packed, internal_gguf.GGMLQuantizationType.Q2_0)
 
-    np.testing.assert_allclose(actual, expected, rtol=0.0, atol=0.0)
+    np.testing.assert_array_equal(actual_packed, expected_packed)
+    np.testing.assert_allclose(actual_values, values, rtol=0.0, atol=0.0)
 
 
 def test_internal_gguf_dequantizes_nvfp4_blocks():
@@ -90,6 +94,27 @@ def test_internal_gguf_dequantizes_nvfp4_blocks():
     expected = np.tile(expected_group, 4).reshape(1, -1)
 
     np.testing.assert_allclose(actual, expected, rtol=0.0, atol=0.0)
+
+
+@pytest.mark.parametrize(
+    ("tensor_qtype", "type_size", "block_size"),
+    [
+        (internal_gguf.GGMLQuantizationType.Q2_0, 18, 64),
+        (internal_gguf.GGMLQuantizationType.TQ1_0, 54, 256),
+        (internal_gguf.GGMLQuantizationType.TQ2_0, 66, 256),
+        (internal_gguf.GGMLQuantizationType.MXFP4, 17, 32),
+        (internal_gguf.GGMLQuantizationType.NVFP4, 36, 64),
+    ],
+)
+def test_internal_gguf_new_dequantizers_preserve_leading_dimensions(tensor_qtype, type_size, block_size):
+    one_dimensional = internal_gguf.dequantize(np.zeros(type_size, dtype=np.uint8), tensor_qtype)
+    stacked = internal_gguf.dequantize(np.zeros((2, 3, type_size * 2), dtype=np.uint8), tensor_qtype)
+
+    assert one_dimensional.shape == (block_size,)
+    assert stacked.shape == (2, 3, block_size * 2)
+
+    with pytest.raises(ValueError, match="row byte width"):
+        internal_gguf.dequantize(np.zeros(type_size + 1, dtype=np.uint8), tensor_qtype)
 
 
 def test_internal_gguf_dequantize_uses_torch_sign_only_path_when_requested(monkeypatch):
@@ -167,6 +192,7 @@ def test_internal_gguf_reader_uses_current_nvfp4_storage_size(tmp_path):
     assert tensor.n_elements == 64
     assert tensor.n_bytes == 36
     np.testing.assert_array_equal(tensor.data, packed)
+    assert internal_gguf.dequantize(tensor.data, tensor.tensor_type).shape == (64,)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_weight_only.py
+++ b/tests/test_weight_only.py
@@ -639,7 +639,7 @@ def test_rtn_microbench_gguf_export_accepts_structured_bits():
     assert output_stats["max"] < 0.012
 
 
-@pytest.mark.parametrize("bits", ["q4_0", "q4_k_m"])
+@pytest.mark.parametrize("bits", ["q2_0", "q4_0", "q4_k_m"])
 def test_gguf_dequantize_weight_accepts_requested_dtype_and_device(bits: str):
     dtype = torch.float16 if torch.cuda.is_available() else torch.bfloat16
     case = _build_rtn_microbench_case(dtype, bits=bits)

--- a/tests/test_weight_only_config.py
+++ b/tests/test_weight_only_config.py
@@ -356,6 +356,16 @@ def test_gguf_bits_string_parser_round_trip():
     assert int(bits) == 4
 
 
+def test_gguf_q2_0_bits_string_parser_round_trip():
+    bits = GGUFBits.from_string("q2_0")
+
+    assert bits.bits == 2
+    assert bits.version == "q"
+    assert bits.variant == "0"
+    assert bits.quality is None
+    assert bits.to_string() == "q2_0"
+
+
 def test_weight_only_payload_dispatches_to_rtn():
     cfg = QuantizeConfig(
         bits=4,


### PR DESCRIPTION
## Summary

Synchronize GPTQModel's native GGUF tensor IDs, storage layouts, codecs, and runtime routing with llama.cpp `3ad1ba733` / gguf-py `0.19.0`, while retaining Prism/Bonsai `Q1_0_g128` as an alias for the official 128-element `Q1_0` layout.

## What Changed

- Match current upstream IDs and block sizes for `NVFP4=40`, `Q1_0=41`, and `Q2_0=42`; add reader/checkpoint coverage for the updated layouts.
- Add native NumPy quantization/dequantization for `Q2_0`, `TQ1_0`, `TQ2_0`, and `MXFP4`, plus `NVFP4` dequantization; make official `Q1_0` use the existing compatible 128-element sign-only codec.
- Pack Q2_0 as four consecutive weights per byte, matching llama.cpp, and preserve arbitrary leading dimensions when dequantizing all newly added formats.
- Match upstream `roundf` semantics at float32 half-way boundaries for Q2_0, TQ1_0, and TQ2_0 fallback quantization.
- Add public `q2_0` configuration support and route current Q1/Q2 checkpoints only to native backends that implement their layouts.
- Keep accelerated C++/CUDA support unchanged; those bridges do not currently expose the new formats. NVFP4 export is intentionally out of scope.

## Tests

- [x] I added a new simple/fast unit test for this change, or documented why that is not applicable.
- [x] I ran the new targeted test locally before opening this PR.
- [x] I ran any other directly relevant local tests.

```bash
cd tests
python -m pytest test_internal_gguf.py -x -q
# 19 passed
python -m pytest test_internal_gguf.py test_weight_only_config.py qcfg/test_config_dispatch.py -x -q
# 64 passed before the final three threshold cases were added
python -m pytest test_local_model_paths.py -k 'native_bonsai or local_gguf or gguf_file' -x -q
# 7 passed, 16 deselected
python -m pytest test_weight_only.py -k 'gguf_dequantize_weight_accepts_requested_dtype_and_device or gguf_triton_q1_0_g128_fused_forward_matches_dense_baseline' -x -q
# 3 passed, 1 skipped, 76 deselected
python -m pytest test_gguf_qlinear_llama.py -x -q
# 2 skipped: optional model/runtime fixture unavailable
python -m pytest kernels/test_gguf_cpp.py -x -q
# 13 skipped: optional llama.cpp/CUDA bridge unavailable

cd ..
ruff check --select E4,E7,E9,F gptqmodel/utils/internal_gguf.py gptqmodel/nn_modules/qlinear/gguf.py gptqmodel/nn_modules/qlinear/gguf_triton.py gptqmodel/models/loader.py gptqmodel/quantization/config.py tests/test_internal_gguf.py tests/test_weight_only.py tests/test_weight_only_config.py
# All checks passed
```

Randomized TQ1_0, TQ2_0, MXFP4, and NVFP4 codec results match the cited upstream gguf-py implementation. Q2_0 encoding and decoding also match the cited llama.cpp consecutive-weight byte layout and its independent `0x64` fixture. The float32 threshold regression also matches system C `roundf` immediately below, at, and above both `+0.5` and `-0.5`.

The full `test_weight_only.py` suite reaches a pre-existing environment failure because TorchInductor cannot compile without `Python.h`; the same first test fails on an untouched `main` worktree.

## Review Requirements

AI-assisted code is welcome.

Every changed file must still be properly reviewed by a human before the PR is opened as ready for review.

We will not accept PRs that are effectively unreviewed AI output. Non-human-reviewed changes often introduce obscure structure, mismatched APIs, project-inconsistent code patterns, or unnecessary monkeypatching instead of a correct fix or clean feature expansion.

- [ ] I personally reviewed every file in this diff.
- [ ] I checked that the code matches existing project structure, APIs, and conventions.
- [ ] I avoided unnecessary monkeypatching and used the project's normal extension points where possible.

## Notes

Raw tensor type `40` now follows the official `NVFP4` assignment. The former private 32-element `Q1_0` interpretation cannot coexist under that ID; Prism/Bonsai artifacts using type `41` remain compatible through the `Q1_0_g128` alias.

Link to Devin session: https://app.devin.ai/sessions/983b34b989f842989aceb3bccefdf8c2
Open in Devin Desktop: https://app.devin.ai/desktop/session/983b34b989f842989aceb3bccefdf8c2?variant=devin
Requested by: @Qubitium