### PR TITLE
[MODEL] support `ouro` and `spark2_5`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Latest News 🗞️🚀
 
-* 09/05/2026 7.4.0-dev `main`: ✨ Added ByteDance `Ouro-1.4B` quantization support.
+* 09/07/2026 7.4.0-dev `main`: ✨ Added XHToken `ouro` and `spark2_5` quantization support.
 * 09/02/2026 7.4.0-dev `main`: ✨ Added `apertus1p5` and `apertus1p5_text` quantization.
 * 09/01/2026 7.4.0-dev `main`: ✨ Added `glm5_next` / GLM-5.3-Flash quantization support.
 * 08/31/2026 7.4.0-dev `main`: ✨ Added Qwen3.8-Flash-Next (`qwen4_exp`) quantization.
@@ -257,27 +257,26 @@ Selected public references where teams or companies explicitly mention GPT-QMode
 
 ## Model Support 🤖
 
-| Model                         |   |                                      |  |                            |  |                                 |  |                        |   |
-|-------------------------------|---|--------------------------------------|--|----------------------------|--|---------------------------------|--|------------------------|---|
-| Apertus 1/1.5                 | ✅ | EXAONE 3/4                           | ✅ | Dots1                      | ✅ | Mistral3 / Ministral3           | ✅ | Qwen 2/3/3.5/3.8 (Next/MoE) | ✅ |
-| Baichuan                      | ✅ | Falcon (H1 / Mamba)                  | ✅ | InternLM 1/2/2.5           | ✅ | Mixtral                         | ✅ | Qwen 2/2.5/3 VL        | ✅ |
-| Bloom                         | ✅ | FastVLM                              | ✅ | Kimi K2                    | ✅ | MobileLLM                       | ✅ | Qwen 2.5/3 Omni        | ✅ |
-| ChatGLM                       | ✅ | Gemma 1-4 / 3n                       | ✅ | Klear                      | ✅ | MOSS                            | ✅ | RefinedWeb             | ✅ |
-| CodeGen                       | ✅ | GPTBigCode                           | ✅ | LING/RING                  | ✅ | MPT                             | ✅ | StableLM               | ✅ |
-| Cohere 1-2 / 2 MoE            | ✅ | GPT-Neo / NeoX                       | ✅ | Llama 1-3.3                | ✅ | Nemotron H / H Puzzle / Omni    | ✅ | StarCoder2             | ✅ |
-| DBRX Converted                | ✅ | GPT-2                                | ✅ | Llama 3.2 VL               | ✅ | Nemotron Ultra / Labs-Diffusion | ✅ | TeleChat2              | ✅ |
-| Deci                          | ✅ | GPT-J                                | ✅ | Llama 4                    | ✅ | OPT                             | ✅ | Trinity                | ✅ |
-| DeepSeek-V2/V3/V3.2/V4/R1     | ✅ | GPT-OSS                              | ✅ | LongCat Flash              | ✅ | OLMo2/3 / LLaDA2                | ✅ | Yi                     | ✅ |
-| DeepSeek-V2 Lite / VL / VL2 / OCR2 | ✅ | Granite / Granite MoE                | ✅ | LongLLaMA                  | ✅ | Ovis 1.6/2/2.5/2.6 MoE/2.6 Next | ✅ | Seed-OSS               | ✅ |
-| Dream                         | ✅ | GRIN-MoE                             | ✅ | Instella                   | ✅ | Phi 1-4                         | ✅ | Voxtral                | ✅ |
-| ERNIE 4.5 / MoE / VL MoE      | ✅ | GLM 4/4V/4.5V/4.6V/5/5.1/5.3/OCR/ASR | ✅ | GLM4 MoE / Lite / 4.5V MoE | ✅ | MiniCPM 3/O/V/V 4_6             | ✅ | PanGu-α                | ✅ |
-| XVERSE                        | ✅ | Brumby                               | ✅ | Hymba                      | ✅ | Mistral                         | ✅ | Qwen 1/2/3/3.5         | ✅ |
-| MiniMax M2/M3                 | ✅ | AfMoE                                | ✅ | Bailing-MoE                | ✅ | LFM2 / LFM2-VL / LFM2-MoE       | ✅ | Marin                  | ✅ |
-| InternVL Chat                 | ✅ | Laguna                               | ✅ | Mimo / Mimo V2             | ✅ | Zamba / Zamba2                  | ✅ | Intern S1 / S2 Preview             | ✅ |
-| HunYuan V1 Dense / MoE        | ✅ | HY-V3                                | ✅ | Inkling           | ✅ | Solar Open / Open 2                    | ✅ | North Micro Vision | ✅ |
-| Mage-VL                       | ✅ | Unlimited-OCR                        | ✅ | HunyuanOCR                 | ✅ | LocateAnything             | ✅ |                        |    |
-| Muse Glimmer                  | ✅ |                                      |    |                            |    |                                 |    |                        |    |
-| SmolLM3                       | ✅ | Ouro                                 | ✅ |                            |    |                                 |    |                        |    |
+| Model | | Model | | Model | | Model | | Model | |
+|---|---|---|---|---|---|---|---|---|---|
+| Apertus 1/1.5 | ✅ | EXAONE 3/4 | ✅ | Dots1 | ✅ | Mistral3 / Ministral3 | ✅ | Qwen 2/3/3.5/3.8 (Next/MoE) | ✅ |
+| Baichuan | ✅ | Falcon (H1 / Mamba) | ✅ | InternLM 1/2/2.5 | ✅ | Mixtral | ✅ | Qwen 2/2.5/3 VL | ✅ |
+| Bloom | ✅ | FastVLM | ✅ | Kimi K2 | ✅ | MobileLLM | ✅ | Qwen 2.5/3 Omni | ✅ |
+| ChatGLM | ✅ | Gemma 1-4 / 3n | ✅ | Klear | ✅ | MOSS | ✅ | RefinedWeb | ✅ |
+| CodeGen | ✅ | GPTBigCode | ✅ | LING/RING | ✅ | MPT | ✅ | StableLM | ✅ |
+| Cohere 1-2 / 2 MoE | ✅ | GPT-Neo / NeoX | ✅ | Llama 1-3.3 | ✅ | Nemotron H / H Puzzle / Omni | ✅ | StarCoder2 | ✅ |
+| DBRX Converted | ✅ | GPT-2 | ✅ | Llama 3.2 VL | ✅ | Nemotron Ultra / Labs-Diffusion | ✅ | TeleChat2 | ✅ |
+| Deci | ✅ | GPT-J | ✅ | Llama 4 | ✅ | OPT | ✅ | Trinity | ✅ |
+| DeepSeek-V2/V3/V3.2/V4/R1 | ✅ | GPT-OSS | ✅ | LongCat Flash | ✅ | OLMo2/3 / LLaDA2 | ✅ | Yi | ✅ |
+| DeepSeek-V2 Lite / VL / VL2 / OCR2 | ✅ | Granite / Granite MoE | ✅ | LongLLaMA | ✅ | Ovis 1.6/2/2.5/2.6 MoE/2.6 Next | ✅ | Seed-OSS | ✅ |
+| Dream | ✅ | GRIN-MoE | ✅ | Instella | ✅ | Phi 1-4 | ✅ | Voxtral | ✅ |
+| ERNIE 4.5 / MoE / VL MoE | ✅ | GLM 4/4V/4.5V/4.6V/5/5.1/5.3/OCR/ASR | ✅ | GLM4 MoE / Lite / 4.5V MoE | ✅ | MiniCPM 3/O/V/V 4_6 | ✅ | PanGu-α | ✅ |
+| XVERSE | ✅ | Brumby | ✅ | Hymba | ✅ | Mistral | ✅ | Qwen 1/2/3/3.5 | ✅ |
+| MiniMax M2/M3 | ✅ | AfMoE | ✅ | Bailing-MoE | ✅ | LFM2 / LFM2-VL / LFM2-MoE | ✅ | Marin | ✅ |
+| InternVL Chat | ✅ | Laguna | ✅ | Mimo / Mimo V2 | ✅ | Zamba / Zamba2 | ✅ | Intern S1 / S2 Preview | ✅ |
+| HunYuan V1 Dense / MoE | ✅ | HY-V3 | ✅ | Inkling | ✅ | Solar Open / Open 2 | ✅ | North Micro Vision | ✅ |
+| Mage-VL | ✅ | Unlimited-OCR | ✅ | HunyuanOCR | ✅ | LocateAnything | ✅ | Muse Glimmer | ✅ |
+| Ouro | ✅ | Spark-X2.5 | ✅ | SmolLM3 | ✅ |  |  |  |  |
 
 
 Prism Bonsai GGUF checkpoints are supported for inference only through GPT-QModel's native GGUF path and internal GGUF runtime. Bonsai checkpoints load through the normal model path or repo argument and do not require the external `gguf` package. Prism model quantization is not included.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 ## Latest News 🗞️🚀
 
+* 09/05/2026 7.4.0-dev `main`: ✨ Added ByteDance `Ouro-1.4B` quantization support.
 * 09/02/2026 7.4.0-dev `main`: ✨ Added `apertus1p5` and `apertus1p5_text` quantization.
 * 09/01/2026 7.4.0-dev `main`: ✨ Added `glm5_next` / GLM-5.3-Flash quantization support.
 * 08/31/2026 7.4.0-dev `main`: ✨ Added Qwen3.8-Flash-Next (`qwen4_exp`) quantization.
@@ -256,27 +257,27 @@ Selected public references where teams or companies explicitly mention GPT-QMode
 
 ## Model Support 🤖
 
-| Model                         |   |                                 |  |                            |  |                                 |  |                        |   |
-|-------------------------------|---|---------------------------------|--|----------------------------|--|---------------------------------|--|------------------------|---|
-| Apertus 1/1.5                 | ✅ | EXAONE 3/4                      | ✅ | Dots1                      | ✅ | Mistral3 / Ministral3           | ✅ | Qwen 2/3/3.5/3.8 (Next/MoE) | ✅ |
-| Baichuan                      | ✅ | Falcon (H1 / Mamba)             | ✅ | InternLM 1/2/2.5           | ✅ | Mixtral                         | ✅ | Qwen 2/2.5/3 VL        | ✅ |
-| Bloom                         | ✅ | FastVLM                         | ✅ | Kimi K2                    | ✅ | MobileLLM                       | ✅ | Qwen 2.5/3 Omni        | ✅ |
-| ChatGLM                       | ✅ | Gemma 1-4 / 3n                  | ✅ | Klear                      | ✅ | MOSS                            | ✅ | RefinedWeb             | ✅ |
-| CodeGen                       | ✅ | GPTBigCode                      | ✅ | LING/RING                  | ✅ | MPT                             | ✅ | StableLM               | ✅ |
-| Cohere 1-2 / 2 MoE            | ✅ | GPT-Neo / NeoX                  | ✅ | Llama 1-3.3                | ✅ | Nemotron H / H Puzzle / Omni    | ✅ | StarCoder2             | ✅ |
-| DBRX Converted                | ✅ | GPT-2                           | ✅ | Llama 3.2 VL               | ✅ | Nemotron Ultra / Labs-Diffusion | ✅ | TeleChat2              | ✅ |
-| Deci                          | ✅ | GPT-J                           | ✅ | Llama 4                    | ✅ | OPT                             | ✅ | Trinity                | ✅ |
-| DeepSeek-V2/V3/V3.2/V4/R1     | ✅ | GPT-OSS                         | ✅ | LongCat Flash              | ✅ | OLMo2/3 / LLaDA2                | ✅ | Yi                     | ✅ |
-| DeepSeek-V2 Lite / VL / VL2 / OCR2 | ✅ | Granite / Granite MoE           | ✅ | LongLLaMA                  | ✅ | Ovis 1.6/2/2.5/2.6 MoE/2.6 Next | ✅ | Seed-OSS               | ✅ |
-| Dream                         | ✅ | GRIN-MoE                        | ✅ | Instella                   | ✅ | Phi 1-4                         | ✅ | Voxtral                | ✅ |
+| Model                         |   |                                      |  |                            |  |                                 |  |                        |   |
+|-------------------------------|---|--------------------------------------|--|----------------------------|--|---------------------------------|--|------------------------|---|
+| Apertus 1/1.5                 | ✅ | EXAONE 3/4                           | ✅ | Dots1                      | ✅ | Mistral3 / Ministral3           | ✅ | Qwen 2/3/3.5/3.8 (Next/MoE) | ✅ |
+| Baichuan                      | ✅ | Falcon (H1 / Mamba)                  | ✅ | InternLM 1/2/2.5           | ✅ | Mixtral                         | ✅ | Qwen 2/2.5/3 VL        | ✅ |
+| Bloom                         | ✅ | FastVLM                              | ✅ | Kimi K2                    | ✅ | MobileLLM                       | ✅ | Qwen 2.5/3 Omni        | ✅ |
+| ChatGLM                       | ✅ | Gemma 1-4 / 3n                       | ✅ | Klear                      | ✅ | MOSS                            | ✅ | RefinedWeb             | ✅ |
+| CodeGen                       | ✅ | GPTBigCode                           | ✅ | LING/RING                  | ✅ | MPT                             | ✅ | StableLM               | ✅ |
+| Cohere 1-2 / 2 MoE            | ✅ | GPT-Neo / NeoX                       | ✅ | Llama 1-3.3                | ✅ | Nemotron H / H Puzzle / Omni    | ✅ | StarCoder2             | ✅ |
+| DBRX Converted                | ✅ | GPT-2                                | ✅ | Llama 3.2 VL               | ✅ | Nemotron Ultra / Labs-Diffusion | ✅ | TeleChat2              | ✅ |
+| Deci                          | ✅ | GPT-J                                | ✅ | Llama 4                    | ✅ | OPT                             | ✅ | Trinity                | ✅ |
+| DeepSeek-V2/V3/V3.2/V4/R1     | ✅ | GPT-OSS                              | ✅ | LongCat Flash              | ✅ | OLMo2/3 / LLaDA2                | ✅ | Yi                     | ✅ |
+| DeepSeek-V2 Lite / VL / VL2 / OCR2 | ✅ | Granite / Granite MoE                | ✅ | LongLLaMA                  | ✅ | Ovis 1.6/2/2.5/2.6 MoE/2.6 Next | ✅ | Seed-OSS               | ✅ |
+| Dream                         | ✅ | GRIN-MoE                             | ✅ | Instella                   | ✅ | Phi 1-4                         | ✅ | Voxtral                | ✅ |
 | ERNIE 4.5 / MoE / VL MoE      | ✅ | GLM 4/4V/4.5V/4.6V/5/5.1/5.3/OCR/ASR | ✅ | GLM4 MoE / Lite / 4.5V MoE | ✅ | MiniCPM 3/O/V/V 4_6             | ✅ | PanGu-α                | ✅ |
-| XVERSE                        | ✅ | Brumby                          | ✅ | Hymba                      | ✅ | Mistral                         | ✅ | Qwen 1/2/3/3.5         | ✅ |
-| MiniMax M2/M3                 | ✅ | AfMoE                           | ✅ | Bailing-MoE                | ✅ | LFM2 / LFM2-VL / LFM2-MoE       | ✅ | Marin                  | ✅ |
-| InternVL Chat                 | ✅ | Laguna                          | ✅ | Mimo / Mimo V2             | ✅ | Zamba / Zamba2                  | ✅ | Intern S1 / S2 Preview             | ✅ |
-| HunYuan V1 Dense / MoE        | ✅ | HY-V3                           | ✅ | Inkling           | ✅ | Solar Open / Open 2                    | ✅ | North Micro Vision | ✅ |
-| Mage-VL                       | ✅ | Unlimited-OCR                   | ✅ | HunyuanOCR                 | ✅ | LocateAnything             | ✅ |                        |    |
-| Muse Glimmer                  | ✅ |                                 |    |                            |    |                                 |    |                        |    |
-| SmolLM3                       | ✅ |                                 |    |                            |    |                                 |    |                        |    |
+| XVERSE                        | ✅ | Brumby                               | ✅ | Hymba                      | ✅ | Mistral                         | ✅ | Qwen 1/2/3/3.5         | ✅ |
+| MiniMax M2/M3                 | ✅ | AfMoE                                | ✅ | Bailing-MoE                | ✅ | LFM2 / LFM2-VL / LFM2-MoE       | ✅ | Marin                  | ✅ |
+| InternVL Chat                 | ✅ | Laguna                               | ✅ | Mimo / Mimo V2             | ✅ | Zamba / Zamba2                  | ✅ | Intern S1 / S2 Preview             | ✅ |
+| HunYuan V1 Dense / MoE        | ✅ | HY-V3                                | ✅ | Inkling           | ✅ | Solar Open / Open 2                    | ✅ | North Micro Vision | ✅ |
+| Mage-VL                       | ✅ | Unlimited-OCR                        | ✅ | HunyuanOCR                 | ✅ | LocateAnything             | ✅ |                        |    |
+| Muse Glimmer                  | ✅ |                                      |    |                            |    |                                 |    |                        |    |
+| SmolLM3                       | ✅ | Ouro                                 | ✅ |                            |    |                                 |    |                        |    |
 
 
 Prism Bonsai GGUF checkpoints are supported for inference only through GPT-QModel's native GGUF path and internal GGUF runtime. Bonsai checkpoints load through the normal model path or repo argument and do not require the external `gguf` package. Prism model quantization is not included.

--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -165,6 +165,7 @@ from .definitions.nemotron_h_puzzle import NemotronHPuzzleQModel  # noqa: E402
 from .definitions.nemotron_omni import NemotronOmniQModel  # noqa: E402
 from .definitions.olmo3 import Olmo3QModel  # noqa: E402
 from .definitions.opt import OptQModel  # noqa: E402
+from .definitions.ouro import OuroQModel  # noqa: E402
 from .definitions.ovis import OvisQModel  # noqa: E402
 from .definitions.ovis2 import Ovis2QModel  # noqa: E402
 from .definitions.ovis2_5 import Ovis2_5QModel  # noqa: E402
@@ -338,6 +339,7 @@ MODEL_MAP = {
     "hymba": HymbaQModel,
     "olmo2": LlamaQModel, # 100% llama clone
     "olmo3": Olmo3QModel,
+    "ouro": OuroQModel,
     "ovis": OvisQModel,
     "ovis2": Ovis2QModel,
     "ovis2_5": Ovis2_5QModel,

--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -190,6 +190,7 @@ from .definitions.qwen4_exp import Qwen4ExpQModel  # noqa: E402
 from .definitions.rw import RwgQModel  # noqa: E402
 from .definitions.solar_open import SolarOpenQModel  # noqa: E402
 from .definitions.solar_open2 import SolarOpen2QModel  # noqa: E402
+from .definitions.spark2_5 import Spark2_5QModel  # noqa: E402
 from .definitions.starcoder2 import Starcoder2QModel  # noqa: E402
 from .definitions.telechat2 import TeleChat2QModel
 from .definitions.unlimited_ocr import UnlimitedOCRQModel  # noqa: E402
@@ -361,6 +362,7 @@ MODEL_MAP = {
     "seed_oss": LlamaQModel, # 100% llama clone
     "solar_open": SolarOpenQModel,
     "solar_open2": SolarOpen2QModel,
+    "spark2_5": Spark2_5QModel,
     "gpt_oss": GPTOSSGPTQ,
     "longcat_flash": LongCatFlashQModel,
     "locateanything": LocateAnythingQModel,

--- a/gptqmodel/models/definitions/__init__.py
+++ b/gptqmodel/models/definitions/__init__.py
@@ -102,6 +102,7 @@ from .qwen4_exp import Qwen4ExpQModel
 from .rw import RwgQModel
 from .solar_open import SolarOpenQModel
 from .solar_open2 import SolarOpen2QModel
+from .spark2_5 import Spark2_5QModel
 from .starcoder2 import Starcoder2QModel
 from .telechat2 import TeleChat2QModel
 from .unlimited_ocr import UnlimitedOCRQModel

--- a/gptqmodel/models/definitions/__init__.py
+++ b/gptqmodel/models/definitions/__init__.py
@@ -83,6 +83,7 @@ from .nemotron_labs_diffusion import NemotronLabsDiffusionQModel
 from .nemotron_h_puzzle import NemotronHPuzzleQModel
 from .olmo3 import Olmo3QModel
 from .opt import OptQModel
+from .ouro import OuroQModel
 from .ovis import OvisQModel
 from .ovis2_5 import Ovis2_5QModel
 from .ovis2_6_moe import Ovis2_6_MoeQModel

--- a/gptqmodel/models/definitions/ouro.py
+++ b/gptqmodel/models/definitions/ouro.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from ..base import BaseQModel
+
+
+class OuroQModel(BaseQModel):
+    """GPTQ definition for ByteDance's looped Ouro decoder."""
+
+    require_trust_remote_code = True
+
+    pre_lm_head_norm_module = "model.norm"
+    rotary_embedding = "model.rotary_emb"
+
+    # Ouro's sandwich RMSNorms are part of the forward path, but only the
+    # linear projections are quantized. The recurrent loop reuses these
+    # decoder layers, so the tree describes one shared layer topology.
+    module_tree = [
+        "model",
+        "layers",
+        "#",
+        {
+            "input_layernorm": ("input_layernorm:!",),
+            "self_attn": (
+                "q_proj:0:in=x",
+                "k_proj:0:in=x",
+                "v_proj:0:in=x",
+                "o_proj:1",
+            ),
+            "input_layernorm_2": ("input_layernorm_2:!",),
+            "post_attention_layernorm": ("post_attention_layernorm:!",),
+            "mlp": (
+                "gate_proj:0:in=x",
+                "up_proj:0:in=x",
+                "down_proj:1",
+            ),
+            "post_attention_layernorm_2": ("post_attention_layernorm_2:!",),
+        },
+    ]
+
+    def before_model_load(self, model_local_path: str, load_quantized_model: bool):
+        """Bridge Ouro's legacy rotary class to the Transformers 5.x loader API."""
+
+        del load_quantized_model
+        from functools import wraps
+        from importlib import import_module
+
+        from transformers.dynamic_module_utils import get_class_from_dynamic_module
+        from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+        rotary_cls = get_class_from_dynamic_module(
+            "modeling_ouro.OuroRotaryEmbedding",
+            model_local_path,
+        )
+        if not hasattr(rotary_cls, "compute_default_rope_parameters"):
+
+            def compute_default_rope_parameters(self, config):
+                del self
+                return ROPE_INIT_FUNCTIONS["default"](config)
+
+            rotary_cls.compute_default_rope_parameters = compute_default_rope_parameters
+
+        remote_module = import_module(rotary_cls.__module__)
+        for mask_name in ("create_causal_mask", "create_sliding_window_causal_mask"):
+            mask_fn = getattr(remote_module, mask_name, None)
+            if not callable(mask_fn) or getattr(mask_fn, "_gptqmodel_ouro_mask_compat", False):
+                continue
+
+            @wraps(mask_fn)
+            def mask_compat(*args, _mask_fn=mask_fn, **kwargs):
+                if "input_embeds" in kwargs and "inputs_embeds" not in kwargs:
+                    kwargs["inputs_embeds"] = kwargs.pop("input_embeds")
+                # Ouro's remote code also forwards cache_position, which was
+                # removed from the Transformers 5.x mask helper signatures.
+                kwargs.pop("cache_position", None)
+                return _mask_fn(*args, **kwargs)
+
+            mask_compat._gptqmodel_ouro_mask_compat = True
+            setattr(remote_module, mask_name, mask_compat)
+
+
+__all__ = ["OuroQModel"]

--- a/gptqmodel/models/definitions/spark2_5.py
+++ b/gptqmodel/models/definitions/spark2_5.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from ..base import BaseQModel
+
+
+class Spark2_5QModel(BaseQModel):
+    """GPTQ definition for Spark-X2.5's hybrid-attention decoder."""
+
+    require_trust_remote_code = True
+
+    # The tags are verified by the Spark decoder's real forward path.  The
+    # fused QKV projection and the MLP gate/up projections consume the same
+    # activation tensor as their tagged sibling group.
+    shared_input_verified_model_types = frozenset({"spark2_5"})
+
+    pre_lm_head_norm_module = "model.norm"
+
+    # Spark has no rotary-embedding module: it computes RoPE tensors directly
+    # in the remote model's forward method.
+    module_tree = [
+        "model",
+        "layers",
+        "#",
+        {
+            "input_layernorm": ("input_layernorm:!",),
+            "self_attn": (
+                "q_k_v_proj:0:in=x",
+                # The 16-head output gate is small and precision-sensitive.
+                "g_proj:0:!",
+                "out_proj:1",
+            ),
+            "post_attention_layernorm": ("post_attention_layernorm:!",),
+            "mlp": (
+                "gate_proj:0:in=x",
+                "up_proj:0:in=x",
+                "down_proj:1",
+            ),
+        },
+    ]
+
+    def before_model_load(self, model_local_path: str, load_quantized_model: bool):
+        """Adapt Spark's legacy mask-helper keyword names to Transformers 5.x."""
+
+        del load_quantized_model
+        from functools import wraps
+        from importlib import import_module
+
+        from transformers.dynamic_module_utils import get_class_from_dynamic_module
+
+        remote_model_cls = get_class_from_dynamic_module(
+            "modeling_spark.Spark2_5Model",
+            model_local_path,
+        )
+        remote_module = import_module(remote_model_cls.__module__)
+
+        for mask_name in ("create_causal_mask", "create_sliding_window_causal_mask"):
+            mask_fn = getattr(remote_module, mask_name, None)
+            if not callable(mask_fn) or getattr(
+                mask_fn, "_gptqmodel_spark_mask_compat", False
+            ):
+                continue
+
+            @wraps(mask_fn)
+            def mask_compat(*args, _mask_fn=mask_fn, **kwargs):
+                if "input_embeds" in kwargs and "inputs_embeds" not in kwargs:
+                    kwargs["inputs_embeds"] = kwargs.pop("input_embeds")
+                # Transformers 5.x removed cache_position from these helper
+                # signatures, while Spark's remote forward still forwards it.
+                kwargs.pop("cache_position", None)
+                return _mask_fn(*args, **kwargs)
+
+            mask_compat._gptqmodel_spark_mask_compat = True
+            setattr(remote_module, mask_name, mask_compat)
+
+    def after_model_load(self, model, load_quantized_model: bool = False):
+        """Expose the dtype-only weight view expected by Spark's remote forward."""
+
+        if not load_quantized_model:
+            return model
+
+        import torch
+
+        for layer in model.model.layers:
+            gate_proj = layer.mlp.gate_proj
+            if hasattr(gate_proj, "weight"):
+                continue
+
+            # Spark reads only ``gate_proj.weight.dtype`` to cast activations.
+            # Quantized linear kernels intentionally store qweight/scales rather
+            # than a dense weight, so a zero-sized, unregistered tensor supplies
+            # that dtype without restoring or serializing a dense matrix.
+            compute_dtype = getattr(gate_proj, "compute_dtype", None)
+            if compute_dtype is None:
+                compute_dtype = gate_proj.scales.dtype
+            gate_proj.weight = torch.empty(0, dtype=compute_dtype)
+
+        return model
+
+
+__all__ = ["Spark2_5QModel"]

--- a/gptqmodel/utils/hf.py
+++ b/gptqmodel/utils/hf.py
@@ -1318,6 +1318,14 @@ def _normalize_remote_code_config_compat(config: Any) -> None:
                 if rope_theta is not None:
                     text_config.rope_theta = rope_theta
 
+    if model_type_lower == "ouro" and not hasattr(config, "pad_token_id"):
+        # Ouro's custom config does not pass pad_token_id to PretrainedConfig,
+        # while its model implementation accesses config.pad_token_id during
+        # construction. Use the model's EOS token as the conventional causal-LM
+        # padding fallback; this is a config compatibility fix, not a tokenizer
+        # model-name workaround.
+        config.pad_token_id = getattr(config, "eos_token_id", None)
+
     if model_type_lower == "hymba":
         # hymba uses Flex by default;
         # however, `modeling_hymba` has not yet been adapted to support the latest version of PyTorch Flex.

--- a/tests/models/test_ouro.py
+++ b/tests/models/test_ouro.py
@@ -7,7 +7,7 @@ from model_test import ModelTest
 
 
 class TestOuro(ModelTest):
-    NATIVE_MODEL_ID = "/monster/data/model/Ouro-1.4B"
+    NATIVE_MODEL_ID = "/monster/data/model/Ouro-1.4B" # ByteDance/Ouro-1.4B
     TRUST_REMOTE_CODE = True
     USE_FLASH_ATTN = False
     EVAL_BATCH_SIZE = 32

--- a/tests/models/test_ouro.py
+++ b/tests/models/test_ouro.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+from model_test import ModelTest
+
+
+class TestOuro(ModelTest):
+    NATIVE_MODEL_ID = "/monster/data/model/Ouro-1.4B"
+    TRUST_REMOTE_CODE = True
+    USE_FLASH_ATTN = False
+    EVAL_BATCH_SIZE = 32
+
+    # Full 1172-row ARC-Challenge scores for GPTQ 4-bit (g128), measured against
+    # dense BF16 acc=0.5017064846416383 and acc_norm=0.5264505119453925. This is
+    # 89.46% / 92.22% dense recovery after Ouro reuses every quantized layer for
+    # all four recurrent steps.
+    EVAL_TASKS_SLOW = {
+        "arc_challenge": {
+            "acc": {"value": 0.44880546075085326, "floor_pct": 0.04},
+            "acc_norm": {"value": 0.4854948805460751, "floor_pct": 0.04},
+        },
+    }
+    EVAL_TASKS_FAST = ModelTest.derive_fast_eval_tasks(EVAL_TASKS_SLOW)
+
+    def test_ouro(self):
+        self.quantize_and_evaluate()

--- a/tests/models/test_spark2_5.py
+++ b/tests/models/test_spark2_5.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+from model_test import ModelTest
+
+
+class TestSpark2_5(ModelTest):
+    NATIVE_MODEL_ID = "/monster/data/model/Spark-X2.5-4B" # XHToken/Spark-X2.5-4B
+    TRUST_REMOTE_CODE = True
+    USE_FLASH_ATTN = False
+    EVAL_BATCH_SIZE = 16
+
+    # Full 1172-row ARC-Challenge scores for GPTQ 4-bit (g128), measured against
+    # dense BF16 acc=0.36006825938566556 and acc_norm=0.3916382252559727. The
+    # quantized checkpoint retains 89.81% / 89.32% of the dense scores.
+    EVAL_TASKS_SLOW = {
+        "arc_challenge": {
+            "acc": {"value": 0.32337883959044367, "floor_pct": 0.04},
+            "acc_norm": {"value": 0.34982935153583616, "floor_pct": 0.04},
+        },
+    }
+    EVAL_TASKS_FAST = ModelTest.derive_fast_eval_tasks(EVAL_TASKS_SLOW)
+
+    def test_spark2_5(self):
+        self.quantize_and_evaluate()

--- a/tests/test_ouro_support.py
+++ b/tests/test_ouro_support.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-FileCopyrightText: 2026 qubitium@modelcloud.ai
+# SPDX-License-Identifier: Apache-2.0
+# Contact: qubitium@modelcloud.ai, x.com/qubitium
+
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from gptqmodel.models import auto
+from gptqmodel.models.definitions.ouro import OuroQModel
+from gptqmodel.utils.hf import normalize_hf_config_compat
+
+
+def test_ouro_model_type_selects_definition(monkeypatch):
+    fake_config = SimpleNamespace(model_type="ouro")
+
+    monkeypatch.setattr(
+        auto,
+        "resolve_trust_remote_code",
+        lambda path, trust_remote_code=False: trust_remote_code,
+    )
+    monkeypatch.setattr(
+        auto.AutoConfig,
+        "from_pretrained",
+        lambda *args, **kwargs: fake_config,
+    )
+
+    assert auto.check_and_get_model_definition(
+        "/monster/data/model/Ouro-1.4B", trust_remote_code=True
+    ) is OuroQModel
+
+
+def test_ouro_module_tree_matches_decoder_forward_boundaries():
+    layer_modules = OuroQModel.simple_layer_modules(
+        model_config=SimpleNamespace(),
+        quantize_config=SimpleNamespace(dynamic=None),
+    )
+
+    assert OuroQModel.require_trust_remote_code is True
+    assert OuroQModel.extract_layers_node() == ["model.layers"]
+    assert OuroQModel.pre_lm_head_norm_module == "model.norm"
+    assert OuroQModel.rotary_embedding == "model.rotary_emb"
+    assert layer_modules == [
+        ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj"],
+        ["self_attn.o_proj"],
+        ["mlp.gate_proj", "mlp.up_proj"],
+        ["mlp.down_proj"],
+    ]
+
+    full_modules = {module for block in OuroQModel.full_layer_modules() for module in block}
+    assert {
+        "input_layernorm:!",
+        "input_layernorm_2:!",
+        "post_attention_layernorm:!",
+        "post_attention_layernorm_2:!",
+    } <= full_modules
+    assert "early_exit_gate" not in full_modules
+
+
+def test_ouro_remote_config_compat_restores_missing_pad_token_id():
+    config = SimpleNamespace(
+        model_type="ouro",
+        auto_map={"AutoModelForCausalLM": "modeling_ouro.OuroForCausalLM"},
+        eos_token_id=0,
+    )
+    assert not hasattr(config, "pad_token_id")
+
+    normalize_hf_config_compat(config, trust_remote_code=True)
+
+    assert config.pad_token_id == config.eos_token_id
+
+
+def test_ouro_before_model_load_patches_legacy_rotary_class(monkeypatch):
+    class FakeOuroRotaryEmbedding:
+        pass
+
+    sentinel = ("inv_freq", 1.0)
+    remote_module = types.ModuleType("fake_ouro_remote")
+
+    def fake_causal_mask(**kwargs):
+        return kwargs
+
+    remote_module.create_causal_mask = fake_causal_mask
+    remote_module.create_sliding_window_causal_mask = fake_causal_mask
+    FakeOuroRotaryEmbedding.__module__ = remote_module.__name__
+    monkeypatch.setitem(sys.modules, remote_module.__name__, remote_module)
+    monkeypatch.setattr(
+        "transformers.dynamic_module_utils.get_class_from_dynamic_module",
+        lambda class_ref, model_local_path: FakeOuroRotaryEmbedding,
+    )
+    monkeypatch.setitem(
+        pytest.importorskip("transformers.modeling_rope_utils").ROPE_INIT_FUNCTIONS,
+        "default",
+        lambda config: sentinel,
+    )
+
+    OuroQModel.before_model_load(OuroQModel, "/monster/data/model/Ouro-1.4B", False)
+
+    assert FakeOuroRotaryEmbedding().compute_default_rope_parameters(object()) == sentinel
+
+
+def test_ouro_before_model_load_adapts_legacy_mask_keyword_locally(monkeypatch):
+    class FakeOuroRotaryEmbedding:
+        pass
+
+    remote_module = types.ModuleType("fake_ouro_mask_remote")
+
+    def fake_causal_mask(**kwargs):
+        return kwargs
+
+    remote_module.create_causal_mask = fake_causal_mask
+    remote_module.create_sliding_window_causal_mask = fake_causal_mask
+    FakeOuroRotaryEmbedding.__module__ = remote_module.__name__
+    monkeypatch.setitem(sys.modules, remote_module.__name__, remote_module)
+    monkeypatch.setattr(
+        "transformers.dynamic_module_utils.get_class_from_dynamic_module",
+        lambda class_ref, model_local_path: FakeOuroRotaryEmbedding,
+    )
+
+    OuroQModel.before_model_load(OuroQModel, "/monster/data/model/Ouro-1.4B", False)
+
+    for mask_name in ("create_causal_mask", "create_sliding_window_causal_mask"):
+        mask = getattr(remote_module, mask_name)
+        assert mask._gptqmodel_ouro_mask_compat is True
+        assert mask(input_embeds="hidden", cache_position="positions") == {"inputs_embeds": "hidden"}

--- a/tests/test_spark2_5_support.py
+++ b/tests/test_spark2_5_support.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import types
+from types import SimpleNamespace
+
+import torch
+
+from gptqmodel.models import auto
+from gptqmodel.models.definitions.spark2_5 import Spark2_5QModel
+
+
+def test_spark2_5_model_type_selects_definition(monkeypatch):
+    fake_config = SimpleNamespace(model_type="spark2_5")
+
+    monkeypatch.setattr(
+        auto,
+        "resolve_trust_remote_code",
+        lambda path, trust_remote_code=False: trust_remote_code,
+    )
+    monkeypatch.setattr(auto, "patch_remote_code_before_config_load", lambda path: None)
+    monkeypatch.setattr(
+        auto.AutoConfig,
+        "from_pretrained",
+        lambda *args, **kwargs: fake_config,
+    )
+
+    assert (
+        auto.check_and_get_model_definition(
+            "/monster/data/model/Spark-X2.5-4B", trust_remote_code=True
+        )
+        is Spark2_5QModel
+    )
+
+
+def test_spark2_5_module_tree_matches_decoder_boundaries():
+    config = SimpleNamespace(model_type="spark2_5")
+    layer_modules = Spark2_5QModel.simple_layer_modules(
+        model_config=config,
+        quantize_config=SimpleNamespace(dynamic=None),
+    )
+
+    assert Spark2_5QModel.require_trust_remote_code is True
+    assert Spark2_5QModel.shared_input_verified(config) is True
+    assert Spark2_5QModel.extract_layers_node() == ["model.layers"]
+    assert Spark2_5QModel.pre_lm_head_norm_module == "model.norm"
+    assert Spark2_5QModel.rotary_embedding is None
+    assert layer_modules == [
+        ["self_attn.q_k_v_proj"],
+        ["self_attn.out_proj"],
+        ["mlp.gate_proj", "mlp.up_proj"],
+        ["mlp.down_proj"],
+    ]
+
+    full_modules = {
+        module
+        for block in Spark2_5QModel.full_layer_modules(model_config=config)
+        for module in block
+    }
+    assert {
+        "input_layernorm:!",
+        "self_attn.g_proj:!",
+        "post_attention_layernorm:!",
+    } <= full_modules
+    assert "self_attn.g_proj" not in {
+        module for block in layer_modules for module in block
+    }
+
+    plan = Spark2_5QModel.shared_input_plan(
+        model_config=config,
+        quantize_config=SimpleNamespace(dynamic=None),
+    )
+    assert plan.group_for("mlp.gate_proj").modules == (
+        "mlp.gate_proj",
+        "mlp.up_proj",
+    )
+
+
+def test_spark2_5_before_model_load_adapts_both_legacy_mask_helpers(monkeypatch):
+    remote_module = types.ModuleType("fake_spark2_5_mask_remote")
+
+    def fake_causal_mask(**kwargs):
+        return kwargs
+
+    class FakeSparkModel:
+        pass
+
+    FakeSparkModel.__module__ = remote_module.__name__
+    remote_module.create_causal_mask = fake_causal_mask
+    remote_module.create_sliding_window_causal_mask = fake_causal_mask
+    monkeypatch.setitem(sys.modules, remote_module.__name__, remote_module)
+    monkeypatch.setattr(
+        "transformers.dynamic_module_utils.get_class_from_dynamic_module",
+        lambda class_ref, model_local_path: FakeSparkModel,
+    )
+
+    Spark2_5QModel.before_model_load(
+        Spark2_5QModel, "/monster/data/model/Spark-X2.5-4B", False
+    )
+
+    for mask_name in ("create_causal_mask", "create_sliding_window_causal_mask"):
+        mask = getattr(remote_module, mask_name)
+        assert mask._gptqmodel_spark_mask_compat is True
+        assert mask(input_embeds="hidden", cache_position="positions") == {
+            "inputs_embeds": "hidden",
+        }
+
+
+def test_spark2_5_before_model_load_is_idempotent(monkeypatch):
+    remote_module = types.ModuleType("fake_spark2_5_idempotent_remote")
+
+    def fake_causal_mask(**kwargs):
+        return kwargs
+
+    class FakeSparkModel:
+        pass
+
+    FakeSparkModel.__module__ = remote_module.__name__
+    remote_module.create_causal_mask = fake_causal_mask
+    remote_module.create_sliding_window_causal_mask = fake_causal_mask
+    monkeypatch.setitem(sys.modules, remote_module.__name__, remote_module)
+    monkeypatch.setattr(
+        "transformers.dynamic_module_utils.get_class_from_dynamic_module",
+        lambda class_ref, model_local_path: FakeSparkModel,
+    )
+
+    Spark2_5QModel.before_model_load(Spark2_5QModel, "/tmp/spark2_5", False)
+    first_helpers = tuple(
+        getattr(remote_module, name)
+        for name in ("create_causal_mask", "create_sliding_window_causal_mask")
+    )
+    Spark2_5QModel.before_model_load(Spark2_5QModel, "/tmp/spark2_5", True)
+    second_helpers = tuple(
+        getattr(remote_module, name)
+        for name in ("create_causal_mask", "create_sliding_window_causal_mask")
+    )
+
+    assert second_helpers == first_helpers
+
+
+def test_spark2_5_after_model_load_supplies_quantized_gate_weight_dtype():
+    class FakeQuantLinear(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.compute_dtype = torch.bfloat16
+            self.register_buffer("scales", torch.ones(1, dtype=torch.bfloat16))
+
+    gate_proj = FakeQuantLinear()
+    model = SimpleNamespace(
+        model=SimpleNamespace(
+            layers=[SimpleNamespace(mlp=SimpleNamespace(gate_proj=gate_proj))],
+        ),
+    )
+
+    assert not hasattr(gate_proj, "weight")
+    returned = Spark2_5QModel.after_model_load(Spark2_5QModel, model, True)
+
+    assert returned is model
+    assert gate_proj.weight.numel() == 0
+    assert gate_proj.weight.dtype is torch.bfloat16
+    assert "weight" not in gate_proj.state_dict()
+
+
+def test_spark2_5_after_model_load_leaves_dense_model_unchanged():
+    dense = torch.nn.Linear(4, 4, bias=False)
+    model = SimpleNamespace(
+        model=SimpleNamespace(
+            layers=[SimpleNamespace(mlp=SimpleNamespace(gate_proj=dense))],
+        ),
+    )
+    original_weight = dense.weight
+
+    returned = Spark2_5QModel.after_model_load(Spark2_5QModel, model, False)
+
+    assert returned is model
+    assert dense.weight is original_weight


### PR DESCRIPTION
## Summary

Add GPTQ quantization support for:

- ByteDance/Ouro-1.4B (`model_type=ouro`)
- XHToken/Spark-X2.5-4B (`model_type=spark2_5`)

Both model types are registered with GPT-QModel's automatic model-definition resolver and include targeted compatibility, quantized-load, and quality-regression coverage.

## What Changed

- Added `OuroQModel` for Ouro's recurrent decoder:
  - Describes the attention, MLP, sandwich RMSNorm, final norm, and rotary boundaries used by the shared decoder layers.
  - Quantizes each physical projection once so it can be reused across all recurrent steps.
  - Bridges the remote model's legacy rotary and causal-mask APIs to Transformers 5.x.
  - Restores a missing remote-code `pad_token_id` from `eos_token_id` during config normalization.
- Added `Spark2_5QModel` for Spark-X2.5's hybrid sliding/full-attention decoder:
  - Supports fused `q_k_v_proj`, `out_proj`, and the MLP projections with verified shared-input groups.
  - Keeps the small, precision-sensitive headwise attention `g_proj` layers dense.
  - Bridges legacy causal-mask arguments to Transformers 5.x.
  - Supplies the dtype-only `gate_proj.weight` view expected by the remote forward path after quantized loading, without registering or serializing a dense weight.
- Registered `ouro` and `spark2_5` in the model map and definitions package.
- Added full-score `ModelTest` coverage plus fast targeted unit tests for model selection, module topology, remote-code compatibility, and quantized loading.
- Updated the README news and reorganized the model-support matrix.

There are no new public APIs or migration requirements. Both models require `trust_remote_code=True`.

## Tests

- [x] I added a new simple/fast unit test for this change, or documented why that is not applicable.
- [x] I ran the new targeted test locally before opening this PR.
- [x] I ran other directly relevant local tests.

Exact targeted test commands and results:

```bash
pytest -q tests/test_ouro_support.py tests/test_spark2_5_support.py
# 11 passed, 3 warnings in 4.08s

ruff check gptqmodel/models/definitions/ouro.py gptqmodel/models/definitions/spark2_5.py tests/test_ouro_support.py tests/test_spark2_5_support.py tests/models/test_ouro.py tests/models/test_spark2_5.py
# All checks passed!
```

The slow/full model tests use all 1,172 ARC-Challenge test rows with GPTQ 4-bit, group size 128:

| Model | Metric | Dense BF16 | GPTQ 4-bit | Dense recovery |
| --- | --- | ---: | ---: | ---: |
| Ouro-1.4B | `acc` | 0.5017064846416383 | 0.44880546075085326 | 89.46% |
| Ouro-1.4B | `acc_norm` | 0.5264505119453925 | 0.4854948805460751 | 92.22% |
| Spark-X2.5-4B | `acc` | 0.36006825938566556 | 0.32337883959044367 | 89.81% |
| Spark-X2.5-4B | `acc_norm` | 0.3916382252559727 | 0.34982935153583616 | 89.32% |

The saved Spark checkpoint was reloaded with 180 Marlin-quantized projections and all 36 headwise attention `g_proj` weights retained dense before the accepted evaluation run.

## Review Requirements

AI-assisted code is welcome.

Every changed file must still be properly reviewed by a human before the PR is opened as ready for review.

- [x] I personally reviewed every file in this diff.
- [x] I checked that the code matches existing project structure, APIs, and conventions.
- [x] I avoided unnecessary monkeypatching and used the project's normal extension points where possible.

## Notes

- The remote-code compatibility changes are scoped through GPT-QModel's normal pre/post model-load extension hooks.
