### PR TITLE
Fix Triton patch for pre-existing autotuner instances

### DIFF
--- a/gptqmodel/utils/nogil_patcher.py
+++ b/gptqmodel/utils/nogil_patcher.py
@@ -112,14 +112,22 @@ def patch_triton_autotuner() -> None:
     module.CacheFuture = CacheFuture
 
     original_init = autotuner_cls.__init__
-    cache_init_lock = threading.Lock()
+    rlock_type = type(threading.RLock())
 
     def ensure_threadsafe_cache(self):
-        if getattr(self, "_gptqmodel_cache_initialized", False):
+        if (
+            getattr(self, "cache", None) is getattr(self, "_cache", None)
+            and isinstance(getattr(self, "_cache_lock", None), rlock_type)
+            and isinstance(getattr(self, "_cache_futures", None), dict)
+        ):
             return
 
-        with cache_init_lock:
-            if getattr(self, "_gptqmodel_cache_initialized", False):
+        with TritonPatch._apply_lock:
+            if (
+                getattr(self, "cache", None) is getattr(self, "_cache", None)
+                and isinstance(getattr(self, "_cache_lock", None), rlock_type)
+                and isinstance(getattr(self, "_cache_futures", None), dict)
+            ):
                 return
 
             cache_map = getattr(self, "cache", {})
@@ -127,7 +135,6 @@ def patch_triton_autotuner() -> None:
             self.cache = self._cache
             self._cache_lock = threading.RLock()
             self._cache_futures = {}
-            self._gptqmodel_cache_initialized = True
 
     def patched_init(self, *args, **kwargs):
         original_init(self, *args, **kwargs)

--- a/gptqmodel/utils/nogil_patcher.py
+++ b/gptqmodel/utils/nogil_patcher.py
@@ -112,14 +112,26 @@ def patch_triton_autotuner() -> None:
     module.CacheFuture = CacheFuture
 
     original_init = autotuner_cls.__init__
+    cache_init_lock = threading.Lock()
+
+    def ensure_threadsafe_cache(self):
+        if getattr(self, "_gptqmodel_cache_initialized", False):
+            return
+
+        with cache_init_lock:
+            if getattr(self, "_gptqmodel_cache_initialized", False):
+                return
+
+            cache_map = getattr(self, "cache", {})
+            self._cache = dict(cache_map)
+            self.cache = self._cache
+            self._cache_lock = threading.RLock()
+            self._cache_futures = {}
+            self._gptqmodel_cache_initialized = True
 
     def patched_init(self, *args, **kwargs):
         original_init(self, *args, **kwargs)
-        cache_map = getattr(self, "cache", {})
-        self._cache = dict(cache_map)
-        self.cache = self._cache
-        self._cache_lock = threading.RLock()
-        self._cache_futures = {}
+        ensure_threadsafe_cache(self)
 
     def patched_check_disk_cache(self, tuning_key, configs, bench_fn):
         if not tuning_key or any(cfg.pre_hook for cfg in configs):
@@ -170,6 +182,7 @@ def patch_triton_autotuner() -> None:
         return False, bench_time, configs_timings, best_config
 
     def _get_config_for_key(self, key, args, kwargs):
+        ensure_threadsafe_cache(self)
         with self._cache_lock:
             cached = self._cache.get(key)
             if cached is not None:
@@ -232,6 +245,7 @@ def patch_triton_autotuner() -> None:
                 self._cache_futures.pop(key, None)
 
     def patched_run(self, *args, **kwargs):
+        ensure_threadsafe_cache(self)
         nargs = dict(zip(self.arg_names, args))
         self.nargs = nargs
         used_cached_result = True

--- a/tests/test_triton_patch_api.py
+++ b/tests/test_triton_patch_api.py
@@ -85,6 +85,31 @@ def test_patched_autotuner_constructor_owns_cache_lock(monkeypatch):
     assert autotuner._cache_futures == {}
 
 
+def test_patched_autotuner_lazily_initializes_preexisting_instance(monkeypatch):
+    triton_autotuner = pytest.importorskip("triton.runtime.autotuner")
+    existing_cache_value = object()
+
+    class _FakeAutotuner:
+        def __init__(self):
+            self.cache = {"existing": existing_cache_value}
+
+    autotuner = _FakeAutotuner()
+
+    monkeypatch.setattr(triton_autotuner, "Autotuner", _FakeAutotuner)
+    monkeypatch.setattr(triton_autotuner, "CacheFuture", None, raising=False)
+    monkeypatch.setattr(nogil_patcher, "version", lambda _package_name: "3.7.0")
+
+    nogil_patcher.patch_triton_autotuner()
+    cached, used_cached_result, bench_time = autotuner._get_config_for_key("existing", (), {})
+
+    assert cached is existing_cache_value
+    assert used_cached_result is True
+    assert bench_time is None
+    assert isinstance(autotuner._cache_lock, type(threading.RLock()))
+    assert autotuner.cache is autotuner._cache
+    assert autotuner._cache_futures == {}
+
+
 def test_package_init_uses_triton_patch_api():
     init_py = Path(__file__).resolve().parents[1] / "gptqmodel" / "__init__.py"
     tree = ast.parse(init_py.read_text(encoding="utf-8"))

--- a/tests/test_triton_patch_api.py
+++ b/tests/test_triton_patch_api.py
@@ -110,6 +110,105 @@ def test_patched_autotuner_lazily_initializes_preexisting_instance(monkeypatch):
     assert autotuner._cache_futures == {}
 
 
+def test_patched_autotuner_lazily_initializes_single_config_run(monkeypatch):
+    triton_autotuner = pytest.importorskip("triton.runtime.autotuner")
+
+    class _FakeConfig:
+        pre_hook = None
+
+        def all_kwargs(self):
+            return {"BLOCK_SIZE": 16}
+
+    class _FakeFn:
+        def run(self, *args, **kwargs):
+            return args, kwargs
+
+    class _FakeAutotuner:
+        def __init__(self):
+            self.arg_names = ["value"]
+            self.base_fn = _FakeFn.run
+            self.cache = {}
+            self.configs = [_FakeConfig()]
+            self.fn = _FakeFn()
+
+    autotuner = _FakeAutotuner()
+
+    monkeypatch.setattr(triton_autotuner, "Autotuner", _FakeAutotuner)
+    monkeypatch.setattr(triton_autotuner, "CacheFuture", None, raising=False)
+    monkeypatch.setattr(nogil_patcher, "version", lambda _package_name: "3.7.0")
+
+    nogil_patcher.patch_triton_autotuner()
+    result = autotuner.run("input")
+
+    assert result == (("input",), {"BLOCK_SIZE": 16})
+    assert autotuner.best_config is autotuner.configs[0]
+    assert isinstance(autotuner._cache_lock, type(threading.RLock()))
+    assert autotuner.cache is autotuner._cache
+    assert autotuner._cache_futures == {}
+
+
+def test_patched_autotuner_lazily_initializes_concurrent_first_lookup(monkeypatch):
+    triton_autotuner = pytest.importorskip("triton.runtime.autotuner")
+    benchmark_count = 0
+    benchmark_count_lock = threading.Lock()
+
+    class _FakeConfig:
+        def all_kwargs(self):
+            return {}
+
+    config = _FakeConfig()
+
+    class _FakeAutotuner:
+        def __init__(self):
+            self.cache = {}
+            self.cache_results = False
+            self.nargs = {}
+
+        def prune_configs(self, _kwargs):
+            return [config]
+
+        def _bench(self, *args, config, **kwargs):
+            nonlocal benchmark_count
+            with benchmark_count_lock:
+                benchmark_count += 1
+            time.sleep(0.01)
+            return 1.0
+
+        def pre_hook(self, _nargs, reset_only):
+            assert reset_only is True
+
+    autotuner = _FakeAutotuner()
+
+    monkeypatch.setattr(triton_autotuner, "Autotuner", _FakeAutotuner)
+    monkeypatch.setattr(triton_autotuner, "CacheFuture", None, raising=False)
+    monkeypatch.setattr(nogil_patcher, "version", lambda _package_name: "3.7.0")
+
+    nogil_patcher.patch_triton_autotuner()
+    barrier = threading.Barrier(16)
+    results = [None] * barrier.parties
+    errors = []
+
+    def lookup(index):
+        try:
+            barrier.wait()
+            results[index] = autotuner._get_config_for_key("new", (), {})
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=lookup, args=(index,)) for index in range(barrier.parties)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert benchmark_count == 1
+    assert all(result[0] is config for result in results)
+    assert all(result[1] is False for result in results)
+    assert autotuner._cache == {"new": config}
+    assert autotuner._cache_futures == {}
+
+
 def test_package_init_uses_triton_patch_api():
     init_py = Path(__file__).resolve().parents[1] / "gptqmodel" / "__init__.py"
     tree = ast.parse(init_py.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

Fixes #3059 by lazily installing GPTQModel's thread-safe Triton cache state when an autotuner instance was created before `TritonPatch.apply()`.

## What Changed

- Centralized patched autotuner cache initialization behind an idempotent helper that reuses `TritonPatch._apply_lock`; no additional lock or initialization marker is introduced.
- Invoke that helper from construction, cache lookup, and execution so already-created third-party autotuners are covered.
- Preserve cache entries populated before the patch is applied.
- Added regression coverage for cached lookup, single-config execution, and concurrent first use.
- No public API changes; broader FLA/Qwen evaluation remains out of scope for the CPU-only environment.

## Tests

- [x] I added a new simple/fast unit test for this change, or documented why that is not applicable.
- [x] I ran the new targeted test locally before opening this PR.
- [x] I ran any other directly relevant local tests.

Paste the exact test commands and results here:

```bash
cd tests && python -m pytest test_triton_patch_api.py::test_patched_autotuner_lazily_initializes_preexisting_instance -x -q
# Before fix: 1 failed with AttributeError: '_FakeAutotuner' object has no attribute '_cache_lock'

cd tests && python -m pytest test_triton_patch_api.py -x -q
# 9 passed

python -m ruff check gptqmodel/utils/nogil_patcher.py tests/test_triton_patch_api.py
# All checks passed
```

## Review Requirements

AI-assisted code is welcome.

Every changed file must still be properly reviewed by a human before the PR is opened as ready for review.

We will not accept PRs that are effectively unreviewed AI output. Non-human-reviewed changes often introduce obscure structure, mismatched APIs, project-inconsistent code patterns, or unnecessary monkeypatching instead of a correct fix or clean feature expansion.

- [ ] I personally reviewed every file in this diff.
- [ ] I checked that the code matches existing project structure, APIs, and conventions.
- [x] I avoided unnecessary monkeypatching and used the project's normal extension points where possible.

## Notes

Opened as draft pending the repository-required human review. The regression models the issue's import-order failure: an autotuner object exists before GPTQModel patches Triton's base class.

Link to Devin session: https://app.devin.ai/sessions/58bb2a5bb975453491254245e6008e8a
Open in Devin Desktop: https://app.devin.ai/desktop/session/58bb2a5bb975453491254245e6008e8a?variant=devin
Requested by: @Qubitium