### PR TITLE
fix(qlinear): harden empty-input and CUDA dispatch contracts

### DIFF
--- a/gptqmodel/nn_modules/qlinear/__init__.py
+++ b/gptqmodel/nn_modules/qlinear/__init__.py
@@ -36,6 +36,33 @@ from ...utils.safe import THREADPOOLCTL
 log = setup_logger()
 
 
+def input_rows(x: t.Tensor) -> int:
+    """Return the number of logical Linear rows in an arbitrary-rank input.
+
+    Linear treats every dimension before the final feature dimension as a
+    batch dimension, so a 4D input has ``B * S * T`` matrix rows.
+    """
+
+    if x.ndim == 0:
+        raise ValueError("Linear input must have at least one dimension")
+    return math.prod(x.shape[:-1])
+
+
+def empty_linear_output(x: t.Tensor, out_features: int) -> t.Tensor:
+    """Allocate an empty Linear output while preserving rank, dtype, device."""
+
+    shape = x.shape[:-1] + (out_features,)
+    if x.requires_grad:
+        # Keep the empty path connected to the input so callers can backprop
+        # through an empty batch just like through nn.Linear (with zero grad).
+        return x.sum(dim=-1, keepdim=True).expand(shape) * 0
+    return t.empty(
+        shape,
+        dtype=x.dtype,
+        device=x.device,
+    )
+
+
 # Packed quantized weights are unpacked through shift operations in several
 # kernels. Keep those shifts behind helpers so Ascend 910B/CANN 9.1 beta can use
 # arithmetic equivalents for operators that torch-npu does not expose as native
@@ -216,6 +243,22 @@ class BaseQuantLinear(nn.Module):
 
         buffers = self.list_buffers()
         return buffers[0].device if buffers else None
+
+    def input_rows(self, x: t.Tensor) -> int:
+        return input_rows(x)
+
+    def empty_linear_output(self, x: t.Tensor) -> t.Tensor:
+        """Return an empty output for any-rank Linear input.
+
+        Applying an adapter is intentional: it preserves the same composition
+        semantics as the non-empty path while still avoiding a native M=0
+        kernel launch. Bias addition has no observable effect for zero elements.
+        """
+
+        out = empty_linear_output(x, self.out_features)
+        if self.adapter is not None:
+            out = self.adapter.apply(x=x, out=out)
+        return out
 
     def smooth_block_size(self) -> int:
         return -1

--- a/gptqmodel/nn_modules/qlinear/exllamav2.py
+++ b/gptqmodel/nn_modules/qlinear/exllamav2.py
@@ -147,8 +147,8 @@ class ExllamaV2Linear(GPTQQuantLinear):
     def forward(self, x: torch.Tensor, force_cuda=False):
         # TODO FIXME: parent should never call us if there is no data to process
         # check: https://github.com/ModelCloud/GPTQModel/issues/1361
-        if x.shape[0] == 0:
-            return torch.empty((0, self.out_features), dtype=x.dtype, device=x.device)
+        if self.input_rows(x) == 0:
+            return self.empty_linear_output(x)
 
         x_dtype = x.dtype
         if x_dtype != torch.float16:

--- a/gptqmodel/nn_modules/qlinear/exllamav2_awq.py
+++ b/gptqmodel/nn_modules/qlinear/exllamav2_awq.py
@@ -132,6 +132,8 @@ class AwqExllamaV2Linear(AWQuantLinear):
         super().post_init()
 
     def forward(self, x: torch.Tensor):
+        if self.input_rows(x) == 0:
+            return self.empty_linear_output(x)
         assert self.q_handle is not None, (
             "module.post_init() must be called before module.forward(). "
         )

--- a/gptqmodel/nn_modules/qlinear/gemm_awq.py
+++ b/gptqmodel/nn_modules/qlinear/gemm_awq.py
@@ -11,7 +11,7 @@ from torch import nn
 
 from ...adapter.adapter import Adapter, Lora
 from ...models._const import DEVICE, PLATFORM
-from ...nn_modules.qlinear import AWQuantLinear
+from ...nn_modules.qlinear import AWQuantLinear, empty_linear_output, input_rows
 from ...quantization import FORMAT, METHOD
 from ...utils.awq import awq_dequantize_weights, awq_gemm_forward, awq_runtime_available, awq_runtime_error
 from ...utils.backend import BACKEND
@@ -40,21 +40,30 @@ class AwqGemmFn(torch.autograd.Function):
         prefer_backend=None,
         fp32_accum=FP32_ACCUM,
     ):
-        ctx.save_for_backward(x, qweight, qzeros, scales, bias)
+        # Input and bias values are not needed for the input-gradient backward;
+        # retain only input metadata and the quantized weight tensors.
+        ctx.save_for_backward(qweight, qzeros, scales)
+        ctx.input_shape = tuple(x.shape)
         ctx.out_features = out_features
 
         out_shape = x.shape[:-1] + (out_features,)
-        if x.shape[0] == 0:
-            return torch.zeros(out_shape, dtype=x.dtype, device=x.device)
+        rows = input_rows(x)
+        ctx.input_rows = rows
+        if rows == 0:
+            # CUDA AWQ kernels do not accept M=0; preserve Linear's shape and
+            # autograd behavior without launching a native kernel.
+            return empty_linear_output(x, out_features)
 
-        # Above compute density threshold it is faster to just dequantize the whole thing and do simple matmul
-        FULL_DEQUANT_MATMUL_THRESHOLD = x.shape[0] * x.shape[1] > 1024
+        # Dense matmul is faster once the flattened row count is large enough.
+        FULL_DEQUANT_MATMUL_THRESHOLD = rows > 1024
+        # Native GEMM consumes [rows, features]; restore leading dimensions later.
+        x_2d = x.reshape(rows, x.shape[-1])
         if FULL_DEQUANT_MATMUL_THRESHOLD:
             out = awq_dequantize_weights(qweight, scales, qzeros, 0, 0, 0, False)
-            out = torch.matmul(x, out.to(dtype=x.dtype))
+            out = torch.matmul(x_2d, out.to(dtype=x.dtype))
         else:
             out = _awq_cuda_gemm_forward(
-                x.reshape(-1, x.shape[-1]),
+                x_2d,
                 qweight,
                 scales,
                 qzeros,
@@ -64,24 +73,24 @@ class AwqGemmFn(torch.autograd.Function):
 
         out = out + bias if bias is not None else out
         out = out.reshape(out_shape)
-
-        if len(out.shape) == 2:
-            out = out.unsqueeze(0)
-
         return out
 
     @staticmethod
     def backward(ctx, grad_output):
-        input, qweight, qzeros, scales, bias = ctx.saved_tensors
-
-        weights = awq_dequantize_weights(
-            qweight, scales, qzeros, 1, 0, 0, False
-        ).to(grad_output.dtype)
+        qweight, qzeros, scales = ctx.saved_tensors
 
         grad_input = None
         if ctx.needs_input_grad[0]:
-            batch_size = grad_output.shape[0]
-            grad_input = grad_output.bmm(weights.transpose(0, 1).unsqueeze(0).repeat(batch_size, 1, 1))
+            if ctx.input_rows == 0:
+                grad_input = grad_output.new_empty(ctx.input_shape)
+                return grad_input, None, None, None, None, None, None, None, None, None
+            weights = awq_dequantize_weights(
+                qweight, scales, qzeros, 1, 0, 0, False
+            ).to(grad_output.dtype)
+            # Mirror forward's flatten/restore so backward supports every rank.
+            grad_output_2d = grad_output.reshape(-1, grad_output.shape[-1])
+            grad_input = torch.matmul(grad_output_2d, weights.transpose(-1, -2))
+            grad_input = grad_input.reshape(ctx.input_shape)
 
         return grad_input, None, None, None, None, None, None, None, None, None
 
@@ -167,11 +176,21 @@ class AwqGEMMLinear(AWQuantLinear):
     def forward(self, x: torch.Tensor):
         out_shape = x.shape[:-1] + (self.out_features,)
 
+        # The extension dereferences these pointers directly; fail early with
+        # a useful message instead of reporting an opaque CUDA device error.
+        for name in ("qweight", "qzeros", "scales"):
+            tensor = getattr(self, name, None)
+            if tensor is not None and tensor.device != x.device:
+                raise RuntimeError(
+                    f"AWQ GEMM input and {name} must be on the same device: "
+                    f"input={x.device}, {name}={tensor.device}"
+                )
+
         input_dtype = x.dtype
         compute_dtype = input_dtype if input_dtype in (torch.float16, torch.bfloat16) else torch.float16
         if input_dtype != compute_dtype:
             x = x.to(compute_dtype)
-        elif not x.is_contiguous():
+        if not x.is_contiguous():
             x = x.contiguous()
 
         self._ensure_runtime_dtype(compute_dtype)

--- a/gptqmodel/nn_modules/qlinear/gemm_awq_triton.py
+++ b/gptqmodel/nn_modules/qlinear/gemm_awq_triton.py
@@ -10,7 +10,7 @@ import torch
 
 from ...adapter.adapter import Adapter, Lora
 from ...models._const import DEVICE, PLATFORM
-from ...nn_modules.qlinear import AWQuantLinear
+from ...nn_modules.qlinear import AWQuantLinear, empty_linear_output, input_rows
 from ...quantization import FORMAT, METHOD
 from ...utils import has_gil_disabled
 from ...utils.backend import BACKEND
@@ -36,24 +36,33 @@ class AwqGemmTritonFn(torch.autograd.Function):
         out_features=0,
         prefer_backend=None,
     ):
-        from ...quantization.awq.modules.triton.gemm import awq_dequantize_triton, awq_gemm_triton
-
-        ctx.save_for_backward(x, qweight, qzeros, scales, bias)
+        # Only quantized weights and input metadata are needed for the
+        # input-gradient backward; input and bias values are not retained.
+        ctx.save_for_backward(qweight, qzeros, scales)
+        ctx.input_shape = tuple(x.shape)
         ctx.out_features = out_features
 
         out_shape = x.shape[:-1] + (out_features,)
         x = x.to(torch.float16)
-        if x.shape[0] == 0:
-            return torch.zeros(out_shape, dtype=x.dtype, device=x.device)
+        rows = input_rows(x)
+        ctx.input_rows = rows
+        if rows == 0:
+            # Triton also requires a positive M dimension, so use the shared
+            # empty path and avoid compiling/launching a zero-row kernel.
+            return empty_linear_output(x, out_features)
 
-        # Above compute density threshold it is faster to just dequantize the whole thing and do simple matmul
-        FULL_DEQUANT_MATMUL_THRESHOLD = x.shape[0] * x.shape[1] > 128
+        from ...quantization.awq.modules.triton.gemm import awq_dequantize_triton, awq_gemm_triton
+
+        # Dense matmul is faster once the flattened row count is large enough.
+        FULL_DEQUANT_MATMUL_THRESHOLD = rows > 128
+        # Triton consumes [rows, features]; restore leading dimensions later.
+        x_2d = x.reshape(rows, x.shape[-1])
         if FULL_DEQUANT_MATMUL_THRESHOLD:
             out = awq_dequantize_triton(qweight, scales, qzeros)
-            out = torch.matmul(x, out.to(x.dtype))
+            out = torch.matmul(x_2d, out.to(x.dtype))
         else:
             out = awq_gemm_triton(
-                x.reshape(-1, x.shape[-1]),
+                x_2d,
                 qweight,
                 scales,
                 qzeros,
@@ -64,23 +73,24 @@ class AwqGemmTritonFn(torch.autograd.Function):
 
         out = out + bias if bias is not None else out
         out = out.reshape(out_shape)
-        if len(out.shape) == 2:
-            out = out.unsqueeze(0)
         return out
 
     @staticmethod
     def backward(ctx, grad_output):
-        from ...quantization.awq.modules.triton.gemm import awq_dequantize_triton
-
-
-        input, qweight, qzeros, scales, bias = ctx.saved_tensors
-
-        weights = awq_dequantize_triton(qweight, scales, qzeros).to(grad_output.dtype)
+        qweight, qzeros, scales = ctx.saved_tensors
 
         grad_input = None
         if ctx.needs_input_grad[0]:
-            batch_size = grad_output.shape[0]
-            grad_input = grad_output.bmm(weights.transpose(0, 1).unsqueeze(0).repeat(batch_size, 1, 1))
+            if ctx.input_rows == 0:
+                grad_input = grad_output.new_empty(ctx.input_shape)
+                return grad_input, None, None, None, None, None, None, None, None
+            from ...quantization.awq.modules.triton.gemm import awq_dequantize_triton
+
+            weights = awq_dequantize_triton(qweight, scales, qzeros).to(grad_output.dtype)
+            # Mirror forward's flatten/restore so backward supports every rank.
+            grad_output_2d = grad_output.reshape(-1, grad_output.shape[-1])
+            grad_input = torch.matmul(grad_output_2d, weights.transpose(-1, -2))
+            grad_input = grad_input.reshape(ctx.input_shape)
 
         return grad_input, None, None, None, None, None, None, None, None
 
@@ -162,11 +172,31 @@ class AwqGEMMTritonLinear(AWQuantLinear):
     def forward(self, x: torch.Tensor):
         out_shape = x.shape[:-1] + (self.out_features,)
 
+        # Quantized tensors are passed as raw device pointers to Triton; do
+        # this check before entering its device context.
+        for name in ("qweight", "qzeros", "scales"):
+            tensor = getattr(self, name, None)
+            if tensor is not None and tensor.device != x.device:
+                raise RuntimeError(
+                    f"AWQ Triton input and {name} must be on the same device: "
+                    f"input={x.device}, {name}={tensor.device}"
+                )
+
         input_dtype = x.dtype
         if input_dtype != torch.float16:
             x = x.half()
+        if not x.is_contiguous():
+            x = x.contiguous()
 
-        with torch.xpu.device(self.qweight.device) if HAS_XPU else torch.cuda.device(self.qweight.device):
+        # Select from x.device instead of whichever accelerator is globally available.
+        device_context = (
+            torch.xpu.device(x.device)
+            if x.device.type == "xpu" and HAS_XPU
+            else torch.cuda.device(x.device)
+            if x.device.type == "cuda"
+            else nullcontext()
+        )
+        with device_context:
             with nullcontext() if self.training else torch.inference_mode():
                 out = AwqGemmTritonFn.apply(
                     x,

--- a/gptqmodel/nn_modules/qlinear/gemv_awq.py
+++ b/gptqmodel/nn_modules/qlinear/gemv_awq.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 
+from typing import Optional, Tuple
+
 import torch
 from torch import nn
 
@@ -23,14 +25,20 @@ class AwqGEMVLinear(AWQuantLinear):
     SUPPORTS_METHODS = [METHOD.AWQ]
     SUPPORTS_FORMATS = {FORMAT.GEMV: 40}
     SUPPORTS_BITS = [4]
-    SUPPORTS_GROUP_SIZE = [-1, 16, 32, 64, 128]
+    # Both native AWQ GEMV implementations support only these normalized group
+    # sizes. Keep -1 for kernel selection, then normalize it in validate() when
+    # the layer's in_features value is available.
+    SUPPORTS_GROUP_SIZE = [-1, 64, 128]
     SUPPORTS_DESC_ACT = [True, False]
     SUPPORTS_SYM = [True, False]
     SUPPORTS_SHARDS = True
     SUPPORTS_TRAINING = True
     SUPPORTS_AUTO_PADDING = False
     SUPPORTS_IN_FEATURES_DIVISIBLE_BY = [1]
-    SUPPORTS_OUT_FEATURES_DIVISIBLE_BY = [1]
+    # The M>8 path uses GEMMV2, whose tile is N=64. Keep the class-wide
+    # contract at 64 so shape-dependent dispatch cannot select an unsupported
+    # native launch.
+    SUPPORTS_OUT_FEATURES_DIVISIBLE_BY = [64]
 
     SUPPORTS_DEVICES = [DEVICE.CUDA, DEVICE.ROCM]
     SUPPORTS_PLATFORM = [PLATFORM.ALL]
@@ -41,6 +49,46 @@ class AwqGEMVLinear(AWQuantLinear):
 
     # for transformers/optimum tests compat
     QUANT_TYPE = "awq_gemv"
+
+    @classmethod
+    def validate(
+        cls,
+        bits: int,
+        group_size: int = -1,
+        desc_act: bool = False,
+        sym: bool = True,
+        in_features: int = None,
+        out_features: int = None,
+        pack_dtype: torch.dtype = None,
+        dtype: Optional[torch.dtype] = None,
+        dynamic: Optional[dict] = None,
+        device: Optional[DEVICE] = None,
+        trainable: Optional[bool] = None,
+        adapter: Optional[Adapter] = None,
+    ) -> Tuple[bool, Optional[Exception]]:
+        """Validate the native group-size contract after resolving -1."""
+        effective_group_size = in_features if group_size == -1 and in_features is not None else group_size
+        native_group_sizes = [size for size in cls.SUPPORTS_GROUP_SIZE if size != -1]
+        if effective_group_size != -1 and effective_group_size not in native_group_sizes:
+            return False, NotImplementedError(
+                f"{cls.__name__} native GEMV supports normalized group_size "
+                f"{native_group_sizes}: actual group_size={effective_group_size}"
+            )
+        # Base validation cannot infer that -1 means the full input width.
+        return super().validate(
+            bits=bits,
+            group_size=effective_group_size,
+            desc_act=desc_act,
+            sym=sym,
+            in_features=in_features,
+            out_features=out_features,
+            pack_dtype=pack_dtype,
+            dtype=dtype,
+            dynamic=dynamic,
+            device=device,
+            trainable=trainable,
+            adapter=adapter,
+        )
 
     def __init__(
         self,
@@ -118,7 +166,14 @@ class AwqGEMVLinear(AWQuantLinear):
 
     def forward(self, x: torch.Tensor):
         out_shape = x.shape[:-1] + (self.out_features,)
+        if self.input_rows(x) == 0:
+            # Avoid a native launch with M=0 while retaining the input rank.
+            return self.empty_linear_output(x)
         inputs = x.reshape(-1, x.shape[-1])
+        if not inputs.is_contiguous():
+            # The CUDA entry point uses vectorized loads and requires a dense
+            # 2D activation matrix.
+            inputs = inputs.contiguous()
 
         input_dtype = inputs.dtype
         if input_dtype != torch.float16:

--- a/gptqmodel/nn_modules/qlinear/gemv_fast_awq.py
+++ b/gptqmodel/nn_modules/qlinear/gemv_fast_awq.py
@@ -154,6 +154,8 @@ class AwqGEMVFastLinear(AWQuantLinear):
                 self.bias = None
 
     def forward(self, x: torch.Tensor):
+        if self.input_rows(x) == 0:
+            return self.empty_linear_output(x)
         if not awq_runtime_available():
             raise ModuleNotFoundError("AWQ torch.ops kernels are not properly installed. Error: " + awq_runtime_error())
 

--- a/gptqmodel/nn_modules/qlinear/machete.py
+++ b/gptqmodel/nn_modules/qlinear/machete.py
@@ -282,8 +282,8 @@ class MacheteLinear(GPTQQuantLinear):
         return buf
 
     def forward(self, x: torch.Tensor):
-        if x.shape[0] == 0:
-            return torch.empty((0, self.out_features), dtype=x.dtype, device=x.device)
+        if self.input_rows(x) == 0:
+            return self.empty_linear_output(x)
 
         input_2d = x.reshape(-1, x.shape[-1])
 

--- a/gptqmodel/nn_modules/qlinear/machete_awq.py
+++ b/gptqmodel/nn_modules/qlinear/machete_awq.py
@@ -201,8 +201,8 @@ class AwqMacheteLinear(AWQuantLinear):
         super().post_init()
 
     def forward(self, x: torch.Tensor):
-        if x.shape[0] == 0:
-            return torch.empty((0, self.out_features), dtype=x.dtype, device=x.device)
+        if self.input_rows(x) == 0:
+            return self.empty_linear_output(x)
 
         input_2d = x.reshape(-1, x.shape[-1])
         group_scales = self.scales.to(dtype=input_2d.dtype)

--- a/gptqmodel/nn_modules/qlinear/marlin.py
+++ b/gptqmodel/nn_modules/qlinear/marlin.py
@@ -410,8 +410,8 @@ class MarlinLinear(GPTQQuantLinear):
     def forward(self, x: torch.Tensor):
         # TODO FIXME: parent should never call us if there is no data to process
         # check: https://github.com/ModelCloud/GPTQModel/issues/1361
-        if x.shape[0] == 0:
-            return torch.empty((0, self.out_features), dtype=x.dtype, device=x.device)
+        if self.input_rows(x) == 0:
+            return self.empty_linear_output(x)
 
         # make sure scales is synced with x/input
         if x.dtype != self.scales.dtype:

--- a/gptqmodel/nn_modules/qlinear/marlin_awq.py
+++ b/gptqmodel/nn_modules/qlinear/marlin_awq.py
@@ -342,6 +342,8 @@ class AwqMarlinLinear(AWQuantLinear):
         super().post_init()
 
     def forward(self, x: torch.Tensor):
+        if self.input_rows(x) == 0:
+            return self.empty_linear_output(x)
         assert self.workspace.numel() > 0, (
             "module.post_init() must be called before module.forward(). "
             "Use marlin_post_init() on the whole model."

--- a/gptqmodel/nn_modules/qlinear/paroquant.py
+++ b/gptqmodel/nn_modules/qlinear/paroquant.py
@@ -281,6 +281,10 @@ class ParoLinear(AwqTorchLinear):
     def forward(self, x: torch.Tensor):
         """Rotate inputs, run quantized matmul, then apply adapters in input space."""
         original_shape = x.shape[:-1] + (self.out_features,)
+        if self.input_rows(x) == 0:
+            # Rotation and AWQ GEMM both require a positive row count; keep the
+            # empty batch on the shared shape-preserving path instead.
+            return self.empty_linear_output(x)
         x_flat = x.reshape(-1, x.shape[-1])
         rotated = self._rotate_inputs(x_flat)
 

--- a/gptqmodel/nn_modules/qlinear/paroquant_triton.py
+++ b/gptqmodel/nn_modules/qlinear/paroquant_triton.py
@@ -190,6 +190,9 @@ class ParoQuantTritonLinear(ParoLinear):
     def forward(self, x: torch.Tensor):
         """Rotate inputs, pick a Triton plan, and preserve adapter semantics."""
         original_shape = x.shape[:-1] + (self.out_features,)
+        if self.input_rows(x) == 0:
+            # Do not autotune or launch Triton plans for a zero-row matrix.
+            return self.empty_linear_output(x)
         adapter_input = x.reshape(-1, x.shape[-1])
         x_flat = x.reshape(-1, x.shape[-1])
         rotated = self._rotate_inputs(x_flat)

--- a/gptqmodel/nn_modules/qlinear/qqq.py
+++ b/gptqmodel/nn_modules/qlinear/qqq.py
@@ -413,8 +413,8 @@ class QQQLinear(GroupedQuantLinear):
     def forward(self, A):
         # TODO FIXME: parent should never call us if there is no data to process
         # check: https://github.com/ModelCloud/GPTQModel/issues/1361
-        if A.shape[0] == 0:
-            return torch.empty((0, self.out_features), dtype=A.dtype, device=A.device)
+        if self.input_rows(A) == 0:
+            return self.empty_linear_output(A)
 
         A_dtype = A.dtype
         # qqq is float16 kernel only
@@ -520,8 +520,8 @@ class QQQTorchLinear(QQQLinear):
         return weight, s_channel
 
     def forward(self, A):
-        if A.shape[0] == 0:
-            return torch.empty((0, self.out_features), dtype=A.dtype, device=A.device)
+        if self.input_rows(A) == 0:
+            return self.empty_linear_output(A)
 
         A_dtype = A.dtype
         if A.dtype != torch.float16:

--- a/gptqmodel/nn_modules/qlinear/swordfish.py
+++ b/gptqmodel/nn_modules/qlinear/swordfish.py
@@ -303,11 +303,8 @@ class SwordfishLinear(GPTQQuantLinear):
         return buf
 
     def forward(self, x: torch.Tensor):
-        if x.shape[0] == 0:
-            result = torch.empty(x.shape[:-1] + (self.out_features,), dtype=x.dtype, device=x.device)
-            if self.adapter is not None:
-                result = self.adapter.apply(x=x, out=result)
-            return result
+        if self.input_rows(x) == 0:
+            return self.empty_linear_output(x)
 
         input_2d = x.reshape(-1, x.shape[-1])
 
@@ -673,11 +670,8 @@ class AwqSwordfishLinear(AWQuantLinear):
         return buf
 
     def forward(self, x: torch.Tensor):
-        if x.shape[0] == 0:
-            result = torch.empty(x.shape[:-1] + (self.out_features,), dtype=x.dtype, device=x.device)
-            if self.adapter is not None:
-                result = self.adapter.apply(x=x, out=result)
-            return result
+        if self.input_rows(x) == 0:
+            return self.empty_linear_output(x)
 
         input_2d = x.reshape(-1, x.shape[-1])
 

--- a/gptqmodel_ext/awq/quantization/gemm_cuda_gen.cu
+++ b/gptqmodel_ext/awq/quantization/gemm_cuda_gen.cu
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <cublas_v2.h>
 #include <cstdlib>
@@ -1244,15 +1245,60 @@ torch::Tensor gemmv2_forward_cuda(
     int group_size,
     int split_k_iters)
 {
+    // Validate the flattened GEMV ABI before allocating or launching. The
+    // caller handles empty batches because this kernel requires M > 0.
+    TORCH_CHECK(_in_feats.is_cuda() && _kernel.is_cuda() &&
+                    _scaling_factors.is_cuda() && _zeros.is_cuda(),
+                "AWQ GEMMV2 expects all tensors on CUDA.");
+    TORCH_CHECK(_in_feats.dim() == 2 && _kernel.dim() == 2 &&
+                    _scaling_factors.dim() == 2 && _zeros.dim() == 2,
+                "AWQ GEMMV2 expects 2D input, weights, scales, and zero-points.");
+    TORCH_CHECK(_in_feats.is_contiguous() && _kernel.is_contiguous() &&
+                    _scaling_factors.is_contiguous() && _zeros.is_contiguous(),
+                "AWQ GEMMV2 expects contiguous input, weights, scales, and zero-points.");
+    TORCH_CHECK(_in_feats.scalar_type() == at::kHalf &&
+                    _scaling_factors.scalar_type() == at::kHalf,
+                "AWQ GEMMV2 only supports float16 input activations and scales.");
+    TORCH_CHECK(_kernel.scalar_type() == at::kInt && _zeros.scalar_type() == at::kInt,
+                "AWQ GEMMV2 packed weights and zero-points must be int32.");
+    TORCH_CHECK(_in_feats.device() == _kernel.device() &&
+                    _in_feats.device() == _scaling_factors.device() &&
+                    _in_feats.device() == _zeros.device(),
+                "AWQ GEMMV2 tensors must be on the same CUDA device.");
+    TORCH_CHECK(group_size == 64 || group_size == 128,
+                "AWQ GEMMV2 supports group_size 64 or 128.");
+    TORCH_CHECK(split_k_iters > 0, "AWQ GEMMV2 split_k_iters must be positive.");
+
     int num_in_feats = _in_feats.size(0);
     int num_in_channels = _in_feats.size(1);
+    int num_out_channels = _kernel.size(0);
+    TORCH_CHECK(num_in_feats > 0, "AWQ GEMMV2 does not support zero-row launches.");
+    TORCH_CHECK(num_in_channels > 0 && num_in_channels % 8 == 0 &&
+                    num_in_channels % group_size == 0,
+                "AWQ GEMMV2 input channels must be divisible by 8 and group_size.");
+    TORCH_CHECK(num_out_channels > 0 && num_out_channels % 64 == 0,
+                "AWQ GEMMV2 output channels must be a positive multiple of 64.");
+    TORCH_CHECK(_kernel.size(1) == num_in_channels / 8,
+                "AWQ GEMMV2 packed weight shape does not match input channels.");
+    const int num_groups = num_in_channels / group_size;
+    const int group_alignment = group_size == 64 ? 2 : 1;
+    const int packed_groups_unaligned = (num_groups + 8 - 1) / 8;
+    const int packed_groups = (packed_groups_unaligned + group_alignment - 1) /
+                              group_alignment * group_alignment;
+    TORCH_CHECK(_zeros.size(0) == num_out_channels &&
+                    _zeros.size(1) == packed_groups,
+                "AWQ GEMMV2 packed zero-point shape does not match input channels.");
+    TORCH_CHECK(_scaling_factors.size(0) == num_out_channels &&
+                    _scaling_factors.size(1) == packed_groups * 8,
+                "AWQ GEMMV2 scale shape does not match input channels.");
+    // Follow the input tensor's device even when it is not the current device.
     const at::cuda::OptionalCUDAGuard device_guard(device_of(_in_feats));
 
     auto options = torch::TensorOptions().dtype(_in_feats.dtype()).device(_in_feats.device());
     // for int4, need _kernel.size(1) * 8
     at::Tensor _out_feats = torch::empty({split_k_iters, num_in_feats, _kernel.size(0)}, options);
     int num_out_feats = _out_feats.size(-2);
-    int num_out_channels = _out_feats.size(-1);
+    num_out_channels = _out_feats.size(-1);
 
     auto in_feats = reinterpret_cast<half*>(_in_feats.data_ptr<at::Half>());
     auto kernel = reinterpret_cast<int*>(_kernel.data_ptr<int>());
@@ -1273,20 +1319,22 @@ torch::Tensor gemmv2_forward_cuda(
     // threadIdx.x: 32
     // threadIdx.y: i_factors[2] * j_factors[2]
     dim3 threads_per_block(32, 4);
+    const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
     if (group_size == 128)
     {
-      gemmv2_forward_4bit_cuda_m128n64k32<128><<<num_blocks, threads_per_block>>>(
+      gemmv2_forward_4bit_cuda_m128n64k32<128><<<num_blocks, threads_per_block, 0, stream>>>(
         split_k_iters, in_feats, kernel, scaling_factors, zeros, num_in_feats, num_in_channels, num_out_channels, out_feats);
     }
     else if (group_size == 64)
     {
-      gemmv2_forward_4bit_cuda_m128n64k32<64><<<num_blocks, threads_per_block>>>(
+      gemmv2_forward_4bit_cuda_m128n64k32<64><<<num_blocks, threads_per_block, 0, stream>>>(
         split_k_iters, in_feats, kernel, scaling_factors, zeros, num_in_feats, num_in_channels, num_out_channels, out_feats);
     }
     else
     {
       throw std::invalid_argument("Group size temporarily not supported.");
     }
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
     return _out_feats.sum(0);
 }
 

--- a/gptqmodel_ext/awq/quantization/gemv_cuda.cu
+++ b/gptqmodel_ext/awq/quantization/gemv_cuda.cu
@@ -14,6 +14,8 @@
 #include <stdio.h>
 #include <torch/extension.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
 #include "gemv_cuda.h"
 #define VECTORIZE_FACTOR 8
 #define Q_VECTORIZE_FACTOR 8
@@ -207,8 +209,57 @@ torch::Tensor gemv_forward_cuda(
     torch::Tensor _zeros,
     int group_size)
 {
+    // Validate the ABI before converting tensors to raw pointers. This turns
+    // malformed layouts or cross-device buffers into actionable Python errors.
+    TORCH_CHECK(_in_feats.is_cuda(), "AWQ GEMV expects CUDA input activations.");
+    TORCH_CHECK(_kernel.is_cuda() && _scaling_factors.is_cuda() && _zeros.is_cuda(),
+                "AWQ GEMV expects all tensors on CUDA.");
+    TORCH_CHECK(_in_feats.dim() == 2, "AWQ GEMV expects 2D input activations.");
+    TORCH_CHECK(_kernel.dim() == 2 && _scaling_factors.dim() == 2 && _zeros.dim() == 2,
+                "AWQ GEMV expects 2D weights, scales, and zero-points.");
+    TORCH_CHECK(_in_feats.is_contiguous() && _kernel.is_contiguous() &&
+                    _scaling_factors.is_contiguous() && _zeros.is_contiguous(),
+                "AWQ GEMV expects contiguous input, weights, scales, and zero-points.");
+    TORCH_CHECK(_in_feats.scalar_type() == at::kHalf,
+                "AWQ GEMV only supports float16 activations.");
+    TORCH_CHECK(_scaling_factors.scalar_type() == at::kHalf,
+                "AWQ GEMV only supports float16 scales.");
+    TORCH_CHECK(_kernel.scalar_type() == at::kInt && _zeros.scalar_type() == at::kInt,
+                "AWQ GEMV packed weights and zero-points must be int32.");
+    TORCH_CHECK(_in_feats.device() == _kernel.device() &&
+                    _in_feats.device() == _scaling_factors.device() &&
+                    _in_feats.device() == _zeros.device(),
+                "AWQ GEMV tensors must be on the same CUDA device.");
+    TORCH_CHECK(group_size == 64 || group_size == 128,
+                "AWQ GEMV supports group_size 64 or 128.");
+
     int num_in_feats = _in_feats.size(0);
     int num_in_channels = _in_feats.size(1);
+    TORCH_CHECK(num_in_feats > 0, "AWQ GEMV does not support zero-row launches.");
+    int num_out_channels = _kernel.size(0);
+    TORCH_CHECK(num_in_channels > 0 && num_in_channels % 8 == 0,
+                "AWQ GEMV input channels must be a positive multiple of 8.");
+    TORCH_CHECK(num_in_channels % group_size == 0,
+                "AWQ GEMV input channels must be divisible by group_size.");
+    TORCH_CHECK(num_out_channels > 0 && num_out_channels % 4 == 0,
+                "AWQ GEMV output channels must be a positive multiple of 4.");
+    TORCH_CHECK(_kernel.size(1) == num_in_channels / 8,
+                "AWQ GEMV packed weight shape does not match input channels.");
+    const int num_groups = num_in_channels / group_size;
+    const int group_alignment = group_size == 64 ? 2 : 1;
+    const int packed_groups_unaligned = (num_groups + PACK_FACTOR - 1) / PACK_FACTOR;
+    const int packed_groups = (packed_groups_unaligned + group_alignment - 1) /
+                              group_alignment * group_alignment;
+    TORCH_CHECK(_zeros.size(0) == num_out_channels &&
+                    _zeros.size(1) == packed_groups,
+                "AWQ GEMV packed zero-point shape does not match input channels.");
+    TORCH_CHECK(_scaling_factors.size(0) == num_out_channels &&
+                    _scaling_factors.size(1) == packed_groups * PACK_FACTOR,
+                "AWQ GEMV scale shape does not match input channels.");
+
+    // Kernels must follow the input tensor's device, not the caller's current
+    // device (which may differ in multi-GPU inference).
+    const at::cuda::OptionalCUDAGuard device_guard(device_of(_in_feats));
     // int kernel_volume = _out_in_map.size(1);
     auto in_feats = reinterpret_cast<float4*>(_in_feats.data_ptr<at::Half>());
     auto kernel = reinterpret_cast<uint32_t*>(_kernel.data_ptr<int>());
@@ -220,7 +271,7 @@ torch::Tensor gemv_forward_cuda(
     // kernel is [OC, IC]
     at::Tensor _out_feats = torch::empty({num_in_feats, _kernel.size(0)}, options);
     int num_out_feats = _out_feats.size(-2);
-    int num_out_channels = _out_feats.size(-1);
+    num_out_channels = _out_feats.size(-1);
     auto out_feats = reinterpret_cast<half*>(_out_feats.data_ptr<at::Half>());
     int blockDim_z = num_out_feats;
     dim3 num_blocks(1, num_out_channels / 4, num_out_feats);
@@ -244,6 +295,6 @@ torch::Tensor gemv_forward_cuda(
         num_in_channels, num_out_channels
       );
     }
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
     return _out_feats;
 ;}
-

--- a/gptqmodel_ext/paroquant/rotation.cu
+++ b/gptqmodel_ext/paroquant/rotation.cu
@@ -9,6 +9,8 @@
 #include "rotation.cuh"
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -97,12 +99,14 @@ __global__ void rotate_kernel_bf16_half_workspace(const __nv_bfloat16 *__restric
       rotate_kernel<CUDA_T, CTA_M, GROUP_SIZE, KROT, false, ROW_PAD><<<grid, block, 0, stream>>>(   \
           x_p, o_p, idx_ij.data_ptr<int16_t>(), t_p, nullptr, seq_len, h);                           \
     }                                                                                                \
+    C10_CUDA_KERNEL_LAUNCH_CHECK();                                                                   \
     break;                                                                                           \
   }
 
 template <int KROT, int CTA_M, int GROUP_SIZE, int ROW_PAD>
 torch::Tensor rotate_launcher_bf16_half_workspace(at::Tensor x, at::Tensor idx_ij,
                                                   at::Tensor theta, at::Tensor scales) {
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(x));
   int h = x.size(-1);
   TORCH_CHECK(h % GROUP_SIZE == 0, "h must be divisible by GROUP_SIZE");
   int groups_per_row = h / GROUP_SIZE;
@@ -131,12 +135,14 @@ torch::Tensor rotate_launcher_bf16_half_workspace(at::Tensor x, at::Tensor idx_i
     rotate_kernel_bf16_half_workspace<CTA_M, GROUP_SIZE, KROT, false, ROW_PAD><<<grid, block, 0, stream>>>(
         x_p, o_p, idx_ij.data_ptr<int16_t>(), t_p, nullptr, seq_len, h);
   }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
   return out;
 }
 
 template <int KROT, int CTA_M, int GROUP_SIZE, int ROW_PAD>
 torch::Tensor rotate_launcher(at::Tensor x, at::Tensor idx_ij, at::Tensor theta,
                               at::Tensor scales) {
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(x));
   int h = x.size(-1);
   TORCH_CHECK(h % GROUP_SIZE == 0, "h must be divisible by GROUP_SIZE");
   int groups_per_row = h / GROUP_SIZE;
@@ -615,14 +621,46 @@ int64_t rotation_autotune_cache_size() {
   return static_cast<int64_t>(autotune_cache().size());
 }
 
+void validate_rotation_inputs(const at::Tensor &x, const at::Tensor &idx,
+                              const at::Tensor &theta, const at::Tensor &scales) {
+  // Rotation kernels use raw pointers and vectorized loads, so reject invalid
+  // devices/layouts before dispatching a specialized launch variant.
+  const bool has_scale = scales.defined() && scales.numel() > 0;
+  TORCH_CHECK(x.is_cuda() && idx.is_cuda() && theta.is_cuda(),
+              "ParoQuant rotation expects CUDA tensors.");
+  TORCH_CHECK(!has_scale || scales.is_cuda(),
+              "ParoQuant rotation scales must be a CUDA tensor.");
+  TORCH_CHECK(x.device() == idx.device() && x.device() == theta.device() &&
+                  (!has_scale || x.device() == scales.device()),
+              "ParoQuant rotation tensors must be on the same CUDA device.");
+  TORCH_CHECK(x.is_contiguous() && idx.is_contiguous() && theta.is_contiguous() &&
+                  (!has_scale || scales.is_contiguous()),
+              "ParoQuant rotation tensors must be contiguous.");
+  TORCH_CHECK(x.is_floating_point() && x.dim() >= 1,
+              "ParoQuant rotation input must be a floating-point tensor with at least one dimension.");
+  TORCH_CHECK(idx.scalar_type() == at::kShort && idx.dim() == 2,
+              "ParoQuant rotation indices must be contiguous int16 pairs.");
+  TORCH_CHECK(theta.is_floating_point() && theta.dim() == 2,
+              "ParoQuant rotation theta must be a 2D floating-point tensor.");
+  TORCH_CHECK(!has_scale || (scales.is_floating_point() && scales.dim() >= 1),
+              "ParoQuant rotation scales must be floating-point.");
+}
+
 } // namespace
 
 torch::Tensor rotate_dynamic(at::Tensor x, at::Tensor idx, at::Tensor theta,
                              c10::optional<at::Tensor> scales_opt, int64_t group_size = 128,
                              int64_t requested_cta_m = -1, int64_t requested_row_pad = -1) {
+  TORCH_CHECK(x.is_cuda(), "ParoQuant rotation requires a CUDA input tensor.");
+  // Autotune and the final launch must run on x's device, not the thread's
+  // previously selected CUDA device.
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(x));
+  TORCH_CHECK(theta.dim() >= 1 && idx.dim() >= 1,
+              "ParoQuant rotation theta and indices must have at least one dimension.");
   int64_t krot = theta.size(0);
   TORCH_CHECK(krot == idx.size(0), "theta.size(0) must equal idx_ij.size(0)");
   at::Tensor scales = scales_opt.value_or(at::Tensor());
+  validate_rotation_inputs(x, idx, theta, scales);
   const bool has_scale = scales.defined() && scales.numel() > 0;
   const LaunchConfig config = resolve_runtime_launch_config(
       x, idx, theta, scales, group_size, krot, static_cast<int>(requested_cta_m),
@@ -634,6 +672,10 @@ torch::Tensor rotate_dynamic(at::Tensor x, at::Tensor idx, at::Tensor theta,
 std::vector<int64_t> rotate_launch_config(at::Tensor x, int64_t krot = 8, bool has_scale = true,
                                           int64_t group_size = 128, int64_t cta_m = -1,
                                           int64_t row_pad = -1) {
+  TORCH_CHECK(x.is_cuda(), "ParoQuant rotation launch config requires a CUDA input tensor.");
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(x));
+  TORCH_CHECK(x.is_contiguous() && x.is_floating_point() && x.dim() >= 1,
+              "ParoQuant rotation launch config expects contiguous floating-point input.");
   const LaunchConfig config = resolve_query_launch_config(
       x, krot, has_scale, group_size, static_cast<int>(cta_m), static_cast<int>(row_pad));
   return {

--- a/tests/test_awq_cuda_contract.py
+++ b/tests/test_awq_cuda_contract.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+import pytest
+import torch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize(
+    "source_path",
+    [
+        "gptqmodel_ext/awq/quantization/gemv_cuda.cu",
+        "gptqmodel_ext/awq/quantization/gemm_cuda_gen.cu",
+        "gptqmodel_ext/paroquant/rotation.cu",
+    ],
+)
+def test_cuda_entrypoints_guard_device_and_launch(source_path):
+    source = (ROOT / source_path).read_text()
+    assert "OptionalCUDAGuard" in source
+    assert "C10_CUDA_KERNEL_LAUNCH_CHECK" in source
+
+
+def test_awq_gemv_native_contract_checks_tensor_layout_and_device():
+    source = (ROOT / "gptqmodel_ext/awq/quantization/gemv_cuda.cu").read_text()
+    for contract in (
+        "is_contiguous",
+        "scalar_type() == at::kHalf",
+        "must be on the same CUDA device",
+        "does not support zero-row launches",
+        "group_size == 64 || group_size == 128",
+    ):
+        assert contract in source
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two CUDA devices")
+def test_awq_gemv_uses_tensor_device_instead_of_current_device():
+    from gptqmodel.utils.awq import (
+        awq_gemmv2_forward,
+        awq_gemv_forward,
+        awq_runtime_error,
+        prewarm_awq_extension,
+    )
+
+    if not prewarm_awq_extension():
+        pytest.skip(awq_runtime_error())
+
+    original_device = torch.cuda.current_device()
+    input_device = torch.device("cuda:1" if original_device == 0 else "cuda:0")
+    torch.cuda.set_device(original_device)
+
+    qweight = torch.zeros((64, 16), device=input_device, dtype=torch.int32)
+    qzeros = torch.zeros((64, 2), device=input_device, dtype=torch.int32)
+    scales = torch.ones((64, 16), device=input_device, dtype=torch.float16)
+
+    decode = awq_gemv_forward(
+        torch.ones((1, 128), device=input_device, dtype=torch.float16),
+        qweight,
+        scales,
+        qzeros,
+        64,
+    )
+    prefill = awq_gemmv2_forward(
+        torch.ones((9, 128), device=input_device, dtype=torch.float16),
+        qweight,
+        scales,
+        qzeros,
+        64,
+        8,
+    )
+
+    assert torch.cuda.current_device() == original_device
+    assert decode.device == input_device and decode.shape == (1, 64)
+    assert prefill.device == input_device and prefill.shape == (9, 64)
+    assert torch.count_nonzero(decode) == 0
+    assert torch.count_nonzero(prefill) == 0
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two CUDA devices")
+def test_paroquant_rotation_uses_tensor_device_instead_of_current_device():
+    from gptqmodel import extension
+    from gptqmodel.utils.paroquant import (
+        _load_rotation_extension,
+        build_identity_rotation_buffers,
+    )
+
+    if not _load_rotation_extension():
+        pytest.skip("ParoQuant CUDA extension is unavailable")
+
+    original_device = torch.cuda.current_device()
+    input_device = torch.device("cuda:1" if original_device == 0 else "cuda:0")
+    torch.cuda.set_device(original_device)
+    x = torch.ones((1, 128), device=input_device, dtype=torch.float16)
+    pairs, theta, scales = build_identity_rotation_buffers(
+        in_features=128,
+        group_size=128,
+        krot=1,
+        device=input_device,
+        dtype=torch.float16,
+    )
+
+    out = extension.op("paroquant", "rotate")(
+        x,
+        pairs,
+        theta,
+        scales,
+        128,
+        -1,
+        -1,
+    )
+
+    assert torch.cuda.current_device() == original_device
+    assert out.device == input_device
+    torch.testing.assert_close(out, x)

--- a/tests/test_awq_rank_and_empty.py
+++ b/tests/test_awq_rank_and_empty.py
@@ -1,0 +1,255 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import gptqmodel.nn_modules.qlinear.gemm_awq as gemm_awq
+import gptqmodel.nn_modules.qlinear.gemm_awq_triton as gemm_awq_triton
+from gptqmodel.nn_modules.qlinear.exllamav2 import ExllamaV2Linear
+from gptqmodel.nn_modules.qlinear.exllamav2_awq import AwqExllamaV2Linear
+from gptqmodel.nn_modules.qlinear import empty_linear_output, input_rows
+from gptqmodel.nn_modules.qlinear.gemm_awq import AwqGEMMLinear
+from gptqmodel.nn_modules.qlinear.gemm_awq_triton import AwqGEMMTritonLinear
+from gptqmodel.nn_modules.qlinear.gemv_awq import AwqGEMVLinear
+from gptqmodel.nn_modules.qlinear.gemv_fast_awq import AwqGEMVFastLinear
+from gptqmodel.nn_modules.qlinear.machete import MacheteLinear
+from gptqmodel.nn_modules.qlinear.machete_awq import AwqMacheteLinear
+from gptqmodel.nn_modules.qlinear.marlin import MarlinLinear
+from gptqmodel.nn_modules.qlinear.marlin_awq import AwqMarlinLinear
+from gptqmodel.nn_modules.qlinear.paroquant import ParoLinear
+from gptqmodel.nn_modules.qlinear.paroquant_triton import ParoQuantTritonLinear
+from gptqmodel.nn_modules.qlinear.qqq import QQQLinear, QQQTorchLinear
+from gptqmodel.nn_modules.qlinear.swordfish import AwqSwordfishLinear, SwordfishLinear
+
+
+def _fake_quant_tensors(in_features=8, out_features=8):
+    return (
+        torch.ones((in_features, out_features // 8), dtype=torch.int32),
+        torch.ones((in_features, out_features), dtype=torch.float16),
+        torch.zeros((in_features, out_features // 8), dtype=torch.int32),
+    )
+
+
+def _patch_backend(monkeypatch, backend, calls):
+    if backend == "triton":
+        triton_state = getattr(
+            gemm_awq_triton, "tritonv2", SimpleNamespace(TRITON_AVAILABLE=False)
+        )
+        monkeypatch.setattr(gemm_awq_triton, "tritonv2", triton_state, raising=False)
+        monkeypatch.setattr(triton_state, "TRITON_AVAILABLE", True)
+
+        def fake_dequant(qweight, scales, qzeros):
+            calls["dequant"] += 1
+            return torch.ones(
+                (qweight.shape[0], qweight.shape[1] * 8), dtype=torch.float16
+            )
+
+        def fake_gemm(x, qweight, scales, qzeros, **kwargs):
+            calls["gemm"] += 1
+            return torch.ones(
+                (x.shape[0], qweight.shape[1] * 8), dtype=x.dtype, device=x.device
+            )
+
+        monkeypatch.setattr(
+            gemm_awq_triton, "awq_dequantize_triton", fake_dequant, raising=False
+        )
+        monkeypatch.setattr(
+            gemm_awq_triton, "awq_gemm_triton", fake_gemm, raising=False
+        )
+        monkeypatch.setattr(
+            "gptqmodel.quantization.awq.modules.triton.gemm.awq_dequantize_triton",
+            fake_dequant,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "gptqmodel.quantization.awq.modules.triton.gemm.awq_gemm_triton",
+            fake_gemm,
+            raising=False,
+        )
+        return gemm_awq_triton.AwqGemmTritonFn
+
+    def fake_dequant(qweight, scales, qzeros, *_args):
+        calls["dequant"] += 1
+        return torch.ones((qweight.shape[0], qweight.shape[1] * 8), dtype=torch.float16)
+
+    def fake_gemm(x, qweight, scales, qzeros, *_args, **_kwargs):
+        calls["gemm"] += 1
+        return torch.ones(
+            (x.shape[0], qweight.shape[1] * 8), dtype=x.dtype, device=x.device
+        )
+
+    monkeypatch.setattr(gemm_awq, "awq_dequantize_weights", fake_dequant)
+    monkeypatch.setattr(gemm_awq, "_awq_cuda_gemm_forward", fake_gemm)
+    return gemm_awq.AwqGemmFn
+
+
+@pytest.mark.parametrize("backend", ["jit", "triton"])
+@pytest.mark.parametrize("shape", [(2, 8), (2, 3, 8), (2, 3, 4, 8)])
+def test_awq_gemm_autograd_supports_arbitrary_rank(monkeypatch, backend, shape):
+    calls = {"dequant": 0, "gemm": 0}
+    fn = _patch_backend(monkeypatch, backend, calls)
+    qweight, scales, qzeros = _fake_quant_tensors()
+    x = torch.ones(shape, dtype=torch.float16, requires_grad=True)
+
+    out = fn.apply(x, qweight, qzeros, scales, 4, 8, None, 8)
+    assert out.shape == shape[:-1] + (8,)
+    out.sum().backward()
+    assert x.grad is not None
+    assert x.grad.shape == x.shape
+    assert torch.all(x.grad == 8)
+    assert calls["gemm"] == 1
+    assert calls["dequant"] == 1
+
+
+@pytest.mark.parametrize("backend", ["jit", "triton"])
+@pytest.mark.parametrize("shape", [(3, 0, 8), (0, 3, 8)])
+def test_awq_gemm_empty_input_skips_forward_and_backward_backends(
+    monkeypatch, backend, shape
+):
+    calls = {"dequant": 0, "gemm": 0}
+    fn = _patch_backend(monkeypatch, backend, calls)
+    qweight, scales, qzeros = _fake_quant_tensors()
+    x = torch.empty(shape, dtype=torch.float16, requires_grad=True)
+
+    out = fn.apply(x, qweight, qzeros, scales, 4, 8, None, 8)
+    assert out.shape == shape[:-1] + (8,)
+    out.sum().backward()
+    assert x.grad is not None
+    assert x.grad.shape == x.shape
+    assert calls == {"dequant": 0, "gemm": 0}
+
+
+@pytest.mark.parametrize("backend, rows", [("jit", 1025), ("triton", 129)])
+def test_awq_gemm_heuristic_uses_logical_rows_for_2d_input(monkeypatch, backend, rows):
+    calls = {"dequant": 0, "gemm": 0}
+    fn = _patch_backend(monkeypatch, backend, calls)
+    qweight, scales, qzeros = _fake_quant_tensors()
+    x = torch.ones((rows, 8), dtype=torch.float16)
+
+    out = fn.apply(x, qweight, qzeros, scales, 4, 8, None, 8)
+    assert out.shape == (rows, 8)
+    assert calls == {"dequant": 1, "gemm": 0}
+
+
+@pytest.mark.parametrize("shape", [(3, 0, 8), (0, 3, 8), (2, 3, 4, 8)])
+def test_linear_shape_helpers_preserve_rank_dtype_and_device(shape):
+    x = torch.empty(shape, dtype=torch.bfloat16)
+    assert input_rows(x) == x.numel() // x.shape[-1]
+    out = empty_linear_output(x, 11)
+    assert out.shape == shape[:-1] + (11,)
+    assert out.dtype == x.dtype
+    assert out.device == x.device
+
+
+def test_empty_linear_output_keeps_autograd_connection():
+    x = torch.empty((2, 0, 8), dtype=torch.float32, requires_grad=True)
+    out = empty_linear_output(x, 11)
+    out.sum().backward()
+    assert x.grad is not None
+    assert x.grad.shape == x.shape
+    assert torch.count_nonzero(x.grad) == 0
+
+
+@pytest.mark.parametrize(
+    "linear_cls",
+    [
+        AwqGEMMLinear,
+        AwqGEMMTritonLinear,
+        MarlinLinear,
+        AwqMarlinLinear,
+        ExllamaV2Linear,
+        AwqExllamaV2Linear,
+        MacheteLinear,
+        AwqMacheteLinear,
+        QQQLinear,
+        QQQTorchLinear,
+        SwordfishLinear,
+        AwqSwordfishLinear,
+        AwqGEMVLinear,
+        AwqGEMVFastLinear,
+        ParoLinear,
+        ParoQuantTritonLinear,
+    ],
+)
+def test_representative_qlinear_empty_shape_without_native_extension(linear_cls):
+    # These forwards all check the common helper before touching backend state;
+    # constructing a minimal shell keeps this test independent of extensions.
+    module = object.__new__(linear_cls)
+    module.out_features = 11
+    module.adapter = None
+    module.training = True
+    if linear_cls in (AwqGEMMLinear, AwqGEMMTritonLinear):
+        module.bits = 4
+        module.group_size = 8
+        module.fp32_accum = True
+        module.qweight = torch.empty((8, 2), dtype=torch.int32)
+        module.qzeros = torch.empty((1, 2), dtype=torch.int32)
+        module.scales = torch.empty((1, 11), dtype=torch.float16)
+        module.bias = None
+    x = torch.empty((2, 0, 8), dtype=torch.float32, requires_grad=True)
+
+    out = module.forward(x)
+    assert out.shape == (2, 0, 11)
+    assert out.dtype == x.dtype
+    out.sum().backward()
+    assert x.grad is not None and x.grad.shape == x.shape
+
+
+def test_awq_gemv_validation_matches_native_kernel_contract():
+    ok, error = AwqGEMVLinear.validate(
+        bits=4,
+        group_size=32,
+        desc_act=False,
+        sym=True,
+        in_features=128,
+        out_features=64,
+        pack_dtype=torch.int32,
+    )
+    assert not ok
+    assert isinstance(error, NotImplementedError)
+
+    ok, error = AwqGEMVLinear.validate(
+        bits=4,
+        group_size=-1,
+        desc_act=False,
+        sym=True,
+        pack_dtype=torch.int32,
+    )
+    assert ok and error is None
+
+    # Positional arguments cover the constructor-style call that originally
+    # exposed duplicate group_size forwarding when resolving -1.
+    ok, error = AwqGEMVLinear.validate(
+        4,
+        -1,
+        False,
+        True,
+        128,
+        64,
+        torch.int32,
+    )
+    assert ok and error is None
+
+    ok, error = AwqGEMVLinear.validate(
+        bits=4,
+        group_size=-1,
+        desc_act=False,
+        sym=True,
+        in_features=256,
+        out_features=64,
+        pack_dtype=torch.int32,
+    )
+    assert not ok
+    assert isinstance(error, NotImplementedError)
+
+    ok, error = AwqGEMVLinear.validate(
+        bits=4,
+        group_size=64,
+        desc_act=False,
+        sym=True,
+        in_features=128,
+        out_features=32,
+        pack_dtype=torch.int32,
+    )
+    assert not ok
+    assert isinstance(error, NotImplementedError)


### PR DESCRIPTION
## Summary

- preserve arbitrary-rank output shapes, adapter semantics, and autograd behavior for empty quantized-linear inputs
- flatten and restore AWQ GEMM inputs consistently in forward/backward, including 4D tensors
- align AWQ GEMV Python selection with native group-size and output-alignment requirements
- validate native AWQ and ParoQuant tensor/device/layout contracts before using raw pointers
- launch CUDA kernels on the input tensor's device/current stream and report launch errors promptly

## Testing

- `ruff check ...` (passed)
- `python -m compileall -q gptqmodel/nn_modules/qlinear` (passed)
- `pytest -q tests/test_awq_rank_and_empty.py tests/test_awq_cuda_contract.py` (`37 passed, 2 skipped` without CUDA access)
- `pytest -q tests/test_awq_cuda_contract.py tests/kernels/test_paroquant.py` (`12 passed` on two GPUs)
- `pytest -q tests/kernels/test_awq_cuda_fp32_reduce.py tests/kernels/test_awq_triton_accum.py` (`8 passed`)
- qlinear selection/dtype/JIT/autotune regression suite (`91 passed, 62 skipped`)
- Llama-3.2-1B AWQ GEMM quantize/save/load/generate end-to-end (`1 passed`)
- Llama-3.2-1B AWQ GEMV FP16 quantize/save/load/generate smoke (passed)
- real CUDA AWQ GEMM and Triton 4D forward/backward smoke (passed)
