### PR TITLE
Scope banner Git lookup to the package checkout

### DIFF
--- a/gptqmodel/_banner.py
+++ b/gptqmodel/_banner.py
@@ -3,8 +3,11 @@
 
 from __future__ import annotations
 
-from importlib.metadata import PackageNotFoundError, version as package_version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as package_version
+from pathlib import Path
 from typing import Iterable
+
 
 TRITON_PACKAGE_CANDIDATES = (
     "triton",
@@ -52,15 +55,23 @@ def build_startup_banner(
     return "\n".join([ascii_logo.rstrip("\n"), *formatted_rows])
 
 
-def _get_git_commit():
+def _get_git_commit() -> str:
+    """Read the package checkout's commit independently of the caller's directory."""
     import subprocess
+
     try:
-        hash = subprocess.check_output(
-            ["git", "rev-parse", "--short", "HEAD"]
-        ).decode().strip()
-        return f"+{hash}"
+        repo_root = Path(__file__).resolve().parent.parent
+        if not (repo_root / ".git").exists():
+            return ""
+        commit = subprocess.check_output(
+            ["git", "-C", str(repo_root), "rev-parse", "--short", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        return f"+{commit}"
     except Exception:
         return ""
+
 
 def get_startup_banner(
     ascii_logo: str,

--- a/gptqmodel/_banner.py
+++ b/gptqmodel/_banner.py
@@ -3,11 +3,9 @@
 
 from __future__ import annotations
 
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as package_version
+from importlib.metadata import PackageNotFoundError, version as package_version
 from pathlib import Path
 from typing import Iterable
-
 
 TRITON_PACKAGE_CANDIDATES = (
     "triton",
@@ -55,10 +53,9 @@ def build_startup_banner(
     return "\n".join([ascii_logo.rstrip("\n"), *formatted_rows])
 
 
-def _get_git_commit() -> str:
+def _get_git_commit():
     """Read the package checkout's commit independently of the caller's directory."""
     import subprocess
-
     try:
         repo_root = Path(__file__).resolve().parent.parent
         if not (repo_root / ".git").exists():
@@ -71,7 +68,6 @@ def _get_git_commit() -> str:
         return f"+{commit}"
     except Exception:
         return ""
-
 
 def get_startup_banner(
     ascii_logo: str,

--- a/tests/test_startup_banner.py
+++ b/tests/test_startup_banner.py
@@ -2,16 +2,87 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib.util
+import subprocess
 from pathlib import Path
+
+import pytest
 
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "gptqmodel" / "_banner.py"
-MODULE_SPEC = importlib.util.spec_from_file_location("gptqmodel_banner_test_module", MODULE_PATH)
+MODULE_SPEC = importlib.util.spec_from_file_location(
+    "gptqmodel_banner_test_module", MODULE_PATH
+)
 assert MODULE_SPEC is not None
 assert MODULE_SPEC.loader is not None
 
 banner_module = importlib.util.module_from_spec(MODULE_SPEC)
 MODULE_SPEC.loader.exec_module(banner_module)
+
+
+def _init_repository(path: Path) -> str:
+    path.mkdir()
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(path),
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.invalid",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-q",
+            "--allow-empty",
+            "-m",
+            path.name,
+        ],
+        check=True,
+    )
+    return subprocess.check_output(
+        ["git", "-C", str(path), "rev-parse", "--short", "HEAD"], text=True
+    ).strip()
+
+
+@pytest.mark.parametrize("installation", ["wheel", "checkout", "worktree"])
+def test_git_hash_uses_package_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, installation: str
+) -> None:
+    foreign = tmp_path / "foreign"
+    foreign_commit = _init_repository(foreign)
+    source = tmp_path / "source"
+    source_commit = _init_repository(source)
+    assert source_commit != foreign_commit
+
+    package_root = source
+    if installation == "wheel":
+        package_root = tmp_path / "site-packages"
+    elif installation == "worktree":
+        package_root = tmp_path / "worktree"
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(source),
+                "worktree",
+                "add",
+                "--detach",
+                str(package_root),
+                "HEAD",
+            ],
+            check=True,
+            capture_output=True,
+        )
+        assert (package_root / ".git").is_file()
+
+    monkeypatch.setattr(
+        banner_module, "__file__", str(package_root / "gptqmodel" / "_banner.py")
+    )
+    monkeypatch.chdir(foreign)
+    expected = "" if installation == "wheel" else f"+{source_commit}"
+    assert banner_module._get_git_commit() == expected
 
 
 def test_build_startup_banner_aligns_versions():
@@ -67,4 +138,7 @@ def test_get_startup_banner_resolves_optional_versions(monkeypatch):
         torch_version="2.10.0+cu130",
     )
 
-    assert any(line.startswith("Triton") and line.endswith("3.6.0") for line in banner.splitlines())
+    assert any(
+        line.startswith("Triton") and line.endswith("3.6.0")
+        for line in banner.splitlines()
+    )

--- a/tests/test_startup_banner.py
+++ b/tests/test_startup_banner.py
@@ -9,9 +9,7 @@ import pytest
 
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "gptqmodel" / "_banner.py"
-MODULE_SPEC = importlib.util.spec_from_file_location(
-    "gptqmodel_banner_test_module", MODULE_PATH
-)
+MODULE_SPEC = importlib.util.spec_from_file_location("gptqmodel_banner_test_module", MODULE_PATH)
 assert MODULE_SPEC is not None
 assert MODULE_SPEC.loader is not None
 
@@ -138,7 +136,4 @@ def test_get_startup_banner_resolves_optional_versions(monkeypatch):
         torch_version="2.10.0+cu130",
     )
 
-    assert any(
-        line.startswith("Triton") and line.endswith("3.6.0")
-        for line in banner.splitlines()
-    )
+    assert any(line.startswith("Triton") and line.endswith("3.6.0") for line in banner.splitlines())


### PR DESCRIPTION
## Summary

The startup banner can report an unrelated repository's commit when GPTQModel is imported from that directory. Run Git from the package checkout and omit the commit suffix when the package has no Git metadata.

## What Changed

- Resolve the Git checkout relative to the package, including linked worktrees.
- Test simulated wheel placement, a source checkout, and a linked worktree from an unrelated working directory.

## Tests

- [x] I added a new simple/fast unit test for this change.
- [x] I ran the new targeted test locally before opening this PR.
- [x] I ran the directly relevant local tests.

Python 3.13.13, pytest 9.1.1:

```bash
PYTHONDONTWRITEBYTECODE=1 PYTHON_GIL=1 OMP_NUM_THREADS=1 \
  CUDA_VISIBLE_DEVICES='' python -m pytest -p no:cacheprovider -q \
  tests/test_startup_banner.py
# 6 passed in 0.21s
```

All three new cases fail before the fix.

## Review Requirements

- [x] I personally reviewed every file in this diff.
- [x] I checked that the code matches existing project structure, APIs, and conventions.
- [x] I avoided unnecessary monkeypatching and used the project's normal extension points where possible.
