### PR TITLE
Align GPTQ keep masks with captured tensor devices

### DIFF
--- a/gptqmodel/looper/gptq_processor.py
+++ b/gptqmodel/looper/gptq_processor.py
@@ -29,7 +29,7 @@ from ..models.writer import (
 )
 from ..nn_modules.qlinear.torch import TorchQuantEmbeddings
 from ..quantization import FOEM, GPTAQ, GPTQ
-from ..quantization.config import GPTAQConfig, FOEMConfig, HessianConfig, METHOD, QuantizeConfig, resolve_quant_format
+from ..quantization.config import METHOD, FOEMConfig, GPTAQConfig, HessianConfig, QuantizeConfig, resolve_quant_format
 from ..utils.device import get_device
 from ..utils.fallback import normalize_fallback
 from ..utils.logger import log_time_block, setup_logger
@@ -391,9 +391,15 @@ class GPTQProcessor(LoopProcessor):
                     if not bool(sample_keep.any().item()):
                         continue
 
-                    sample_inp = inp_tensor[sample_index : sample_index + 1, sample_keep, :].contiguous()
+                    input_keep = sample_keep.to(device=inp_tensor.device)
+                    sample_inp = inp_tensor[
+                        sample_index : sample_index + 1, input_keep, :
+                    ].contiguous()
                     if out_tensor is not None and out_tensor.dim() >= 3 and out_tensor.shape[:2] == inp_tensor.shape[:2]:
-                        sample_out = out_tensor[sample_index : sample_index + 1, sample_keep, :].contiguous()
+                        output_keep = sample_keep.to(device=out_tensor.device)
+                        sample_out = out_tensor[
+                            sample_index : sample_index + 1, output_keep, :
+                        ].contiguous()
                     else:
                         sample_out = out
                     g.add_batch(sample_inp.data, sample_out.data, batch_index=batch_idx)  # noqa: F821

--- a/gptqmodel/looper/gptq_processor.py
+++ b/gptqmodel/looper/gptq_processor.py
@@ -29,7 +29,7 @@ from ..models.writer import (
 )
 from ..nn_modules.qlinear.torch import TorchQuantEmbeddings
 from ..quantization import FOEM, GPTAQ, GPTQ
-from ..quantization.config import METHOD, FOEMConfig, GPTAQConfig, HessianConfig, QuantizeConfig, resolve_quant_format
+from ..quantization.config import GPTAQConfig, FOEMConfig, HessianConfig, METHOD, QuantizeConfig, resolve_quant_format
 from ..utils.device import get_device
 from ..utils.fallback import normalize_fallback
 from ..utils.logger import log_time_block, setup_logger

--- a/tests/test_gptq_keep_mask_device.py
+++ b/tests/test_gptq_keep_mask_device.py
@@ -1,0 +1,83 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from gptqmodel.looper.gptq_processor import GPTQProcessor
+from gptqmodel.quantization.config import QuantizeConfig
+from gptqmodel.quantization.gptq import GPTQ
+
+
+@pytest.mark.parametrize(
+    "mask_device,input_device,output_device",
+    [
+        ("cpu", "cpu", "cpu"),
+        pytest.param(
+            "cuda:0",
+            "cuda:0",
+            "cuda:0",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(), reason="CUDA is required"
+            ),
+        ),
+        pytest.param(
+            "cuda:0",
+            "cuda:1",
+            "cuda:1",
+            marks=pytest.mark.skipif(
+                torch.cuda.device_count() < 2, reason="Two CUDA devices are required"
+            ),
+        ),
+        pytest.param(
+            "cuda:0",
+            "cuda:0",
+            "cuda:1",
+            marks=pytest.mark.skipif(
+                torch.cuda.device_count() < 2, reason="Two CUDA devices are required"
+            ),
+        ),
+    ],
+)
+def test_keep_mask_preserves_samples_across_devices(
+    mask_device: str,
+    input_device: str,
+    output_device: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    layer = torch.nn.Linear(2, 2, bias=False, device=input_device)
+    task = GPTQ(layer, qcfg=QuantizeConfig(bits=4, group_size=2))
+    processor = object.__new__(GPTQProcessor)
+    processor.tasks = {"linear": task}
+    processor._batch_tls = SimpleNamespace(index=7)
+    processor._mask_tls = SimpleNamespace(
+        value=torch.tensor(
+            [[True, False, True], [False, True, False], [False, False, False]],
+            device=mask_device,
+        )
+    )
+    inputs = torch.arange(18, device=input_device, dtype=torch.float32).reshape(3, 3, 2)
+    outputs = layer(inputs).to(output_device)
+    captured = []
+    add_batch = task.add_batch
+
+    def capture(
+        inp: torch.Tensor, out: torch.Tensor, batch_index: int | None = None
+    ) -> None:
+        captured.append((inp, out, batch_index))
+        add_batch(inp, out, batch_index=batch_index)
+
+    monkeypatch.setattr(task, "add_batch", capture)
+    processor.pre_process_fwd_hook("linear")(layer, (inputs,), outputs)
+
+    assert len(captured) == 2
+    for (inp, out, batch_index), (row, positions) in zip(
+        captured, [(0, [0, 2]), (1, [1])]
+    ):
+        torch.testing.assert_close(inp, inputs[row : row + 1, positions, :])
+        torch.testing.assert_close(out, outputs[row : row + 1, positions, :])
+        assert batch_index == 7
+        assert inp.is_contiguous() and out.is_contiguous()
+    kept = torch.stack([inputs[0, 0], inputs[0, 2], inputs[1, 1]])
+    torch.testing.assert_close(task.finalize_hessian(), 2.0 * kept.T @ kept / 3)
+    assert task.nsamples == 3
+    assert task.fwd_counter == 2


### PR DESCRIPTION
## Summary

GPTQ capture raises an indexing-device error when a calibration keep mask and the captured tensor are on different CUDA devices. Move each sample's mask to the input and output tensor devices independently before indexing.

## What Changed

- Preserve per-sample filtering, empty-sample skipping, and batch indices.
- Add CPU, same-GPU, and two-GPU tests checking captured rows, sample counts, and Hessian contents.

## Tests

- [x] I added a new simple/fast unit test for this change.
- [x] I ran the new targeted test locally before opening this PR.
- [x] I ran the directly relevant local tests.

Python 3.13.13, torch 2.11.0+cu128, Transformers 5.16.1; two CUDA GPUs:

```bash
PYTHONDONTWRITEBYTECODE=1 PYTHON_GIL=1 OMP_NUM_THREADS=1 \
  CUDA_VISIBLE_DEVICES=0,1 python -m pytest -p no:cacheprovider -q \
  tests/test_gptq_keep_mask_device.py \
  tests/test_shared_input_hessian_dedup.py \
  tests/test_gptq.py::test_embedding_capture_applies_rank_two_attention_mask
# 40 passed, 14 warnings in 5.93s
```

Both two-GPU regressions fail before the fix. No tests skipped; warnings are TorchScript deprecations. CUDA cases skip when the required devices are unavailable.

## Review Requirements

- [x] I personally reviewed every file in this diff.
- [x] I checked that the code matches existing project structure, APIs, and conventions.
- [x] I avoided unnecessary monkeypatching and used the project's normal extension points where possible.
