### PR TITLE
[MODEL] support K2 Horizon quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 ## Latest News 🗞️🚀
 
+* 09/07/2026 7.4.0-dev `main`: ✨ Added `k2_horizon` quantization support for K2-Horizon dense and MoVA/MoE models.
 * 09/07/2026 7.4.0-dev `main`: ✨ Added XHToken `ouro` and `spark2_5` quantization support.
 * 09/02/2026 7.4.0-dev `main`: ✨ Added `apertus1p5` and `apertus1p5_text` quantization.
 * 09/01/2026 7.4.0-dev `main`: ✨ Added `glm5_next` / GLM-5.3-Flash quantization support.
@@ -276,7 +277,7 @@ Selected public references where teams or companies explicitly mention GPT-QMode
 | InternVL Chat | ✅ | Laguna | ✅ | Mimo / Mimo V2 | ✅ | Zamba / Zamba2 | ✅ | Intern S1 / S2 Preview | ✅ |
 | HunYuan V1 Dense / MoE | ✅ | HY-V3 | ✅ | Inkling | ✅ | Solar Open / Open 2 | ✅ | North Micro Vision | ✅ |
 | Mage-VL | ✅ | Unlimited-OCR | ✅ | HunyuanOCR | ✅ | LocateAnything | ✅ | Muse Glimmer | ✅ |
-| Ouro | ✅ | Spark-X2.5 | ✅ | SmolLM3 | ✅ |  |  |  |  |
+| Ouro | ✅ | Spark-X2.5 | ✅ | SmolLM3 | ✅ | K2-Horizon (Dense / MoVA) | ✅ |  |  |
 
 
 Prism Bonsai GGUF checkpoints are supported for inference only through GPT-QModel's native GGUF path and internal GGUF runtime. Bonsai checkpoints load through the normal model path or repo argument and do not require the external `gguf` package. Prism model quantization is not included.

--- a/gptqmodel/looper/forward_executor.py
+++ b/gptqmodel/looper/forward_executor.py
@@ -84,7 +84,11 @@ class ForwardExecutor:
             return nullcontext()
 
         should_use_lifecycle = getattr(self.looper, "_should_use_moe_lifecycle", None)
-        if callable(should_use_lifecycle) and not should_use_lifecycle(module, processor):
+        if callable(should_use_lifecycle) and not should_use_lifecycle(
+            module,
+            processor,
+            current_subset=current_subset,
+        ):
             return nullcontext()
 
         return self.looper.MoELifecycleContext(

--- a/gptqmodel/looper/module_looper.py
+++ b/gptqmodel/looper/module_looper.py
@@ -480,9 +480,17 @@ class ModuleLooper(DeviceAssignmentState):
 
         def __enter__(self):
             """Set up MoE lifecycle hooks if applicable."""
-            if self.module_looper._should_use_moe_lifecycle(self.module, self.processor):
+            if self.module_looper._should_use_moe_lifecycle(
+                self.module,
+                self.processor,
+                current_subset=self.current_subset,
+            ):
                 hooks = self.module_looper.gptq_model.moe_lifecycle_hooks
-                self.moe_block = hooks.get_moe_block(self.module, self.module_looper.gptq_model.__class__)
+                self.moe_block = hooks.get_moe_block_for_subset(
+                    self.module,
+                    self.module_looper.gptq_model.__class__,
+                    current_subset=self.current_subset,
+                )
 
                 if self.moe_block is not None:
                     # Save original forward method
@@ -888,7 +896,12 @@ class ModuleLooper(DeviceAssignmentState):
             return True
         return False
 
-    def _should_use_moe_lifecycle(self, module: nn.Module, processor: LoopProcessor) -> bool:
+    def _should_use_moe_lifecycle(
+        self,
+        module: nn.Module,
+        processor: LoopProcessor,
+        current_subset: Optional[Dict[str, Any]] = None,
+    ) -> bool:
         """
         Check if MoE lifecycle hooks should be used for this module.
 
@@ -913,7 +926,11 @@ class ModuleLooper(DeviceAssignmentState):
             return False
 
         # Check if this module contains an MoE block
-        moe_block = hooks.get_moe_block(module, self.gptq_model.__class__)
+        moe_block = hooks.get_moe_block_for_subset(
+            module,
+            self.gptq_model.__class__,
+            current_subset=current_subset,
+        )
         if moe_block is None:
             log.warn(
                 f"pass_whole_dataset_to_each_expert is enabled but no MoE block found in module "

--- a/gptqmodel/looper/stage_subset.py
+++ b/gptqmodel/looper/stage_subset.py
@@ -809,7 +809,11 @@ def _run_single_subset_pass(
     if looper.gptq_model and hasattr(looper.gptq_model, 'moe_lifecycle_hooks'):
         hooks = looper.gptq_model.moe_lifecycle_hooks
         if hooks is not None:
-            moe_block = hooks.get_moe_block(module, looper.gptq_model.__class__)
+            moe_block = hooks.get_moe_block_for_subset(
+                module,
+                looper.gptq_model.__class__,
+                current_subset=subset,
+            )
             if moe_block is not None:
                 # Get the full name/path of the MoE block
                 for mod_name, mod in module.named_modules():

--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -129,6 +129,7 @@ from .definitions.internlm2 import InternLM2QModel  # noqa: E402
 from .definitions.intern_s2_preview import InternS2PreviewQModel  # noqa: E402
 from .definitions.interns1 import InternS1QModel  # noqa: E402
 from .definitions.internvl_chat import InternVLChatQModel  # noqa: E402
+from .definitions.k2_horizon import K2HorizonQModel  # noqa: E402
 from .definitions.klear import KlearQModel  # noqa: E402
 from .definitions.kimi_k25 import KimiK25QModel  # noqa: E402
 from .definitions.laguna import LagunaQModel  # noqa: E402
@@ -268,6 +269,7 @@ MODEL_MAP = {
     "hunyuan_v1_moe": HunYuanMoEV1QModel,
     "hunyuan_vl": HunYuanVLQModel,
     "hy_v3": HYV3QModel,
+    "k2_horizon": K2HorizonQModel,
     "qwen": QwenQModel,
     "mistral": LlamaQModel, # 100% llama clone
     "yi": LlamaQModel, # 100% llama clone

--- a/gptqmodel/models/base.py
+++ b/gptqmodel/models/base.py
@@ -269,6 +269,12 @@ class BaseQModel(nn.Module):
     # usage: set to property in model.config that holds this int value: total number of experts
     dynamic_expert_index: Optional[str] = None
 
+    # Optional per-module expert cardinalities for architectures that contain
+    # more than one expert family in a decoder layer.  Keys are layer-relative
+    # prefixes (for example ``mlp.experts``) and values are config attributes.
+    # Entries not matching a key continue to use ``dynamic_expert_index``.
+    dynamic_expert_indices: Optional[Dict[str, str]] = None
+
     # some models require a different model loader, such as mllama which uses AutoModelForPreTraining
     loader = AutoModelForCausalLM
 
@@ -683,6 +689,10 @@ class BaseQModel(nn.Module):
         if model_config is not None and cls.dynamic_expert_index is not None:
             num_experts = cls.get_num_experts(model_config)
 
+            def expert_count(module_name: str) -> int:
+                count = cls.get_num_experts_for_module(model_config, module_name)
+                return num_experts if count is None else count
+
             moe_simple = []
             capture_only_modules = None
             for names in layer_modules:
@@ -728,9 +738,19 @@ class BaseQModel(nn.Module):
                         if not is_expert_segment:
                             moe_simple[-1].extend(segment_names)
                             continue
-                        for index in range(num_experts):
+                        # Most definitions use one cardinality per block.  If
+                        # a block mixes families, retain each family's own
+                        # count instead of expanding every placeholder with
+                        # the global MoE count.
+                        segment_counts = {expert_count(n) for n in segment_names}
+                        if len(segment_counts) == 1:
+                            for index in range(segment_counts.pop()):
+                                for n in segment_names:
+                                    moe_simple[-1].append(n.replace(EXPERT_INDEX_PLACEHOLDER, str(index)))
+                        else:
                             for n in segment_names:
-                                moe_simple[-1].append(n.replace(EXPERT_INDEX_PLACEHOLDER, str(index)))
+                                for index in range(expert_count(n)):
+                                    moe_simple[-1].append(n.replace(EXPERT_INDEX_PLACEHOLDER, str(index)))
                     # Currently, only need to add `capture_only_modules` to `['mlp.experts.#.gate_proj', 'mlp.experts.#.up_proj']`
                     # or ['mlp.shared_expert.gate_proj', 'mlp.shared_expert.up_proj', 'mlp.experts.#.gate_proj', 'mlp.experts.#.up_proj']
                     # or ['mlp.shared_experts.gate_proj', 'mlp.shared_experts.up_proj', 'mlp.experts.#.gate_proj', 'mlp.experts.#.up_proj']
@@ -741,7 +761,7 @@ class BaseQModel(nn.Module):
                 else:
                     # result like: ['mlp.experts.0.gate_proj', 'mlp.experts.1.gate_proj', 'mlp.experts.0.up_proj', 'mlp.experts.1.up_proj', ...]
                     for n in names:
-                        for index in range(num_experts):
+                        for index in range(expert_count(n)):
                             moe_simple[-1].append(n.replace(EXPERT_INDEX_PLACEHOLDER, str(index)))
 
             return moe_simple
@@ -750,6 +770,7 @@ class BaseQModel(nn.Module):
 
     @classmethod
     def get_num_experts(cls, model_config):
+        """Return the model-wide fallback expert count."""
         if hasattr(model_config, "text_config"):
             num_experts = getattr(model_config.text_config, cls.dynamic_expert_index)
         elif hasattr(model_config, "thinker_config"):
@@ -757,6 +778,50 @@ class BaseQModel(nn.Module):
         else:
             num_experts = getattr(model_config, cls.dynamic_expert_index)
         return num_experts
+
+    @classmethod
+    def get_num_experts_for_module(cls, model_config, module_name: str) -> Optional[int]:
+        """Resolve a placeholder's expert count from its longest matching prefix.
+
+        ``module_name`` is a layer-relative module-tree path.  A missing or
+        malformed mapped config field deliberately falls back to the legacy
+        ``dynamic_expert_index`` behavior so existing model definitions remain
+        compatible.
+        """
+        if not isinstance(module_name, str) or EXPERT_INDEX_PLACEHOLDER not in module_name:
+            return None
+
+        expert_prefix = module_name.split(EXPERT_INDEX_PLACEHOLDER, 1)[0].rstrip(".")
+        mappings = getattr(cls, "dynamic_expert_indices", None) or {}
+        matched = None
+        for prefix, field_name in mappings.items():
+            if not isinstance(prefix, str) or not isinstance(field_name, str):
+                continue
+            prefix = prefix.strip(".")
+            if expert_prefix == prefix or expert_prefix.startswith(f"{prefix}."):
+                if matched is None or len(prefix) > len(matched[0]):
+                    matched = (prefix, field_name)
+
+        field_name = matched[1] if matched is not None else cls.dynamic_expert_index
+        if not field_name:
+            return None
+
+        config = model_config
+        if hasattr(config, "text_config"):
+            config = config.text_config
+        elif hasattr(config, "thinker_config"):
+            config = config.thinker_config.text_config
+        value = getattr(config, field_name, None)
+        if value is None and matched is not None:
+            # Mapped fields are optional on dense/checkpoint compatibility
+            # configs; preserve the legacy fallback in that case.
+            value = getattr(config, cls.dynamic_expert_index, None) if cls.dynamic_expert_index else None
+        if value is None:
+            return None
+        try:
+            return max(int(value), 0)
+        except (TypeError, ValueError):
+            return None
 
     @classmethod
     def filter_not_quantize_module(cls, layer_modules, quantize_config):

--- a/gptqmodel/models/definitions/__init__.py
+++ b/gptqmodel/models/definitions/__init__.py
@@ -61,6 +61,7 @@ from .internlm2 import InternLM2QModel
 from .intern_s2_preview import InternS2PreviewQModel
 from .interns1 import InternS1QModel
 from .internvl_chat import InternVLChatQModel
+from .k2_horizon import K2HorizonGPTQ, K2HorizonQModel
 from .lfm2_vl import LFM2VLQModel
 from .mage_vl import MageVLQModel
 from .llama4 import Llama4QModel, Llama4TextQModel

--- a/gptqmodel/models/definitions/k2_horizon.py
+++ b/gptqmodel/models/definitions/k2_horizon.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, Dict, Optional
+
+import torch
+
+from ...nn_modules.hooked_linear import StopForward
+from ...utils.device import get_device
+from ...utils.model import move_to
+from ..base import BaseQModel
+from ..moe_lifecycle import GateUpDownMoELifecycleHooks, _get_module_by_relative_path
+
+
+class K2HorizonMoELifecycleHooks(GateUpDownMoELifecycleHooks):
+    """Quantization replay hooks for K2's MLP MoE and MoVA value experts."""
+
+    def get_moe_block_for_subset(
+        self,
+        layer_module: torch.nn.Module,
+        model_class: type,
+        current_subset: Optional[Dict[str, Any]] = None,
+    ) -> Optional[torch.nn.Module]:
+        # ``module_tree`` keeps ``mlp`` as the canonical :moe root for generic
+        # MoE handling.  MoVA value experts are a second family in attention;
+        # select that block only when the active subset contains its leaves.
+        if current_subset and any(
+            name.startswith("self_attn.v_experts.") for name in current_subset
+        ):
+            return getattr(layer_module, "self_attn", None)
+        return super().get_moe_block_for_subset(
+            layer_module,
+            model_class,
+            current_subset=current_subset,
+        )
+
+    def _extract_moe_block_prefix(
+        self,
+        subset: Dict[str, Any],
+        moe_block: torch.nn.Module,
+    ) -> Optional[str]:
+        if any(name.startswith("self_attn.v_experts.") for name in subset or ()):
+            return "self_attn"
+        return super()._extract_moe_block_prefix(subset, moe_block)
+
+    def forward_to_all_experts(
+        self,
+        moe_block: torch.nn.Module,
+        hidden_states: torch.Tensor,
+        processor: Any,
+        subset: Dict[str, Any],
+        ordered_module_names: Optional[list[str]],
+        original_forward: callable,
+        model_class: type,
+        module_looper: Any,
+        moe_block_prefix: Optional[str] = None,
+        replica_module: Optional[torch.nn.Module] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        v_experts = getattr(moe_block, "v_experts", None)
+        if v_experts is None:
+            return super().forward_to_all_experts(
+                moe_block=moe_block,
+                hidden_states=hidden_states,
+                processor=processor,
+                subset=subset,
+                ordered_module_names=ordered_module_names,
+                original_forward=original_forward,
+                model_class=model_class,
+                module_looper=module_looper,
+                moe_block_prefix=moe_block_prefix,
+                replica_module=replica_module,
+                **kwargs,
+            )
+
+        if hidden_states.dim() == 3:
+            expert_input = hidden_states.reshape(-1, hidden_states.shape[-1])
+        else:
+            expert_input = hidden_states
+
+        prefix = moe_block_prefix or "self_attn"
+        expert_count = 0
+        stop_forward_raised = False
+
+        for expert_idx, expert in enumerate(v_experts):
+            expert_name = f"{prefix}.v_experts.{expert_idx}"
+            if expert_name not in subset:
+                continue
+
+            runtime_expert = expert
+            if replica_module is not None:
+                runtime_expert = _get_module_by_relative_path(
+                    replica_module, expert_name
+                )
+            if runtime_expert is None:
+                runtime_expert = subset[expert_name]
+
+            try:
+                runtime_device = get_device(runtime_expert)
+                runtime_expert(move_to(expert_input, runtime_device))
+                expert_count += 1
+            except StopForward:
+                stop_forward_raised = True
+
+        if stop_forward_raised:
+            raise StopForward()
+
+        # The native MoVA forward routes through v_experts again.  Pause the
+        # processor hooks for that final call so each selected leaf is counted
+        # exactly once while preserving the model's true attention output.
+        if expert_count > 0:
+            module_looper._set_processor_hooks_paused(processor, True)
+            try:
+                return original_forward(hidden_states, **kwargs)
+            finally:
+                module_looper._set_processor_hooks_paused(processor, False)
+        return original_forward(hidden_states, **kwargs)
+
+
+class K2HorizonQModel(BaseQModel):
+    """GPT-QModel definition for K2 Horizon dense and MoVA checkpoints."""
+
+    require_trust_remote_code = True
+    layer_modules_strict = False
+    dynamic_expert_index = "num_experts"
+    dynamic_expert_indices = {
+        "mlp.experts": "num_experts",
+        "self_attn.v_experts": "mova_num_experts",
+    }
+
+    pre_lm_head_norm_module = "model.norm"
+    moe_expert_module_name_prefixes = [".expert", ".v_experts."]
+    moe_lifecycle_hooks = K2HorizonMoELifecycleHooks()
+
+    module_tree = [
+        "model",
+        "layers",
+        "#",
+        {
+            "input_layernorm": ("input_layernorm:!",),
+            "self_attn": {
+                "q_norm": ("q_norm:!",),
+                "k_norm": ("k_norm:!",),
+                "q_proj": ("q_proj:0",),
+                "k_proj": ("k_proj:0",),
+                # Dense layers expose v_proj; MoVA layers expose routed value
+                # experts instead.  Strict=False makes this one tree valid for
+                # both layer variants.
+                "v_proj": ("v_proj:0",),
+                "gate_proj": ("gate_proj:0",),
+                "v_router": ("v_router:!",),
+                "v_experts": {
+                    # ('#',) denotes the ModuleList element itself, whose
+                    # runtime module is a Linear rather than an MLP wrapper.
+                    "#": ("#",),
+                },
+                "o_proj": ("o_proj:1",),
+            },
+            "post_attention_layernorm": ("post_attention_layernorm:!",),
+            "mlp:moe": {
+                "gate": ("gate:!",),
+                "experts": {
+                    "#": ("gate_proj:0", "up_proj:0", "down_proj:1"),
+                },
+                "shared_experts": ("gate_proj:0", "up_proj:0", "down_proj:1"),
+                # Dense fallback used by K2-Horizon's first layers and the
+                # standalone 0.9B dense checkpoint.
+                "": ("gate_proj:0", "up_proj:0", "down_proj:1"),
+            },
+        },
+    ]
+
+
+# A descriptive alias is useful to callers that use GPTQ-oriented names.
+K2HorizonGPTQ = K2HorizonQModel
+
+__all__ = ["K2HorizonGPTQ", "K2HorizonMoELifecycleHooks", "K2HorizonQModel"]

--- a/gptqmodel/models/moe_lifecycle.py
+++ b/gptqmodel/models/moe_lifecycle.py
@@ -83,7 +83,6 @@ class MoELifecycleHooks:
         Args:
             layer_module: The layer module (e.g., DecoderLayer)
             model_class: The model class (to access module_tree)
-
         Returns:
             The MoE block module, or None if not found
 
@@ -102,6 +101,20 @@ class MoELifecycleHooks:
         moe_block = getattr(layer_module, moe_module_name[0], None)
 
         return moe_block
+
+    def get_moe_block_for_subset(
+        self,
+        layer_module: nn.Module,
+        model_class: type,
+        current_subset: Optional[Dict[str, Any]] = None,
+    ) -> Optional[nn.Module]:
+        """Resolve the MoE root for a quantization subset.
+
+        The default delegates to the original two-argument hook so existing
+        model-specific ``get_moe_block`` overrides remain compatible. Models
+        with multiple expert families can override this method.
+        """
+        return self.get_moe_block(layer_module, model_class)
 
     def get_experts_module(self, moe_block: nn.Module, model_class: type) -> Optional[nn.Module]:
         """

--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -155,6 +155,8 @@ MoETopKState = List[Tuple[nn.Module, str, int]]
 MOE_TOPK_FIELD_NAMES = [
     "top_k",
     "moe_k", # ernie4_5_vl_moe
+    # K2 Horizon's MoVA router uses this name instead of ``top_k``.
+    "num_experts_per_tok",
 ]
 
 MOE_NUM_EXPERTS_FIELD_NAMES = [
@@ -2256,22 +2258,51 @@ def has_any_attr(obj, names):
 def find_moe_routing_modules(model):
     modules = []
     for module in model.modules():
-        if has_any_attr(module, MOE_TOPK_FIELD_NAMES) and \
-                has_any_attr(module, MOE_NUM_EXPERTS_FIELD_NAMES):
+        if has_any_attr(module, MOE_TOPK_FIELD_NAMES) and _get_local_expert_count(module):
             modules.append(module)
     return modules
+
+
+def _get_local_expert_count(module: nn.Module) -> Optional[int]:
+    """Return the expert cardinality owned by one router module.
+
+    Most MoE implementations expose ``num_experts`` directly.  K2 Horizon's
+    MoVA value router instead owns an ``nn.ModuleList`` called ``v_experts``;
+    deriving its local count is important because the model also contains a
+    separate 100-expert MLP router.
+    """
+    for name in MOE_NUM_EXPERTS_FIELD_NAMES:
+        value = getattr(module, name, None)
+        if isinstance(value, int) and value > 0:
+            return value
+
+    experts = getattr(module, "v_experts", None)
+    if experts is not None:
+        try:
+            count = len(experts)
+        except TypeError:
+            count = 0
+        if count > 0:
+            return count
+    return None
 
 
 def set_moe_topk(model: nn.Module, new_topk: int) -> MoETopKState:
     routers = find_moe_routing_modules(model)
     state: MoETopKState = []
     for r in routers:
+        local_count = _get_local_expert_count(r)
+        if local_count is None:
+            continue
         for name in MOE_TOPK_FIELD_NAMES:
             if hasattr(r, name):
                 old = getattr(r, name)
                 assert isinstance(old, int)
                 state.append((r, name, old))
-                setattr(r, name, new_topk)
+                # A global override is resolved independently for every
+                # router.  In particular, an override of 100 means all 100
+                # MLP experts but only the 64 local MoVA value experts.
+                setattr(r, name, min(new_topk, local_count))
                 break
     return state
 

--- a/tests/models/test_k2_horizon.py
+++ b/tests/models/test_k2_horizon.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+from model_test import ModelTest
+
+from gptqmodel.quantization.config import ExpertsRoutingBypass, MoEConfig
+
+
+class TestK2Horizon(ModelTest):
+    NATIVE_MODEL_ID = "/monster/data/model/K2-Horizon-0.9B"
+    TRUST_REMOTE_CODE = True
+    USE_FLASH_ATTN = False
+    EVAL_BATCH_SIZE = 32
+    EVAL_TASKS_SLOW = {
+        "arc_challenge": {
+            "acc": {"value": 0.30802047781569963, "floor_pct": 0.04},
+            "acc_norm": {"value": 0.3191126279863481, "floor_pct": 0.04},
+        },
+    }
+    EVAL_TASKS_FAST = ModelTest.derive_fast_eval_tasks(EVAL_TASKS_SLOW)
+    MODEL_COMPAT_FAST_LAYER_POSITION = "first"
+
+    def test_k2_horizon(self):
+        self.quantize_and_evaluate()
+
+
+class TestK2HorizonMoVA(ModelTest):
+    NATIVE_MODEL_ID = "/monster/data/model/K2-Horizon-MoVA-36B-A4B"
+    TRUST_REMOTE_CODE = True
+    USE_FLASH_ATTN = False
+    EVAL_BATCH_SIZE = 4
+    DATASET_SIZE_FAST = 32
+    # Full dense BF16 ARC-Challenge baseline (1,172 samples):
+    # acc=0.5776450511945392, acc_norm=0.5964163822525598.
+    EVAL_TASKS_SLOW = {
+        "arc_challenge": {
+            "acc": {"value": 0.5537542662116041, "floor_pct": 0.04},
+            "acc_norm": {"value": 0.5776450511945392, "floor_pct": 0.04},
+        },
+    }
+    EVAL_TASKS_FAST = ModelTest.derive_fast_eval_tasks(EVAL_TASKS_SLOW)
+    # K2 has two independently sized routed families (100 MLP experts and 64
+    # MoVA value experts). Replay the calibration set through every expert;
+    # chunking keeps the per-subset memory bounded.
+    MOE_CONFIG = MoEConfig(routing=ExpertsRoutingBypass(batch_size=16))
+    # The first three layers are dense; exercise a real MoVA/MoE layer in fast mode.
+    MODEL_COMPAT_FAST_LAYER_POSITION = "last"
+
+    @classmethod
+    def load_dataset(cls, tokenizer=None, rows: int = 0):
+        # The MoVA checkpoint's chat template requires every historical
+        # assistant message to carry an explicit thinking field. The shared
+        # calibration corpus does not provide one, but it includes an
+        # equivalent pre-rendered text sample. Use that representation rather
+        # than inventing reasoning content merely to satisfy the template.
+        dataset = super().load_dataset(tokenizer=tokenizer, rows=rows)
+        return [{"text": sample["text"]} for sample in dataset]
+
+    def test_k2_horizon_mova(self):
+        self.quantize_and_evaluate()

--- a/tests/test_k2_horizon_support.py
+++ b/tests/test_k2_horizon_support.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+from transformers import dynamic_module_utils
+
+from gptqmodel.models import auto
+from gptqmodel.models.definitions.k2_horizon import (
+    K2HorizonMoELifecycleHooks,
+    K2HorizonQModel,
+)
+from gptqmodel.utils.model import (
+    find_moe_routing_modules,
+    restore_moe_topk,
+    set_moe_topk,
+)
+
+
+MOVA_MODEL_PATH = Path("/monster/data/model/K2-Horizon-MoVA-36B-A4B")
+DENSE_MODEL_PATH = Path("/monster/data/model/K2-Horizon-0.9B")
+
+
+def _quantize_config():
+    return SimpleNamespace(dynamic=None)
+
+
+def test_k2_horizon_model_type_selects_definition(monkeypatch):
+    monkeypatch.setattr(
+        auto,
+        "resolve_trust_remote_code",
+        lambda path, trust_remote_code=False: trust_remote_code,
+    )
+    monkeypatch.setattr(
+        auto.AutoConfig,
+        "from_pretrained",
+        lambda *args, **kwargs: SimpleNamespace(model_type="k2_horizon"),
+    )
+
+    assert (
+        auto.check_and_get_model_definition(
+            "k2-horizon-fixture", trust_remote_code=True
+        )
+        is K2HorizonQModel
+    )
+
+
+def test_k2_horizon_expands_mlp_and_mova_experts_with_independent_counts():
+    config = SimpleNamespace(num_experts=100, mova_num_experts=64)
+    blocks = K2HorizonQModel.simple_layer_modules(config, _quantize_config())
+    modules = {name for block in blocks for name in block}
+
+    assert K2HorizonQModel.dynamic_expert_index == "num_experts"
+    assert K2HorizonQModel.dynamic_expert_indices == {
+        "mlp.experts": "num_experts",
+        "self_attn.v_experts": "mova_num_experts",
+    }
+    assert "self_attn.v_experts.0" in modules
+    assert "self_attn.v_experts.63" in modules
+    assert "self_attn.v_experts.64" not in modules
+    assert "mlp.experts.0.gate_proj" in modules
+    assert "mlp.experts.99.down_proj" in modules
+    assert "mlp.experts.100.gate_proj" not in modules
+    assert {
+        "self_attn.q_proj",
+        "self_attn.k_proj",
+        "self_attn.v_proj",
+        "self_attn.gate_proj",
+        "self_attn.o_proj",
+        "mlp.shared_experts.gate_proj",
+        "mlp.gate_proj",
+        "mlp.up_proj",
+        "mlp.down_proj",
+    } <= modules
+    assert "self_attn.v_router" not in modules
+    assert "mlp.gate" not in modules
+
+
+def test_k2_horizon_dense_config_does_not_expand_expert_placeholders():
+    config = SimpleNamespace(num_experts=0, mova_num_experts=0)
+    modules = {
+        name
+        for block in K2HorizonQModel.simple_layer_modules(config, _quantize_config())
+        for name in block
+    }
+
+    assert not any(name.startswith("self_attn.v_experts.") for name in modules)
+    assert not any(name.startswith("mlp.experts.") for name in modules)
+    assert {
+        "self_attn.v_proj",
+        "mlp.gate_proj",
+        "mlp.up_proj",
+        "mlp.down_proj",
+    } <= modules
+
+
+class _MLPRouter(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.top_k = 8
+        self.num_experts = 100
+
+
+class _MoVARouter(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.num_experts_per_tok = 4
+        self.v_experts = torch.nn.ModuleList([torch.nn.Identity() for _ in range(64)])
+
+
+def test_k2_horizon_routing_override_clamps_each_router_to_its_local_count():
+    model = torch.nn.Module()
+    model.mlp = _MLPRouter()
+    model.self_attn = _MoVARouter()
+
+    assert find_moe_routing_modules(model) == [model.mlp, model.self_attn]
+    state = set_moe_topk(model, 100)
+    assert model.mlp.top_k == 100
+    assert model.self_attn.num_experts_per_tok == 64
+
+    restore_moe_topk(state)
+    assert model.mlp.top_k == 8
+    assert model.self_attn.num_experts_per_tok == 4
+
+
+def test_k2_horizon_lifecycle_selects_expert_family_from_subset():
+    layer = torch.nn.Module()
+    layer.self_attn = _MoVARouter()
+    layer.mlp = _MLPRouter()
+    hooks = K2HorizonMoELifecycleHooks()
+
+    assert (
+        hooks.get_moe_block_for_subset(
+            layer,
+            K2HorizonQModel,
+            current_subset={"self_attn.v_experts.0": object()},
+        )
+        is layer.self_attn
+    )
+    assert (
+        hooks.get_moe_block_for_subset(
+            layer,
+            K2HorizonQModel,
+            current_subset={"mlp.experts.0.gate_proj": object()},
+        )
+        is layer.mlp
+    )
+
+
+def test_k2_horizon_lifecycle_replays_mova_inputs_through_each_value_expert():
+    class _MoVABlock(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.v_experts = torch.nn.ModuleList(
+                [torch.nn.Linear(4, 3, bias=False), torch.nn.Linear(4, 3, bias=False)]
+            )
+
+    class _Looper:
+        def __init__(self):
+            self.paused = []
+
+        def _set_processor_hooks_paused(self, processor, paused):
+            self.paused.append(paused)
+
+    block = _MoVABlock()
+    calls = [0, 0]
+    handles = []
+    for index, expert in enumerate(block.v_experts):
+        handles.append(
+            expert.register_forward_pre_hook(
+                lambda module, args, index=index: calls.__setitem__(
+                    index, calls[index] + 1
+                )
+            )
+        )
+
+    hidden_states = torch.randn(2, 3, 4)
+    looper = _Looper()
+    result = K2HorizonMoELifecycleHooks().forward_to_all_experts(
+        moe_block=block,
+        hidden_states=hidden_states,
+        processor=object(),
+        subset={
+            "self_attn.v_experts.0": block.v_experts[0],
+            "self_attn.v_experts.1": block.v_experts[1],
+        },
+        ordered_module_names=[
+            "self_attn.v_experts.0",
+            "self_attn.v_experts.1",
+        ],
+        original_forward=lambda inputs, **kwargs: inputs + 1,
+        model_class=K2HorizonQModel,
+        module_looper=looper,
+        moe_block_prefix="self_attn",
+    )
+
+    for handle in handles:
+        handle.remove()
+    assert calls == [1, 1]
+    assert looper.paused == [True, False]
+    torch.testing.assert_close(result, hidden_states + 1)
+
+
+@pytest.mark.parametrize("model_path", [MOVA_MODEL_PATH, DENSE_MODEL_PATH])
+def test_local_k2_horizon_remote_config_matches_registered_definition(
+    model_path, monkeypatch, tmp_path
+):
+    if not model_path.is_dir():
+        pytest.skip(f"local K2 fixture is unavailable: {model_path}")
+
+    modules_cache = tmp_path / "hf_modules"
+    monkeypatch.setattr(dynamic_module_utils, "HF_MODULES_CACHE", str(modules_cache))
+    config = auto.AutoConfig.from_pretrained(
+        model_path,
+        trust_remote_code=True,
+        local_files_only=True,
+    )
+    assert config.model_type == "k2_horizon"
+    assert auto.MODEL_MAP[config.model_type] is K2HorizonQModel


### PR DESCRIPTION
## Summary

- add `k2_horizon` model registration and module definitions for the dense 0.9B checkpoint
- support the 36B MoVA/MoE checkpoint's independently sized 100-expert MLP and 64-expert value-attention families
- extend MoE lifecycle routing and per-module expert expansion without breaking existing two-argument lifecycle hooks
- add dense and MoVA `ModelTest` coverage, including ARC-Challenge score baselines and strict-template-compatible calibration input
- document K2-Horizon support in the README

## Validation

- `pytest -q tests/test_k2_horizon_support.py` (8 passed)
- related MoE/module-stage regression suite (95 passed)
- Ruff checks and `git diff --check`
- 0.9B one-layer INT4/Marlin quantization plus full ARC-Challenge evaluation
- 36B dense BF16 ARC-Challenge baseline over 1,172 samples
- direct Transformers/Tokenicer prompt and token-ID comparison for both checkpoints

## Notes

The MoVA checkpoint requires historical assistant chat messages to contain an explicit thinking field. Its test therefore uses the calibration corpus's existing pre-rendered `text` representation instead of inventing reasoning content.
