### PR TITLE
Avoid full model scans during per-module finalization

### DIFF
--- a/gptqmodel/looper/awq_processor.py
+++ b/gptqmodel/looper/awq_processor.py
@@ -2414,7 +2414,7 @@ class AWQProcessor(LoopProcessor):
         assert q_zeros.device == CPU
         assert q_scales.device == CPU
         quant_linear_cls = self._resolve_qlinear_kernel(module.full_name)
-        layers = find_modules(self.gptq_model.model)
+        layers = {module.full_name: self.gptq_model.model.get_submodule(module.full_name)}
         module_label = getattr(module, "full_name", getattr(module, "name", ""))
         parent_key = getattr(module, "full_name", getattr(module, "name", None))
         # replace module with quantized module
@@ -2450,11 +2450,12 @@ class AWQProcessor(LoopProcessor):
                 source=module_label,
             )
         # pack module
-        qModules = {
-            name: submodule
-            for name, submodule in find_modules(self.gptq_model.model, [quant_linear_cls]).items()
-            if name == module.full_name
-        }
+        qmodule = self.gptq_model.model.get_submodule(module.full_name)
+        qModules = (
+            {module.full_name: qmodule}
+            if isinstance(qmodule, quant_linear_cls)
+            else {}
+        )
         pack_start = time.perf_counter() if timer is not None else None
         with log_time_block(
                 "pack",

--- a/gptqmodel/looper/gptq_processor.py
+++ b/gptqmodel/looper/gptq_processor.py
@@ -33,7 +33,7 @@ from ..quantization.config import GPTAQConfig, FOEMConfig, HessianConfig, METHOD
 from ..utils.device import get_device
 from ..utils.fallback import normalize_fallback
 from ..utils.logger import log_time_block, setup_logger
-from ..utils.model import create_quant_module, find_modules, pack_module
+from ..utils.model import create_quant_module, pack_module
 from ..utils.module_locks import parent_module_lock
 from ..utils.torch import HAS_NPU
 
@@ -616,7 +616,7 @@ class GPTQProcessor(LoopProcessor):
         assert q_scales.device == CPU
         assert q_g_idx.device == CPU
 
-        layers = find_modules(model.model)
+        layers = {module.full_name: model.model.get_submodule(module.full_name)}
         module_label = getattr(module, "full_name", getattr(module, "name", ""))
         parent_key = getattr(module, "full_name", getattr(module, "name", None))
 
@@ -654,11 +654,12 @@ class GPTQProcessor(LoopProcessor):
             )
 
         # pack module
-        qModules = {
-            name: submodule
-            for name, submodule in find_modules(model.model, [model.qlinear_kernel, TorchQuantEmbeddings]).items()
-            if name == module.full_name
-        }
+        qmodule = model.model.get_submodule(module.full_name)
+        qModules = (
+            {module.full_name: qmodule}
+            if isinstance(qmodule, (model.qlinear_kernel, TorchQuantEmbeddings))
+            else {}
+        )
         pack_start = time.perf_counter() if timer is not None else None
         with log_time_block(
             "pack",

--- a/gptqmodel/looper/paroquant_processor.py
+++ b/gptqmodel/looper/paroquant_processor.py
@@ -69,7 +69,6 @@ from ..utils.fallback import normalize_fallback
 from ..utils.logger import log_time_block, setup_logger
 from ..utils.model import (
     create_quant_module,
-    find_modules,
     get_module_by_name_prefix,
     move_to,
     nested_move_to,
@@ -2568,7 +2567,7 @@ class ParoQuantProcessor(LoopProcessor):
 
         module.weight.data = move_to(pack_weight, device=CPU)
         quant_linear_cls = self._resolve_qlinear_kernel(module.full_name)
-        layers = find_modules(model.model)
+        layers = {module.full_name: model.model.get_submodule(module.full_name)}
         module_label = getattr(module, "full_name", getattr(module, "name", ""))
 
         with log_time_block(
@@ -2595,11 +2594,12 @@ class ParoQuantProcessor(LoopProcessor):
                     init_kwargs=self.qcfg.quant_linear_init_kwargs(),
                 )
 
-        qmodules = {
-            name: submodule
-            for name, submodule in find_modules(model.model, [quant_linear_cls]).items()
-            if name == module.full_name
-        }
+        qmodule = model.model.get_submodule(module.full_name)
+        qmodules = (
+            {module.full_name: qmodule}
+            if isinstance(qmodule, quant_linear_cls)
+            else {}
+        )
         with log_time_block(
             "pack",
             logger=log,

--- a/gptqmodel/looper/qqq_processor.py
+++ b/gptqmodel/looper/qqq_processor.py
@@ -21,7 +21,7 @@ from ..utils.fallback import normalize_fallback
 from ..quantization.qqq import QQQ
 from ..utils.backend import BACKEND
 from ..utils.logger import setup_logger, log_time_block
-from ..utils.model import create_quant_module, find_modules, move_to, pack_module
+from ..utils.model import create_quant_module, move_to, pack_module
 from ..utils.torch import CPU
 
 log = setup_logger()
@@ -270,7 +270,7 @@ class QQQProcessor(LoopProcessor):
             q_g_idx = module.state.pop("q_g_idx")
             q_scales_extra = module.state.pop("q_scales_extra")
 
-        layers = find_modules(model.model)
+        layers = {module.full_name: model.model.get_submodule(module.full_name)}
         module_label = getattr(module, "full_name", getattr(module, "name", ""))
         quant_linear_cls, backend = self._quant_linear_kernel()
 
@@ -299,11 +299,12 @@ class QQQProcessor(LoopProcessor):
             )
 
         # pack module
-        qModules = {
-            name: submodule
-            for name, submodule in find_modules(model.model, [quant_linear_cls]).items()
-            if name == module.full_name
-        }
+        qmodule = model.model.get_submodule(module.full_name)
+        qModules = (
+            {module.full_name: qmodule}
+            if isinstance(qmodule, quant_linear_cls)
+            else {}
+        )
         with log_time_block(
             "pack",
             logger=log,

--- a/gptqmodel/looper/weight_only_processor.py
+++ b/gptqmodel/looper/weight_only_processor.py
@@ -35,7 +35,7 @@ from ..quantization.config import (
 )
 from ..quantization.rtn import RTN
 from ..utils.logger import log_time_block, setup_logger
-from ..utils.model import create_quant_module, find_modules, pack_module
+from ..utils.model import create_quant_module, pack_module
 from ..nn_modules.qlinear.torch import TorchQuantEmbeddings
 from ..utils.module_locks import parent_module_lock
 
@@ -167,7 +167,7 @@ class WeightOnlyProcessor(LoopProcessor):
             assert q_scales.device == CPU
             assert q_g_idx.device == CPU
 
-        layers = find_modules(model.model)
+        layers = {module.full_name: model.model.get_submodule(module.full_name)}
         module_label = getattr(module, "full_name", getattr(module, "name", ""))
         parent_key = getattr(module, "full_name", getattr(module, "name", None))
         original_layer = layers.get(module.full_name)
@@ -196,13 +196,12 @@ class WeightOnlyProcessor(LoopProcessor):
         if timer is not None and create_start is not None:
             timer.record("submodule_finalize_create", time.perf_counter() - create_start, source=module_label)
 
-        qmodules = {
-            name: submodule
-            for name, submodule in find_modules(
-                model.model, [model.qlinear_kernel, TorchQuantEmbeddings]
-            ).items()
-            if name == module.full_name
-        }
+        qmodule = model.model.get_submodule(module.full_name)
+        qmodules = (
+            {module.full_name: qmodule}
+            if isinstance(qmodule, (model.qlinear_kernel, TorchQuantEmbeddings))
+            else {}
+        )
 
         if self._uses_direct_pack(active_qcfg):
             pack_start = time.perf_counter() if timer is not None else None

--- a/tests/test_finalize_module_lookup.py
+++ b/tests/test_finalize_module_lookup.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import threading
+from types import ModuleType, SimpleNamespace
+from typing import Iterator
+
+import pytest
+import torch
+from torch import nn
+
+from gptqmodel.looper import (
+    awq_processor,
+    gptq_processor,
+    paroquant_processor,
+    qqq_processor,
+    weight_only_processor,
+)
+from gptqmodel.looper.named_module import NamedModule
+from gptqmodel.nn_modules.qlinear.paroquant import ParoLinear
+from gptqmodel.nn_modules.qlinear.qqq import QQQTorchLinear
+from gptqmodel.nn_modules.qlinear.torch import TorchLinear, TorchQuantEmbeddings
+from gptqmodel.nn_modules.qlinear.torch_awq import AwqTorchLinear
+from gptqmodel.quantization.config import (
+    AWQConfig,
+    GPTQConfig,
+    ParoConfig,
+    QQQConfig,
+    RTNConfig,
+)
+from gptqmodel.utils.backend import BACKEND
+
+
+class _UnrelatedSubtree(nn.Module):
+    def named_children(self) -> Iterator[tuple[str, nn.Module]]:
+        raise AssertionError("Finalizing a known module traversed an unrelated subtree")
+
+
+@pytest.mark.parametrize(
+    "implementation,processor_cls,config_cls,kernel,embedding",
+    [
+        (gptq_processor, gptq_processor.GPTQProcessor, GPTQConfig, TorchLinear, False),
+        (gptq_processor, gptq_processor.GPTQProcessor, GPTQConfig, TorchLinear, True),
+        (
+            weight_only_processor,
+            weight_only_processor.WeightOnlyProcessor,
+            RTNConfig,
+            TorchLinear,
+            False,
+        ),
+        (
+            weight_only_processor,
+            weight_only_processor.WeightOnlyProcessor,
+            RTNConfig,
+            TorchLinear,
+            True,
+        ),
+        (qqq_processor, qqq_processor.QQQProcessor, QQQConfig, QQQTorchLinear, False),
+        (awq_processor, awq_processor.AWQProcessor, AWQConfig, AwqTorchLinear, False),
+        (
+            paroquant_processor,
+            paroquant_processor.ParoQuantProcessor,
+            ParoConfig,
+            ParoLinear,
+            False,
+        ),
+    ],
+    ids=["gptq", "gptq-embedding", "rtn", "rtn-embedding", "qqq", "awq", "paro"],
+)
+def test_finalize_looks_up_only_the_module_being_packed(
+    monkeypatch: pytest.MonkeyPatch,
+    implementation: ModuleType,
+    processor_cls: type,
+    config_cls: type,
+    kernel: type[nn.Module],
+    embedding: bool,
+) -> None:
+    original = (
+        nn.Embedding(128, 128, dtype=torch.float16)
+        if embedding
+        else nn.Linear(128, 128, bias=False, dtype=torch.float16)
+    )
+    tree = nn.Module()
+    tree.layers = nn.ModuleList([nn.ModuleDict({"proj": original})])
+    tree.unrelated = _UnrelatedSubtree()
+    name = "layers.0.proj"
+    module = NamedModule(original, name="proj", full_name=name, layer_index=0)
+    module.state.update(
+        q_scales=torch.ones(128, 1),
+        q_zeros=torch.zeros(128, 1),
+        q_g_idx=torch.zeros(128, dtype=torch.int32),
+        q_scales_extra=torch.ones(128),
+        pack_weight=original.weight.detach().clone(),
+        pairs=torch.zeros(1, dtype=torch.int16),
+        theta=torch.zeros(1),
+        channel_scales=torch.ones(1),
+    )
+    processor = object.__new__(processor_cls)
+    processor.lock = threading.Lock()
+    processor.calculate_w_wq_diff = False
+    processor.qcfg = config_cls(
+        bits=4, group_size=128, sym=True, device="cpu", offload_to_disk=False
+    )
+    processor.format = processor.qcfg.format
+    model = SimpleNamespace(model=tree, qlinear_kernel=kernel, lm_head="lm_head")
+    processor.gptq_model = model
+    if processor_cls is qqq_processor.QQQProcessor:
+        processor._quant_linear_kernel = lambda: (kernel, BACKEND.QQQ_TORCH)
+
+    def check_pack_inputs(**kwargs: object) -> None:
+        replacement = tree.get_submodule(name)
+        expected_type = TorchQuantEmbeddings if embedding else kernel
+        assert isinstance(replacement, expected_type)
+        assert replacement is not original
+        assert kwargs["layers"] == {name: original}
+        assert kwargs["qModules"] == {name: replacement}
+        raise RuntimeError("packing boundary")
+
+    monkeypatch.setattr(implementation, "pack_module", check_pack_inputs)
+    with pytest.raises(RuntimeError, match="packing boundary"):
+        processor.submodule_finalize(module, model)

--- a/tests/test_specialized_eora_lifecycle.py
+++ b/tests/test_specialized_eora_lifecycle.py
@@ -74,9 +74,7 @@ def test_eora_handoff_preserves_independent_reconstruction(method):
     assert module.state["wq"].device.type == "cpu"
 
 
-def test_qqq_packs_uncorrected_weight_after_eora(monkeypatch):
-    import gptqmodel.looper.qqq_processor as implementation
-
+def test_qqq_packs_uncorrected_weight_after_eora() -> None:
     processor = object.__new__(QQQProcessor)
     processor.lock = threading.Lock()
     processor.calculate_w_wq_diff = True
@@ -84,6 +82,7 @@ def test_qqq_packs_uncorrected_weight_after_eora(monkeypatch):
     module = SimpleNamespace(
         weight=torch.nn.Parameter(torch.ones(4, 4)),
         name="proj",
+        full_name="proj",
         state={
             "wq": base,
             "q_zeros": None,
@@ -92,13 +91,14 @@ def test_qqq_packs_uncorrected_weight_after_eora(monkeypatch):
             "q_scales_extra": None,
         },
     )
-    monkeypatch.setattr(implementation, "find_modules", lambda model: {})
+    model = torch.nn.Module()
+    model.proj = torch.nn.Linear(4, 4, bias=False)
 
     def stop_before_packing():
         raise RuntimeError("packing boundary")
 
     processor._quant_linear_kernel = stop_before_packing
     with pytest.raises(RuntimeError, match="packing boundary"):
-        processor.submodule_finalize(module, SimpleNamespace(model=None))
+        processor.submodule_finalize(module, SimpleNamespace(model=model))
     assert torch.equal(module.weight, base)
     assert "wq" not in module.state

--- a/tests/test_specialized_eora_lifecycle.py
+++ b/tests/test_specialized_eora_lifecycle.py
@@ -74,7 +74,7 @@ def test_eora_handoff_preserves_independent_reconstruction(method):
     assert module.state["wq"].device.type == "cpu"
 
 
-def test_qqq_packs_uncorrected_weight_after_eora() -> None:
+def test_qqq_packs_uncorrected_weight_after_eora():
     processor = object.__new__(QQQProcessor)
     processor.lock = threading.Lock()
     processor.calculate_w_wq_diff = True


### PR DESCRIPTION
## Summary

Finalizing one module currently scans the full model twice to retrieve a module whose qualified name is already known. Use `get_submodule` before and after replacement in the GPTQ, weight-only, QQQ, AWQ, and Paro finalizers.

## What Changed

- Preserve kernel filtering, embedding handling, and the existing packing API.
- Check the original and replacement objects passed to packing for all five processors, and reject traversal of an unrelated subtree.
- Use a real module tree in the existing QQQ lifecycle test.

## Tests

- [x] I added a new simple/fast unit test for this change.
- [x] I ran the new targeted test locally before opening this PR.
- [x] I ran the directly relevant local tests.

Python 3.13.13, torch 2.11.0+cu128, Transformers 5.16.1; CPU:

```bash
PYTHONDONTWRITEBYTECODE=1 PYTHON_GIL=1 OMP_NUM_THREADS=1 \
  CUDA_VISIBLE_DEVICES='' python -m pytest -p no:cacheprovider -q \
  tests/test_finalize_module_lookup.py \
  tests/test_specialized_eora_lifecycle.py
# 10 passed in 4.07s

PYTHONDONTWRITEBYTECODE=1 PYTHON_GIL=1 OMP_NUM_THREADS=1 \
  CUDA_VISIBLE_DEVICES='' MAX_JOBS=1 \
  python -m pytest -p no:cacheprovider -q \
  tests/test_weight_only.py::test_baseqmodel_quantize_uses_weight_only_rtn_pipeline \
  tests/test_weight_only.py::test_baseqmodel_quantize_allows_rtn_awq_export \
  tests/test_weight_only.py::test_baseqmodel_quantize_allows_direct_gguf_export \
  tests/test_quantized_embeddings.py tests/test_format_conversion_flow.py
# 17 passed, 14 warnings in 7.82s
```

All seven new cases fail before the fix. The new tests verify the packing inputs; the existing tests cover CPU RTN and direct GGUF pipelines, including RTN export to AWQ, embeddings, and format conversion. Warnings are TorchScript deprecations.

## Review Requirements

- [x] I personally reviewed every file in this diff.
- [x] I checked that the code matches existing project structure, APIs, and conventions.
- [x] I avoided unnecessary monkeypatching and used the project's normal extension points where possible.
