### PR TITLE
refactor(machete): harden runtime cache

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,5 +16,6 @@ include gptqmodel_ext/floatx_cpu.cpp
 include gptqmodel_ext/marlin/generate_kernels.py
 include gptqmodel_ext/machete/generate.py
 recursive-exclude gptqmodel_ext __pycache__ *.pyc
+prune gptqmodel_ext/machete/generated
 prune tests/
 prune format/

--- a/README.md
+++ b/README.md
@@ -420,6 +420,21 @@ export GPTQMODEL_FP32_ACCUM=0
 
 JIT-compiled kernels are cached at `~/.cache/gptqmodel/torch_extensions` by default. Multiple processes on one host may safely share the cache: builds are serialized with a cross-process file lock that the OS releases automatically if a process dies.
 
+Machete's pinned CUTLASS checkout and generated CUDA sources are kept in the
+versioned user cache (`~/.cache/gptqmodel`, or `GPTQMODEL_CACHE_DIR`; when set,
+`XDG_CACHE_HOME/gptqmodel` is used). Set `GPTQMODEL_CUTLASS_DIR` to use an
+already-installed, read-only CUTLASS 4.7.1 checkout. `GPTQMODEL_OFFLINE=1`
+disables downloads and requires that checkout or a verified cache hit already
+exist. For environments where compilation is not allowed, point
+`GPTQMODEL_MACHETE_PRECOMPILED_LIBRARY` at a compatible Machete shared library;
+an invalid or missing explicit library is reported as an error and does not
+fall back to JIT. The generated source cache can be populated ahead of time by
+prewarming the extension:
+
+```shell
+python -c "from gptqmodel import extension; extension.load('machete')"
+```
+
 ```shell
 # optional: relocate the kernel cache (e.g. one cache per process)
 export GPTQMODEL_TORCH_EXTENSIONS_DIR=/path/to/cache

--- a/gptqmodel/utils/cpp.py
+++ b/gptqmodel/utils/cpp.py
@@ -1285,12 +1285,30 @@ class TorchOpsJitExtension:
     def _load_configured_prebuilt_library(self, library_path: Path) -> bool:
         """Load an explicitly configured library without evaluating JIT callbacks."""
 
-        if self._loaded_prebuilt_library == library_path and self._load_result and library_path.is_file():
+        if (
+            self._loaded_prebuilt_library == library_path
+            and self._load_result
+            and library_path.is_file()
+        ):
             return True
         if not library_path.is_file():
             self._last_error = (
                 f"{self.display_name}: configured prebuilt library `{library_path}` does not exist. "
                 f"Unset `{self.prebuilt_library_env}` to enable JIT compilation, or provide a compatible file."
+            )
+            self._load_attempted = True
+            self._load_result = False
+            return False
+        if self._ops_available() and self._loaded_prebuilt_library != library_path:
+            loaded_detail = (
+                f" from `{self._loaded_prebuilt_library}`"
+                if self._loaded_prebuilt_library is not None
+                else ""
+            )
+            self._last_error = (
+                f"{self.display_name}: required torch.ops are already registered{loaded_detail}; cannot verify "
+                f"that configured prebuilt library `{library_path}` provides them. PyTorch cannot unload operator "
+                "registrations in-process, so start a new process before selecting a different prebuilt library."
             )
             self._load_attempted = True
             self._load_result = False
@@ -1339,7 +1357,9 @@ class TorchOpsJitExtension:
             self._load_attempted = False
             self._load_result = False
             self._last_error = ""
-            self._loaded_prebuilt_library = None
+            # torch.ops registrations cannot be unloaded. Keep the artifact
+            # identity so a later environment-path switch cannot claim the
+            # existing namespace as registrations from a different library.
             self._namespace_cache = None
             self._op_cache = {}
             if self._configured_prebuilt_library() is not None:

--- a/gptqmodel/utils/cpp.py
+++ b/gptqmodel/utils/cpp.py
@@ -856,6 +856,7 @@ class TorchOpsJitExtension:
         binary_names: Optional[Sequence[str]] = None,
         python_abi_dependent: bool | None = None,
         torch_stable_abi_target: tuple[int, int] | None = None,
+        prebuilt_library_env: Optional[str] = None,
     ) -> None:
         self.name = name
         self.namespace = namespace
@@ -875,10 +876,12 @@ class TorchOpsJitExtension:
         self.binary_names = tuple(binary_names or (name,))
         self.python_abi_dependent = python_abi_dependent
         self.torch_stable_abi_target = tuple(torch_stable_abi_target) if torch_stable_abi_target else None
+        self.prebuilt_library_env = prebuilt_library_env
         self.compile_baseline_seconds = get_jit_compile_baseline_seconds(name)
         self._load_attempted = False
         self._load_result = False
         self._last_error = ""
+        self._loaded_prebuilt_library: Optional[Path] = None
         self._namespace_cache: Optional[object] = None
         self._op_cache: dict[str, object] = {}
         self._source_abi_detection_cache: dict[
@@ -1271,6 +1274,52 @@ class TorchOpsJitExtension:
                         candidates.append(match)
         return candidates
 
+    def _configured_prebuilt_library(self) -> Optional[Path]:
+        if not self.prebuilt_library_env:
+            return None
+        configured = os.getenv(self.prebuilt_library_env)
+        if not configured:
+            return None
+        return Path(configured).expanduser().resolve(strict=False)
+
+    def _load_configured_prebuilt_library(self, library_path: Path) -> bool:
+        """Load an explicitly configured library without evaluating JIT callbacks."""
+
+        if self._loaded_prebuilt_library == library_path and self._load_result and library_path.is_file():
+            return True
+        if not library_path.is_file():
+            self._last_error = (
+                f"{self.display_name}: configured prebuilt library `{library_path}` does not exist. "
+                f"Unset `{self.prebuilt_library_env}` to enable JIT compilation, or provide a compatible file."
+            )
+            self._load_attempted = True
+            self._load_result = False
+            return False
+        try:
+            torch.ops.load_library(str(library_path))
+        except Exception as exc:
+            self._last_error = (
+                f"{self.display_name}: configured prebuilt library `{library_path}` is incompatible: {exc}. "
+                f"Unset `{self.prebuilt_library_env}` to enable JIT compilation, or provide a compatible file."
+            )
+            self._load_attempted = True
+            self._load_result = False
+            return False
+        if not self._refresh_runtime_cache():
+            self._last_error = (
+                f"{self.display_name}: configured prebuilt library `{library_path}` loaded but did not register "
+                f"required torch.ops ({', '.join(self.required_ops)}). Unset `{self.prebuilt_library_env}` to "
+                "enable JIT compilation, or provide a compatible file."
+            )
+            self._load_attempted = True
+            self._load_result = False
+            return False
+        self._load_attempted = True
+        self._load_result = True
+        self._loaded_prebuilt_library = library_path
+        self._last_error = ""
+        return True
+
     def _try_load_prebuilt_library(self, build_root: Path) -> bool:
         for library_path in self._candidate_binary_paths(build_root):
             if not library_path.is_file():
@@ -1290,8 +1339,11 @@ class TorchOpsJitExtension:
             self._load_attempted = False
             self._load_result = False
             self._last_error = ""
+            self._loaded_prebuilt_library = None
             self._namespace_cache = None
             self._op_cache = {}
+            if self._configured_prebuilt_library() is not None:
+                return
             build_root = self.base_build_root()
             if build_root.exists():
                 lock_timeout_seconds = self._build_lock_timeout_seconds()
@@ -1346,6 +1398,14 @@ class TorchOpsJitExtension:
             self._load_result = False
             self._last_error = stable_abi_error
             return False
+
+        # This check intentionally precedes every build_root(), sources, and
+        # include-path callback. An explicit prebuilt artifact is authoritative:
+        # a missing or incompatible file must never silently trigger a source build.
+        configured_prebuilt = self._configured_prebuilt_library()
+        if configured_prebuilt is not None:
+            with self._lock:
+                return self._load_configured_prebuilt_library(configured_prebuilt)
 
         if self._load_attempted and self._load_result and not self.force_rebuild_enabled():
             return True

--- a/gptqmodel/utils/machete.py
+++ b/gptqmodel/utils/machete.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import importlib.metadata
 import json
 import os
 import shutil
@@ -12,11 +14,12 @@ import sys
 import tarfile
 import tempfile
 import urllib.request
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import List, Optional
 
 import pcre
 import torch
+from filelock import FileLock
 
 from .cpp import (
     TorchOpsJitExtension,
@@ -27,6 +30,7 @@ from .cpp import (
     is_nvcc_compatible,
     resolved_cuda_arch_flags,
 )
+from .env import env_flag
 from .logger import setup_logger
 from .marlin_scalar_type import ScalarType, scalar_types
 from .rocm import IS_ROCM
@@ -39,7 +43,12 @@ _MACHETE_OPS_NAMESPACE = "gptqmodel_machete"
 
 _CUTLASS_VERSION = "4.7.1"
 _CUTLASS_RELEASE_URL = f"https://github.com/NVIDIA/cutlass/archive/refs/tags/v{_CUTLASS_VERSION}.tar.gz"
+_CUTLASS_ARCHIVE_SHA256 = "8290eb914cd5aaf4c665ee4108ba5bd65383cfee1296286a42a7ef711554d365"
 _CUTLASS_VERSION_MARKER = ".gptqmodel_cutlass_version"
+_MACHETE_COMPLETE_MARKER = ".gptqmodel_complete"
+_MACHETE_MANIFEST_NAME = ".gptqmodel_manifest.json"
+_MACHETE_GENERATION_CACHE_VERSION = 1
+_MACHETE_CACHE_LOCK_TIMEOUT_SECONDS = 600
 _CUTLASS_VERSION_DEFINE_PATTERN = pcre.compile(
     r"^\s*#define\s+CUTLASS_(MAJOR|MINOR|PATCH)\s+(\d+)\s*$",
     flags=pcre.Flag.MULTILINE,
@@ -79,8 +88,54 @@ def _repo_local_cutlass_root() -> Path:
     return _machete_project_root() / "cutlass"
 
 
+def _gptqmodel_cache_dir() -> Path:
+    """Return the user cache root used by downloaded source artifacts."""
+
+    configured = os.getenv("GPTQMODEL_CACHE_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    xdg_cache_home = os.getenv("XDG_CACHE_HOME")
+    if xdg_cache_home:
+        return Path(xdg_cache_home).expanduser() / "gptqmodel"
+    return Path.home() / ".cache" / "gptqmodel"
+
+
+def _cutlass_cache_key() -> str:
+    return f"{_CUTLASS_VERSION}-{_CUTLASS_ARCHIVE_SHA256}"
+
+
+def _cutlass_cache_dir() -> Path:
+    return _gptqmodel_cache_dir() / "cutlass" / _cutlass_cache_key()
+
+
 def _cutlass_download_cache_dir() -> Path:
-    return _machete_project_root() / "build" / "_deps"
+    return _gptqmodel_cache_dir() / "downloads"
+
+
+def _cutlass_archive_path() -> Path:
+    return _cutlass_download_cache_dir() / f"cutlass-v{_cutlass_cache_key()}.tar.gz"
+
+
+def _machete_cache_lock_path(name: str) -> Path:
+    return _gptqmodel_cache_dir() / "locks" / f"{name}.lock"
+
+
+def _offline_mode() -> bool:
+    return env_flag("GPTQMODEL_OFFLINE", default=False)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _acquire_machete_cache_lock(name: str) -> FileLock:
+    lock_path = _machete_cache_lock_path(name)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    return FileLock(str(lock_path), timeout=_MACHETE_CACHE_LOCK_TIMEOUT_SECONDS)
 
 
 def _cutlass_python_bindings_present(cutlass_root: Path) -> bool:
@@ -133,133 +188,248 @@ def _cutlass_checkout_version_error(cutlass_root: Path) -> Optional[str]:
     return None
 
 
-def _repo_local_cutlass_version_matches(cutlass_root: Path) -> bool:
-    marker = _repo_local_cutlass_version_marker(cutlass_root)
-    return (
-        _cutlass_checkout_version(cutlass_root) == _CUTLASS_VERSION
-        and marker.is_file()
-        and marker.read_text(encoding="utf-8").strip() == _CUTLASS_VERSION
+def _mark_cutlass_cache(cutlass_root: Path) -> None:
+    """Mark a cache-owned checkout complete; never call this for user sources."""
+
+    _repo_local_cutlass_version_marker(cutlass_root).write_text(
+        json.dumps(
+            {
+                "version": _CUTLASS_VERSION,
+                "archive_sha256": _CUTLASS_ARCHIVE_SHA256,
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
     )
 
 
-def _mark_repo_local_cutlass_version(cutlass_root: Path) -> None:
-    _repo_local_cutlass_version_marker(cutlass_root).write_text(f"{_CUTLASS_VERSION}\n", encoding="utf-8")
-
-
-def _use_repo_local_cutlass(cutlass_root: Path) -> Path:
-    if not _repo_local_cutlass_version_matches(cutlass_root):
-        _mark_repo_local_cutlass_version(cutlass_root)
-    os.environ["GPTQMODEL_CUTLASS_DIR"] = str(cutlass_root)
-    return cutlass_root
-
-
 def _download_cutlass_archive(url: str, destination: Path) -> None:
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    partial = destination.with_suffix(destination.suffix + ".part")
-    if partial.exists():
-        partial.unlink()
+    """Download and atomically publish the pinned CUTLASS archive."""
 
-    log.info("Machete: downloading CUTLASS v%s into `%s`.", _CUTLASS_VERSION, destination)
-    with urllib.request.urlopen(url) as response, partial.open("wb") as handle:
-        shutil.copyfileobj(response, handle)
-    partial.replace(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    partial = destination.with_name(f".{destination.name}.{os.getpid()}.tmp")
+    try:
+        if partial.exists():
+            partial.unlink()
+
+        log.info("Machete: downloading CUTLASS v%s into `%s`.", _CUTLASS_VERSION, destination)
+        with urllib.request.urlopen(url) as response, partial.open("wb") as handle:
+            shutil.copyfileobj(response, handle)
+        actual = _sha256(partial)
+        if actual != _CUTLASS_ARCHIVE_SHA256:
+            raise RuntimeError(
+                "Machete: CUTLASS archive checksum mismatch: "
+                f"expected {_CUTLASS_ARCHIVE_SHA256}, got {actual}."
+            )
+        os.replace(partial, destination)
+    finally:
+        try:
+            partial.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def _extract_cutlass_archive(archive_path: Path, destination_parent: Path) -> None:
+    """Extract a tarball after rejecting traversal, links, and special files."""
+
     with tarfile.open(archive_path, "r:gz") as archive:
+        root = destination_parent.resolve()
+        members = archive.getmembers()
+        for member in members:
+            member_path = PurePosixPath(member.name)
+            if member_path.is_absolute() or ".." in member_path.parts:
+                raise RuntimeError(f"Machete: unsafe CUTLASS archive member `{member.name}`.")
+            target = (destination_parent / member.name).resolve(strict=False)
+            try:
+                target.relative_to(root)
+            except ValueError as exc:
+                raise RuntimeError(f"Machete: unsafe CUTLASS archive member `{member.name}`.") from exc
+            if member.issym() or member.islnk() or not (member.isdir() or member.isfile()):
+                raise RuntimeError(
+                    f"Machete: unsupported or unsafe CUTLASS archive member `{member.name}`."
+                )
         extract_kwargs = {"path": destination_parent}
         if sys.version_info >= (3, 12):
             extract_kwargs["filter"] = "data"
-        archive.extractall(**extract_kwargs)
+        archive.extractall(members=members, **extract_kwargs)
 
 
-def _ensure_cutlass_source() -> Path:
-    repo_local_root = _repo_local_cutlass_root().resolve()
-    configured_root = os.getenv("GPTQMODEL_CUTLASS_DIR")
-    if configured_root:
-        configured_path = Path(configured_root).expanduser().resolve()
-        if _cutlass_checkout_complete(configured_path):
-            version_error = _cutlass_checkout_version_error(configured_path)
-            if version_error is None:
-                if configured_path == repo_local_root:
-                    return _use_repo_local_cutlass(configured_path)
-                return configured_path
-            if configured_path != repo_local_root:
-                raise RuntimeError(
-                    "Machete: GPTQMODEL_CUTLASS_DIR points to an incompatible CUTLASS checkout. "
-                    f"{version_error} Unset GPTQMODEL_CUTLASS_DIR to allow auto-download, or point it at a "
-                    f"CUTLASS v{_CUTLASS_VERSION} checkout."
-                )
-            log.info(
-                "Machete: GPTQMODEL_CUTLASS_DIR points to stale repo-local CUTLASS checkout `%s`; refreshing to v%s.",
-                configured_path,
-                _CUTLASS_VERSION,
-            )
-        else:
-            log.info(
-                "Machete: GPTQMODEL_CUTLASS_DIR=`%s` is incomplete; falling back to repo-local CUTLASS checkout.",
-                configured_path,
+def _validate_cutlass_checkout(cutlass_root: Path, *, require_marker: bool = False) -> None:
+    if not _cutlass_checkout_complete(cutlass_root):
+        raise RuntimeError(
+            f"Machete: CUTLASS checkout `{cutlass_root}` is incomplete; "
+            f"GPTQModel requires CUTLASS v{_CUTLASS_VERSION}."
+        )
+    version_error = _cutlass_checkout_version_error(cutlass_root)
+    if version_error:
+        raise RuntimeError(f"Machete: {version_error}")
+    if require_marker:
+        marker = _repo_local_cutlass_version_marker(cutlass_root)
+        try:
+            marker_data = json.loads(marker.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError) as exc:
+            raise RuntimeError(
+                f"Machete: CUTLASS cache `{cutlass_root}` is missing a valid completion marker."
+            ) from exc
+        expected = {
+            "version": _CUTLASS_VERSION,
+            "archive_sha256": _CUTLASS_ARCHIVE_SHA256,
+        }
+        if marker_data != expected:
+            raise RuntimeError(
+                f"Machete: CUTLASS cache `{cutlass_root}` has a stale or incompatible completion marker."
             )
 
-    if _cutlass_checkout_complete(repo_local_root):
-        if _cutlass_checkout_version_error(repo_local_root) is None:
-            return _use_repo_local_cutlass(repo_local_root)
-    if repo_local_root.exists():
-        current_version = _cutlass_checkout_version(repo_local_root)
-        log.info(
-            "Machete: refreshing repo-local CUTLASS checkout at `%s`%s to v%s.",
-            repo_local_root,
-            f" from v{current_version}" if current_version else "",
-            _CUTLASS_VERSION,
+
+def _cache_cutlass_checkout(archive_path: Path) -> Path:
+    archive_digest = _sha256(archive_path) if archive_path.is_file() else "missing"
+    if archive_digest != _CUTLASS_ARCHIVE_SHA256:
+        raise RuntimeError(
+            "Machete: refusing to extract an unverified CUTLASS archive: "
+            f"expected {_CUTLASS_ARCHIVE_SHA256}, got {archive_digest}."
         )
 
-    archive_path = _cutlass_download_cache_dir() / f"cutlass-v{_CUTLASS_VERSION}.tar.gz"
-    archive_path.parent.mkdir(parents=True, exist_ok=True)
-    if not archive_path.exists():
-        _download_cutlass_archive(_CUTLASS_RELEASE_URL, archive_path)
+    checkout = _cutlass_cache_dir()
+    if checkout.is_dir():
+        try:
+            _validate_cutlass_checkout(checkout, require_marker=True)
+            return checkout.resolve()
+        except RuntimeError:
+            log.warning("Machete: ignoring incomplete CUTLASS cache `%s`.", checkout)
+    elif checkout.exists():
+        raise RuntimeError(f"Machete: CUTLASS cache path `{checkout}` is not a directory.")
 
-    parent = repo_local_root.parent
+    parent = checkout.parent
     parent.mkdir(parents=True, exist_ok=True)
-    if repo_local_root.exists():
-        shutil.rmtree(repo_local_root, ignore_errors=True)
-
-    with tempfile.TemporaryDirectory(dir=parent, prefix="cutlass-unpack-") as temp_dir:
+    with tempfile.TemporaryDirectory(dir=parent, prefix=f".{_CUTLASS_VERSION}.unpack-") as temp_dir:
         temp_root = Path(temp_dir)
         _extract_cutlass_archive(archive_path, temp_root)
         extracted_root = temp_root / f"cutlass-{_CUTLASS_VERSION}"
-        if not extracted_root.exists():
-            raise RuntimeError(f"Machete: failed to extract CUTLASS archive `{archive_path}`.")
-        extracted_root.replace(repo_local_root)
-        _mark_repo_local_cutlass_version(repo_local_root)
+        _validate_cutlass_checkout(extracted_root)
+        _mark_cutlass_cache(extracted_root)
 
-    return _use_repo_local_cutlass(repo_local_root)
+        stale = checkout.with_name(f".{checkout.name}.stale-{os.getpid()}")
+        if stale.exists():
+            shutil.rmtree(stale, ignore_errors=True)
+        if checkout.exists():
+            os.replace(checkout, stale)
+        try:
+            os.replace(extracted_root, checkout)
+        except Exception:
+            if stale.exists() and not checkout.exists():
+                os.replace(stale, checkout)
+            raise
+        if stale.exists():
+            shutil.rmtree(stale, ignore_errors=True)
+    _validate_cutlass_checkout(checkout, require_marker=True)
+    return checkout.resolve()
 
 
-def _machete_generated_dir() -> Path:
-    return _machete_source_root() / "generated"
+def _ensure_cutlass_source() -> Path:
+    """Resolve CUTLASS from a strict override, compatible repo checkout, or cache."""
+
+    configured_root = os.getenv("GPTQMODEL_CUTLASS_DIR")
+    if configured_root:
+        configured_path = Path(configured_root).expanduser().resolve()
+        try:
+            _validate_cutlass_checkout(configured_path)
+        except RuntimeError as exc:
+            raise RuntimeError(
+                "Machete: GPTQMODEL_CUTLASS_DIR is authoritative and must point to a read-only, "
+                f"compatible CUTLASS v{_CUTLASS_VERSION} checkout: {exc}"
+            ) from exc
+        return configured_path
+
+    repo_local_root = _repo_local_cutlass_root().resolve()
+    if repo_local_root.is_dir():
+        try:
+            _validate_cutlass_checkout(repo_local_root)
+            return repo_local_root
+        except RuntimeError:
+            log.info("Machete: ignoring incompatible repo-local CUTLASS checkout `%s`.", repo_local_root)
+
+    with _acquire_machete_cache_lock(f"cutlass-{_CUTLASS_VERSION}"):
+        cached_checkout = _cutlass_cache_dir()
+        if cached_checkout.is_dir():
+            try:
+                _validate_cutlass_checkout(cached_checkout, require_marker=True)
+                return cached_checkout.resolve()
+            except RuntimeError:
+                log.warning("Machete: ignoring incomplete CUTLASS cache `%s`.", cached_checkout)
+        archive_path = _cutlass_archive_path()
+        archive_digest = _sha256(archive_path) if archive_path.is_file() else None
+        archive_valid = archive_digest == _CUTLASS_ARCHIVE_SHA256
+        if not archive_valid:
+            if _offline_mode():
+                archive_status = (
+                    f"has SHA256 {archive_digest}, expected {_CUTLASS_ARCHIVE_SHA256}"
+                    if archive_digest is not None
+                    else "is missing"
+                )
+                raise RuntimeError(
+                    "Machete: GPTQMODEL_OFFLINE=1 and no verified CUTLASS v%s source cache is available; "
+                    "archive `%s` %s. Set GPTQMODEL_CUTLASS_DIR to a compatible checkout, or run "
+                    "`python -c \"from gptqmodel import extension; extension.load('machete')\"` once "
+                    "while online to populate the cache. To skip JIT entirely, set "
+                    "GPTQMODEL_MACHETE_PRECOMPILED_LIBRARY to a compatible shared library."
+                    % (_CUTLASS_VERSION, archive_path, archive_status)
+                )
+            _download_cutlass_archive(_CUTLASS_RELEASE_URL, archive_path)
+            if not archive_path.is_file() or _sha256(archive_path) != _CUTLASS_ARCHIVE_SHA256:
+                actual = _sha256(archive_path) if archive_path.is_file() else "missing"
+                raise RuntimeError(
+                    "Machete: downloaded CUTLASS archive checksum mismatch: "
+                    f"expected {_CUTLASS_ARCHIVE_SHA256}, got {actual}."
+                )
+        return _cache_cutlass_checkout(archive_path)
 
 
-def _machete_generation_marker() -> Path:
-    return _machete_generated_dir() / ".gptqmodel_complete"
+def _machete_generated_dir(fingerprint: Optional[str] = None) -> Path:
+    root = _gptqmodel_cache_dir() / "machete" / "generated"
+    return root if fingerprint is None else root / fingerprint
+
+
+def _machete_generation_marker(generated_dir: Optional[Path] = None) -> Path:
+    return (generated_dir or _machete_generated_dir()) / _MACHETE_COMPLETE_MARKER
+
+
+def _machete_generation_manifest(generated_dir: Optional[Path] = None) -> Path:
+    return (generated_dir or _machete_generated_dir()) / _MACHETE_MANIFEST_NAME
 
 
 def _cutlass_python_binding_inputs(cutlass_root: Path) -> list[Path]:
     python_dir = cutlass_root / "python"
-    candidates = [
-        python_dir / "cutlass_library.py",
-        python_dir / "cutlass_library" / "__init__.py",
-    ]
-    return [candidate for candidate in candidates if candidate.exists()]
+    module = python_dir / "cutlass_library.py"
+    if module.is_file():
+        return [module]
+    package = python_dir / "cutlass_library"
+    if (package / "__init__.py").is_file():
+        # A configured checkout is allowed to differ from the pinned cache, so
+        # fingerprint the complete importable generator package rather than
+        # only __init__.py. The pinned checkout remains content-addressed by the
+        # archive SHA, while this also prevents stale reuse for local edits.
+        return sorted(package.rglob("*.py"))
+    return []
 
 
 def _machete_generation_signature(cutlass_root: Path) -> str:
-    return json.dumps(
-        {
-            "cutlass_root": str(cutlass_root.resolve()),
-            "cutlass_version": _CUTLASS_VERSION,
-        },
-        sort_keys=True,
-    )
+    payload = {
+        "cache_version": _MACHETE_GENERATION_CACHE_VERSION,
+        "cutlass_version": _CUTLASS_VERSION,
+        "cutlass_archive_sha256": _CUTLASS_ARCHIVE_SHA256,
+        "jinja2_version": importlib.metadata.version("jinja2"),
+        "inputs": [],
+    }
+    for index, path in enumerate(_machete_generator_inputs(cutlass_root)):
+        resolved = path.resolve()
+        if not resolved.is_file():
+            payload["inputs"].append({"index": index, "name": path.name, "missing": True})
+            continue
+        payload["inputs"].append(
+            {"index": index, "name": path.name, "sha256": _sha256(resolved), "size": resolved.stat().st_size}
+        )
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
 
 
 def _machete_generator_inputs(cutlass_root: Path) -> list[Path]:
@@ -271,29 +441,50 @@ def _machete_generator_inputs(cutlass_root: Path) -> list[Path]:
     ]
 
 
-def _generated_machete_sources() -> list[Path]:
-    return sorted(_machete_generated_dir().glob("*.cu"))
+def _generated_machete_sources(generated_dir: Optional[Path] = None) -> list[Path]:
+    return sorted((generated_dir or _machete_generated_dir()).glob("*.cu"))
 
 
-def _generated_machete_sources_current(cutlass_root: Path) -> bool:
-    marker = _machete_generation_marker()
-    generated_sources = _generated_machete_sources()
-    if not marker.exists() or not generated_sources:
+def _generated_machete_sources_current(cutlass_root: Path, generated_dir: Optional[Path] = None) -> bool:
+    generated_dir = generated_dir or _machete_generated_dir()
+    marker = _machete_generation_marker(generated_dir)
+    manifest_path = _machete_generation_manifest(generated_dir)
+    generated_sources = _generated_machete_sources(generated_dir)
+    if (
+        not marker.exists()
+        or not manifest_path.exists()
+        or not generated_sources
+        or any(not path.is_file() or path.is_symlink() for path in generated_sources)
+    ):
         return False
-    if marker.read_text(encoding="utf-8").strip() != _machete_generation_signature(cutlass_root):
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if manifest.get("version") != _MACHETE_GENERATION_CACHE_VERSION:
+            return False
+        if marker.read_text(encoding="utf-8").strip() != manifest.get("signature"):
+            return False
+        if manifest.get("signature") != _machete_generation_signature(cutlass_root):
+            return False
+        files = manifest.get("files")
+        if not isinstance(files, dict) or set(files) != {path.name for path in generated_sources}:
+            return False
+        for path in generated_sources:
+            if _sha256(path) != files.get(path.name):
+                return False
+    except (OSError, ValueError, TypeError):
         return False
-    marker_mtime_ns = marker.stat().st_mtime_ns
-    return not any(path.stat().st_mtime_ns > marker_mtime_ns for path in _machete_generator_inputs(cutlass_root))
+    return True
 
 
-def _run_machete_generator(cutlass_root: Path) -> None:
+def _run_machete_generator(cutlass_root: Path, output_dir: Optional[Path] = None) -> None:
     generator = _machete_source_root() / "generate.py"
+    output_dir = output_dir or _machete_generated_dir()
     env = os.environ.copy()
     env["GPTQMODEL_CUTLASS_DIR"] = str(cutlass_root)
 
-    log.info("Machete: generating CUTLASS-backed kernel sources in `%s`.", _machete_generated_dir())
+    log.info("Machete: generating CUTLASS-backed kernel sources in `%s`.", output_dir)
     result = subprocess.run(
-        [sys.executable, str(generator)],
+        [sys.executable, str(generator), "--output-dir", str(output_dir)],
         cwd=str(_machete_project_root()),
         env=env,
         check=False,
@@ -311,26 +502,52 @@ def _run_machete_generator(cutlass_root: Path) -> None:
 
 def _ensure_generated_machete_sources() -> list[Path]:
     cutlass_root = _ensure_cutlass_source()
-    if _generated_machete_sources_current(cutlass_root):
-        return _generated_machete_sources()
+    fingerprint = _machete_generation_signature(cutlass_root)
+    generated_dir = _machete_generated_dir(fingerprint)
+    with _acquire_machete_cache_lock("machete-generated"):
+        if _generated_machete_sources_current(cutlass_root, generated_dir):
+            return _generated_machete_sources(generated_dir)
 
-    generated_dir = _machete_generated_dir()
-    if generated_dir.exists():
-        shutil.rmtree(generated_dir, ignore_errors=True)
+        generated_root = generated_dir.parent
+        generated_root.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=generated_root, prefix=f".{fingerprint}.tmp-") as temp_dir:
+            temp_output = Path(temp_dir)
+            _run_machete_generator(cutlass_root, temp_output)
+            generated_sources = _generated_machete_sources(temp_output)
+            if not generated_sources or any(path.is_symlink() or not path.is_file() for path in generated_sources):
+                raise RuntimeError("Machete: generator completed without producing any CUDA sources.")
+            unexpected = [path for path in temp_output.iterdir() if path.suffix != ".cu"]
+            if unexpected:
+                raise RuntimeError(
+                    "Machete: generator produced unexpected files: "
+                    + ", ".join(path.name for path in unexpected)
+                )
+            manifest = {
+                "version": _MACHETE_GENERATION_CACHE_VERSION,
+                "signature": fingerprint,
+                "files": {path.name: _sha256(path) for path in generated_sources},
+            }
+            _machete_generation_manifest(temp_output).write_text(
+                json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+            )
+            _machete_generation_marker(temp_output).write_text(fingerprint + "\n", encoding="utf-8")
 
-    _run_machete_generator(cutlass_root)
-
-    generated_sources = _generated_machete_sources()
-    if not generated_sources:
-        raise RuntimeError(
-            "Machete: generator completed without producing any CUDA sources."
-        )
-
-    _machete_generation_marker().write_text(
-        _machete_generation_signature(cutlass_root),
-        encoding="utf-8",
-    )
-    return generated_sources
+            stale = generated_dir.with_name(f".{generated_dir.name}.stale-{os.getpid()}")
+            if stale.exists():
+                shutil.rmtree(stale, ignore_errors=True)
+            if generated_dir.exists():
+                os.replace(generated_dir, stale)
+            try:
+                os.replace(temp_output, generated_dir)
+            except Exception:
+                if stale.exists() and not generated_dir.exists():
+                    os.replace(stale, generated_dir)
+                raise
+            if stale.exists():
+                shutil.rmtree(stale, ignore_errors=True)
+    if not _generated_machete_sources_current(cutlass_root, generated_dir):
+        raise RuntimeError(f"Machete: generated source cache `{generated_dir}` failed integrity validation.")
+    return _generated_machete_sources(generated_dir)
 
 
 def _machete_sources() -> list[str]:
@@ -343,6 +560,7 @@ def _machete_include_paths() -> list[str]:
     project_root = _machete_project_root()
     cutlass_root = _ensure_cutlass_source()
     include_paths = [
+        str(_machete_source_root().resolve()),
         str((project_root / "gptqmodel_ext").resolve()),
         str((project_root / "gptqmodel_ext" / "cutlass_extensions").resolve()),
         str((cutlass_root / "include").resolve()),
@@ -416,6 +634,7 @@ _MACHETE_TORCH_OPS_EXTENSION = TorchOpsJitExtension(
     extra_include_paths=_machete_include_paths,
     extra_ldflags=_machete_extra_ldflags,
     force_rebuild_env="GPTQMODEL_MACHETE_FORCE_REBUILD",
+    prebuilt_library_env="GPTQMODEL_MACHETE_PRECOMPILED_LIBRARY",
     verbose_env="GPTQMODEL_EXT_VERBOSE",
     requires_cuda=True,
     python_abi_dependent=False,

--- a/gptqmodel/utils/machete.py
+++ b/gptqmodel/utils/machete.py
@@ -446,16 +446,27 @@ def _generated_machete_sources(generated_dir: Optional[Path] = None) -> list[Pat
     return sorted((generated_dir or _machete_generated_dir()).glob("*.cu"))
 
 
-def _generated_machete_sources_current(cutlass_root: Path, generated_dir: Optional[Path] = None) -> bool:
+def _generated_machete_sources_current(
+    cutlass_root: Path, generated_dir: Optional[Path] = None
+) -> bool:
     generated_dir = generated_dir or _machete_generated_dir()
     marker = _machete_generation_marker(generated_dir)
     manifest_path = _machete_generation_manifest(generated_dir)
-    generated_sources = _generated_machete_sources(generated_dir)
+    try:
+        entries = list(generated_dir.iterdir())
+    except OSError:
+        return False
+    generated_sources = sorted(path for path in entries if path.suffix == ".cu")
+    expected_names = {
+        *(path.name for path in generated_sources),
+        _MACHETE_COMPLETE_MARKER,
+        _MACHETE_MANIFEST_NAME,
+    }
     if (
-        not marker.exists()
-        or not manifest_path.exists()
+        generated_dir.is_symlink()
         or not generated_sources
-        or any(not path.is_file() or path.is_symlink() for path in generated_sources)
+        or {path.name for path in entries} != expected_names
+        or any(not path.is_file() or path.is_symlink() for path in entries)
     ):
         return False
     try:
@@ -467,7 +478,9 @@ def _generated_machete_sources_current(cutlass_root: Path, generated_dir: Option
         if manifest.get("signature") != _machete_generation_signature(cutlass_root):
             return False
         files = manifest.get("files")
-        if not isinstance(files, dict) or set(files) != {path.name for path in generated_sources}:
+        if not isinstance(files, dict) or set(files) != {
+            path.name for path in generated_sources
+        }:
             return False
         for path in generated_sources:
             if _sha256(path) != files.get(path.name):

--- a/gptqmodel/utils/machete.py
+++ b/gptqmodel/utils/machete.py
@@ -227,6 +227,7 @@ def _download_cutlass_archive(url: str, destination: Path) -> None:
         try:
             partial.unlink()
         except FileNotFoundError:
+            # Expected if the temp file was never created or already moved/removed.
             pass
 
 

--- a/gptqmodel_ext/machete/generate.py
+++ b/gptqmodel_ext/machete/generate.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import argparse
 import itertools
 import math
 import os
-import shutil
 from collections.abc import Iterable
 from copy import deepcopy
 from dataclasses import dataclass, fields
@@ -50,7 +50,7 @@ else:
         f"`{_CUTLASS_PYTHON_DIR}`. Set GPTQMODEL_CUTLASS_DIR to a valid CUTLASS checkout."
     )
 
-from vllm_cutlass_library_extension import (
+from vllm_cutlass_library_extension import (  # noqa: E402
     DataType,
     EpilogueScheduleTag,
     EpilogueScheduleType,
@@ -71,7 +71,7 @@ from vllm_cutlass_library_extension import (
 #
 
 DISPATCH_TEMPLATE = """
-#include "../machete_mm_launcher.cuh"
+#include "machete_mm_launcher.cuh"
 
 namespace machete {
 
@@ -197,7 +197,7 @@ std::vector<std::string> supported_schedules_dispatch(
 """
 
 IMPL_TEMPLATE = """
-#include "../machete_mm_launcher.cuh"
+#include "machete_mm_launcher.cuh"
 
 namespace machete {
     
@@ -247,7 +247,7 @@ impl_{{type_sig}}_sch_{{sch_sig}}(MMArgs args) {
 """
 
 PREPACK_TEMPLATE = """
-#include "../machete_prepack_launcher.cuh"
+#include "machete_prepack_launcher.cuh"
 
 namespace machete {
 
@@ -534,11 +534,23 @@ def create_sources(impl_configs: list[ImplConfig], num_impl_files=8):
     return sources
 
 
-def generate():
+def _default_output_dir() -> Path:
+    configured = os.environ.get("GPTQMODEL_CACHE_DIR")
+    if configured:
+        cache_root = Path(configured).expanduser()
+    else:
+        xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+        cache_root = (
+            Path(xdg_cache_home).expanduser() / "gptqmodel"
+            if xdg_cache_home
+            else Path.home() / ".cache" / "gptqmodel"
+        )
+    return cache_root / "machete" / "generated" / "manual"
+
+
+def generate(output_dir: str | os.PathLike[str] | None = None):
     # See csrc/quantization/machete/Readme.md, the Codegeneration for more info
     # about how this works
-    SCRIPT_DIR = os.path.dirname(__file__)
-
     sch_common_params = dict(
         kernel_schedule=TmaMI,
         epilogue_schedule=TmaCoop,
@@ -712,22 +724,28 @@ def generate():
     #                  itertools.repeat(qqq_heuristic))
     # ]
 
-    output_dir = os.path.join(SCRIPT_DIR, "generated")
-
-    # Delete the "generated" directory if it exists
-    if os.path.exists(output_dir):
-        shutil.rmtree(output_dir)
-
-    # Create the "generated" directory
-    os.makedirs(output_dir)
+    if output_dir is None:
+        output_path = _default_output_dir()
+    else:
+        output_path = Path(output_dir).expanduser()
+    if output_path.exists():
+        if not output_path.is_dir():
+            raise RuntimeError(f"Machete output path is not a directory: `{output_path}`.")
+        if any(output_path.iterdir()):
+            raise RuntimeError(f"Machete output directory must be empty: `{output_path}`.")
+    else:
+        output_path.mkdir(parents=True)
 
     # Render each group of configurations into separate files
     for filename, code in create_sources(impl_configs):
-        filepath = os.path.join(output_dir, f"{filename}.cu")
-        with open(filepath, "w") as output_file:
+        filepath = output_path / f"{filename}.cu"
+        with filepath.open("w", encoding="utf-8") as output_file:
             output_file.write(code)
         print(f"Rendered template to {filepath}")
 
 
 if __name__ == "__main__":
-    generate()
+    parser = argparse.ArgumentParser(description="Generate Machete CUDA source files.")
+    parser.add_argument("--output-dir", type=Path, default=None)
+    args = parser.parse_args()
+    generate(args.output_dir)

--- a/tests/test_machete_jit.py
+++ b/tests/test_machete_jit.py
@@ -612,16 +612,34 @@ def test_machete_sources_generate_once_when_missing(monkeypatch, tmp_path):
     assert sources_first[1].startswith(str(tmp_path / "cache"))
     assert str(machete_root / "generated") not in sources_first[1]
     generated_dir = Path(sources_first[1]).parent
-    manifest = json.loads((generated_dir / machete_utils._MACHETE_MANIFEST_NAME).read_text(encoding="utf-8"))
-    assert manifest["files"]["machete_dispatch.cu"] == hashlib.sha256(
-        (generated_dir / "machete_dispatch.cu").read_bytes()
-    ).hexdigest()
+    manifest = json.loads(
+        (generated_dir / machete_utils._MACHETE_MANIFEST_NAME).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert (
+        manifest["files"]["machete_dispatch.cu"]
+        == hashlib.sha256(
+            (generated_dir / "machete_dispatch.cu").read_bytes()
+        ).hexdigest()
+    )
 
-    (generated_dir / "machete_dispatch.cu").write_text("// tampered\n", encoding="utf-8")
+    (generated_dir / "machete_dispatch.cu").write_text(
+        "// tampered\n", encoding="utf-8"
+    )
     sources_repaired = machete_utils._machete_sources()
     assert sources_repaired == sources_first
     assert len(run_calls) == 2
-    assert (generated_dir / "machete_dispatch.cu").read_text(encoding="utf-8") == "// generated\n"
+    assert (generated_dir / "machete_dispatch.cu").read_text(
+        encoding="utf-8"
+    ) == "// generated\n"
+
+    shadow_header = generated_dir / "machete_mm_launcher.cuh"
+    shadow_header.write_text("// shadow trusted launcher\n", encoding="utf-8")
+    sources_repaired = machete_utils._machete_sources()
+    assert sources_repaired == sources_first
+    assert len(run_calls) == 3
+    assert not shadow_header.exists()
 
 
 def test_machete_sources_regenerate_when_cutlass_root_changes(monkeypatch, tmp_path):

--- a/tests/test_machete_jit.py
+++ b/tests/test_machete_jit.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import hashlib
+import io
+import json
 import os
 import re
 import shutil
@@ -378,23 +381,24 @@ def test_ensure_cutlass_source_bootstraps_repo_local_checkout(monkeypatch, tmp_p
     archive_path = tmp_path / f"cutlass-v{machete_utils._CUTLASS_VERSION}.tar.gz"
     _write_fake_cutlass_archive(archive_path)
 
-    monkeypatch.setattr(machete_utils, "_machete_project_root", lambda: tmp_path)
+    monkeypatch.setattr(machete_utils, "_machete_project_root", lambda: tmp_path / "project")
+    monkeypatch.setenv("GPTQMODEL_CACHE_DIR", str(tmp_path / "cache"))
     monkeypatch.delenv("GPTQMODEL_CUTLASS_DIR", raising=False)
+    monkeypatch.setattr(machete_utils, "_CUTLASS_ARCHIVE_SHA256", hashlib.sha256(archive_path.read_bytes()).hexdigest())
     monkeypatch.setattr(
         machete_utils,
         "_download_cutlass_archive",
-        lambda _url, destination: shutil.copyfile(archive_path, destination),
+        lambda _url, destination: (destination.parent.mkdir(parents=True, exist_ok=True), shutil.copyfile(archive_path, destination)),
     )
 
     cutlass_root = machete_utils._ensure_cutlass_source()
-    monkeypatch.setenv("GPTQMODEL_CUTLASS_DIR", os.environ["GPTQMODEL_CUTLASS_DIR"])
-
-    assert cutlass_root == (tmp_path / "cutlass").resolve()
+    assert cutlass_root == machete_utils._cutlass_cache_dir().resolve()
     assert (cutlass_root / "include" / "cutlass" / "cutlass.h").is_file()
     assert (cutlass_root / "python" / "cutlass_library.py").is_file()
-    assert (cutlass_root / machete_utils._CUTLASS_VERSION_MARKER).read_text(encoding="utf-8").strip() == machete_utils._CUTLASS_VERSION
-    assert str(cutlass_root) == str((tmp_path / "cutlass").resolve())
-    assert str(cutlass_root) == os.environ["GPTQMODEL_CUTLASS_DIR"]
+    marker = json.loads((cutlass_root / machete_utils._CUTLASS_VERSION_MARKER).read_text(encoding="utf-8"))
+    assert marker["version"] == machete_utils._CUTLASS_VERSION
+    assert marker["archive_sha256"] == machete_utils._CUTLASS_ARCHIVE_SHA256
+    assert "gptqmodel_ext/machete/generated" not in str(cutlass_root)
 
 
 def test_cutlass_checkout_complete_accepts_tools_util_layout(tmp_path):
@@ -425,6 +429,81 @@ def test_ensure_cutlass_source_rejects_mismatched_configured_checkout(monkeypatc
         machete_utils._ensure_cutlass_source()
 
 
+def test_cutlass_configured_checkout_is_strictly_read_only(monkeypatch, tmp_path):
+    configured = tmp_path / "cutlass"
+    _write_fake_cutlass_checkout(configured, version=machete_utils._CUTLASS_VERSION)
+    before = sorted(path.relative_to(configured) for path in configured.rglob("*"))
+    monkeypatch.setenv("GPTQMODEL_CUTLASS_DIR", str(configured))
+
+    assert machete_utils._ensure_cutlass_source() == configured.resolve()
+    assert sorted(path.relative_to(configured) for path in configured.rglob("*")) == before
+    assert not (configured / machete_utils._CUTLASS_VERSION_MARKER).exists()
+
+
+def test_cutlass_archive_checksum_is_verified_before_atomic_publish(monkeypatch, tmp_path):
+    destination = tmp_path / "cache" / "cutlass.tar.gz"
+    monkeypatch.setattr(machete_utils, "_CUTLASS_ARCHIVE_SHA256", "0" * 64)
+    monkeypatch.setattr(machete_utils.urllib.request, "urlopen", lambda _url: io.BytesIO(b"bad"))
+
+    with pytest.raises(RuntimeError, match="checksum mismatch"):
+        machete_utils._download_cutlass_archive("https://example.invalid/cutlass", destination)
+
+    assert not destination.exists()
+    assert not list(destination.parent.glob(".*.tmp"))
+
+
+@pytest.mark.parametrize("member_name", ["../escaped", "/absolute"])
+def test_cutlass_archive_rejects_unsafe_paths(member_name, tmp_path):
+    archive_path = tmp_path / "unsafe.tar.gz"
+    payload = b"unsafe"
+    with tarfile.open(archive_path, "w:gz") as archive:
+        member = tarfile.TarInfo(member_name)
+        member.size = len(payload)
+        archive.addfile(member, io.BytesIO(payload))
+
+    destination = tmp_path / "extract"
+    destination.mkdir()
+    with pytest.raises(RuntimeError, match="unsafe CUTLASS archive member"):
+        machete_utils._extract_cutlass_archive(archive_path, destination)
+
+    assert not (tmp_path / "escaped").exists()
+
+
+def test_cutlass_offline_cache_miss_has_remediation(monkeypatch, tmp_path):
+    monkeypatch.setattr(machete_utils, "_machete_project_root", lambda: tmp_path / "project")
+    monkeypatch.setenv("GPTQMODEL_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("GPTQMODEL_OFFLINE", "1")
+    monkeypatch.delenv("GPTQMODEL_CUTLASS_DIR", raising=False)
+    monkeypatch.setattr(
+        machete_utils,
+        "_download_cutlass_archive",
+        lambda *_args, **_kwargs: pytest.fail("offline mode attempted a download"),
+    )
+
+    with pytest.raises(RuntimeError, match=r"GPTQMODEL_OFFLINE=1.*GPTQMODEL_CUTLASS_DIR"):
+        machete_utils._ensure_cutlass_source()
+
+
+def test_cutlass_offline_uses_complete_extracted_cache_without_archive(monkeypatch, tmp_path):
+    monkeypatch.setattr(machete_utils, "_machete_project_root", lambda: tmp_path / "project")
+    monkeypatch.setenv("GPTQMODEL_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("GPTQMODEL_OFFLINE", "1")
+    monkeypatch.delenv("GPTQMODEL_CUTLASS_DIR", raising=False)
+    checkout = machete_utils._cutlass_cache_dir()
+    _write_fake_cutlass_checkout(checkout, version=machete_utils._CUTLASS_VERSION)
+    (checkout / machete_utils._CUTLASS_VERSION_MARKER).write_text(
+        json.dumps(
+            {
+                "version": machete_utils._CUTLASS_VERSION,
+                "archive_sha256": machete_utils._CUTLASS_ARCHIVE_SHA256,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert machete_utils._ensure_cutlass_source() == checkout.resolve()
+
+
 def test_ensure_cutlass_source_marks_matching_repo_local_checkout_without_redownload(monkeypatch, tmp_path):
     repo_root = tmp_path
     repo_cutlass = repo_root / "cutlass"
@@ -442,7 +521,7 @@ def test_ensure_cutlass_source_marks_matching_repo_local_checkout_without_redown
     cutlass_root = machete_utils._ensure_cutlass_source()
 
     assert cutlass_root == repo_cutlass.resolve()
-    assert (repo_cutlass / machete_utils._CUTLASS_VERSION_MARKER).read_text(encoding="utf-8").strip() == machete_utils._CUTLASS_VERSION
+    assert not (repo_cutlass / machete_utils._CUTLASS_VERSION_MARKER).exists()
     assert download_calls == []
 
 
@@ -453,18 +532,22 @@ def test_ensure_cutlass_source_refreshes_repo_local_checkout_when_version_mismat
     _write_fake_cutlass_checkout(repo_cutlass, version="3.5.0")
 
     monkeypatch.setattr(machete_utils, "_machete_project_root", lambda: tmp_path)
+    monkeypatch.setenv("GPTQMODEL_CACHE_DIR", str(tmp_path / "cache"))
     monkeypatch.delenv("GPTQMODEL_CUTLASS_DIR", raising=False)
+    monkeypatch.setattr(machete_utils, "_CUTLASS_ARCHIVE_SHA256", hashlib.sha256(archive_path.read_bytes()).hexdigest())
     monkeypatch.setattr(
         machete_utils,
         "_download_cutlass_archive",
-        lambda _url, destination: shutil.copyfile(archive_path, destination),
+        lambda _url, destination: (destination.parent.mkdir(parents=True, exist_ok=True), shutil.copyfile(archive_path, destination)),
     )
 
     cutlass_root = machete_utils._ensure_cutlass_source()
 
-    assert cutlass_root == repo_cutlass.resolve()
+    assert cutlass_root == machete_utils._cutlass_cache_dir().resolve()
     assert machete_utils._cutlass_checkout_version(cutlass_root) == machete_utils._CUTLASS_VERSION
-    assert (cutlass_root / machete_utils._CUTLASS_VERSION_MARKER).read_text(encoding="utf-8").strip() == machete_utils._CUTLASS_VERSION
+    marker = json.loads((cutlass_root / machete_utils._CUTLASS_VERSION_MARKER).read_text(encoding="utf-8"))
+    assert marker["version"] == machete_utils._CUTLASS_VERSION
+    assert marker["archive_sha256"] == machete_utils._CUTLASS_ARCHIVE_SHA256
 
 
 def test_scaled_mm_epilogues_c3x_matches_cutlass_442_broadcast_signatures():
@@ -510,22 +593,35 @@ def test_machete_sources_generate_once_when_missing(monkeypatch, tmp_path):
     def fake_run(args, cwd, env, check, capture_output, text):
         del cwd, env, check, capture_output, text
         run_calls.append(list(args))
-        generated_dir = machete_root / "generated"
+        generated_dir = Path(args[args.index("--output-dir") + 1])
         generated_dir.mkdir(parents=True, exist_ok=True)
         (generated_dir / "machete_dispatch.cu").write_text("// generated\n", encoding="utf-8")
         return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(machete_utils, "_machete_project_root", lambda: tmp_path)
+    monkeypatch.setenv("GPTQMODEL_CACHE_DIR", str(tmp_path / "cache"))
     monkeypatch.setattr(machete_utils, "_ensure_cutlass_source", lambda: fake_cutlass)
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     sources_first = machete_utils._machete_sources()
     sources_second = machete_utils._machete_sources()
 
-    assert run_calls == [[sys.executable, str(machete_root / "generate.py")]]
+    assert len(run_calls) == 1
     assert sources_first == sources_second
     assert sources_first[0] == str(machete_root / "machete_pytorch.cu")
-    assert sources_first[1] == str(machete_root / "generated" / "machete_dispatch.cu")
+    assert sources_first[1].startswith(str(tmp_path / "cache"))
+    assert str(machete_root / "generated") not in sources_first[1]
+    generated_dir = Path(sources_first[1]).parent
+    manifest = json.loads((generated_dir / machete_utils._MACHETE_MANIFEST_NAME).read_text(encoding="utf-8"))
+    assert manifest["files"]["machete_dispatch.cu"] == hashlib.sha256(
+        (generated_dir / "machete_dispatch.cu").read_bytes()
+    ).hexdigest()
+
+    (generated_dir / "machete_dispatch.cu").write_text("// tampered\n", encoding="utf-8")
+    sources_repaired = machete_utils._machete_sources()
+    assert sources_repaired == sources_first
+    assert len(run_calls) == 2
+    assert (generated_dir / "machete_dispatch.cu").read_text(encoding="utf-8") == "// generated\n"
 
 
 def test_machete_sources_regenerate_when_cutlass_root_changes(monkeypatch, tmp_path):
@@ -549,7 +645,7 @@ def test_machete_sources_regenerate_when_cutlass_root_changes(monkeypatch, tmp_p
     def fake_run(args, cwd, env, check, capture_output, text):
         del cwd, check, capture_output, text
         run_calls.append(list(args))
-        generated_dir = machete_root / "generated"
+        generated_dir = Path(args[args.index("--output-dir") + 1])
         generated_dir.mkdir(parents=True, exist_ok=True)
         (generated_dir / "machete_dispatch.cu").write_text(
             f"// generated for {env['GPTQMODEL_CUTLASS_DIR']}\n",
@@ -558,6 +654,7 @@ def test_machete_sources_regenerate_when_cutlass_root_changes(monkeypatch, tmp_p
         return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(machete_utils, "_machete_project_root", lambda: tmp_path)
+    monkeypatch.setenv("GPTQMODEL_CACHE_DIR", str(tmp_path / "cache"))
     monkeypatch.setattr(machete_utils, "_ensure_cutlass_source", lambda: current_cutlass_root)
     monkeypatch.setattr(subprocess, "run", fake_run)
 
@@ -566,10 +663,7 @@ def test_machete_sources_regenerate_when_cutlass_root_changes(monkeypatch, tmp_p
     current_cutlass_root = cutlass_b
     machete_utils._machete_sources()
 
-    assert run_calls == [
-        [sys.executable, str(machete_root / "generate.py")],
-        [sys.executable, str(machete_root / "generate.py")],
-    ]
+    assert len(run_calls) == 1
 
 
 def test_machete_ldflags_link_cuda_driver():

--- a/tests/test_machete_jit_include_paths.py
+++ b/tests/test_machete_jit_include_paths.py
@@ -27,7 +27,8 @@ def test_machete_include_paths_use_wheel_headers_when_local_cuda_is_incomplete(m
 
     include_paths = machete_module._machete_include_paths()
 
-    assert include_paths[:4] == [
+    assert include_paths[:5] == [
+        str(project_root / "gptqmodel_ext" / "machete"),
         str(project_root / "gptqmodel_ext"),
         str(project_root / "gptqmodel_ext" / "cutlass_extensions"),
         str(cutlass_root / "include"),
@@ -58,6 +59,7 @@ def test_machete_include_paths_skip_wheel_headers_when_local_cuda_has_required_h
     include_paths = machete_module._machete_include_paths()
 
     assert include_paths == [
+        str(project_root / "gptqmodel_ext" / "machete"),
         str(project_root / "gptqmodel_ext"),
         str(project_root / "gptqmodel_ext" / "cutlass_extensions"),
         str(cutlass_root / "include"),

--- a/tests/test_torch_ops_jit_extension.py
+++ b/tests/test_torch_ops_jit_extension.py
@@ -510,6 +510,64 @@ def test_torch_ops_jit_extension_prefers_cached_binary(monkeypatch, tmp_path):
     assert compile_calls == []
 
 
+def test_torch_ops_jit_extension_explicit_prebuilt_is_authoritative_and_reused(monkeypatch, tmp_path):
+    library = tmp_path / "machete.so"
+    library.write_bytes(b"prebuilt")
+    source_calls: list[str] = []
+    load_calls: list[str] = []
+    loader = _make_loader(
+        tmp_path,
+        sources=lambda: source_calls.append("sources") or ["never.cpp"],
+        default_build_root=lambda: source_calls.append("build_root") or tmp_path / "jit_build",
+        prebuilt_library_env="UNIT_TEST_PREBUILT",
+    )
+    monkeypatch.setenv("UNIT_TEST_PREBUILT", str(library))
+    monkeypatch.setattr(cpp_module.torch.ops, "load_library", lambda path: load_calls.append(path))
+    monkeypatch.setattr(loader, "_refresh_runtime_cache", lambda: True)
+
+    assert loader.load() is True
+    assert loader.load() is True
+    assert load_calls == [str(library)]
+    assert source_calls == []
+
+
+def test_torch_ops_jit_extension_prebuilt_clear_cache_does_not_touch_jit_root(monkeypatch, tmp_path):
+    library = tmp_path / "machete.so"
+    library.write_bytes(b"prebuilt")
+    source_calls: list[str] = []
+    load_calls: list[str] = []
+    loader = _make_loader(
+        tmp_path,
+        sources=lambda: source_calls.append("sources") or ["never.cpp"],
+        default_build_root=lambda: source_calls.append("build_root") or tmp_path / "jit_build",
+        prebuilt_library_env="UNIT_TEST_PREBUILT",
+    )
+    monkeypatch.setenv("UNIT_TEST_PREBUILT", str(library))
+    monkeypatch.setattr(cpp_module.torch.ops, "load_library", lambda path: load_calls.append(path))
+    monkeypatch.setattr(loader, "_refresh_runtime_cache", lambda: True)
+
+    assert loader.load() is True
+    loader.clear_cache()
+    assert loader.load() is True
+    assert load_calls == [str(library), str(library)]
+    assert source_calls == []
+
+
+def test_torch_ops_jit_extension_missing_prebuilt_does_not_fall_back_to_jit(monkeypatch, tmp_path):
+    source_calls: list[str] = []
+    loader = _make_loader(
+        tmp_path,
+        sources=lambda: source_calls.append("sources") or ["never.cpp"],
+        default_build_root=lambda: source_calls.append("build_root") or tmp_path / "jit_build",
+        prebuilt_library_env="UNIT_TEST_PREBUILT",
+    )
+    monkeypatch.setenv("UNIT_TEST_PREBUILT", str(tmp_path / "missing.so"))
+
+    assert loader.load() is False
+    assert "configured prebuilt library" in loader.last_error_message()
+    assert source_calls == []
+
+
 def test_torch_ops_jit_extension_force_rebuild_clears_cache(monkeypatch, tmp_path):
     """Guard force-rebuild mode so stale cached libraries never short-circuit a requested rebuild."""
 

--- a/tests/test_torch_ops_jit_extension.py
+++ b/tests/test_torch_ops_jit_extension.py
@@ -522,7 +522,9 @@ def test_torch_ops_jit_extension_explicit_prebuilt_is_authoritative_and_reused(m
         prebuilt_library_env="UNIT_TEST_PREBUILT",
     )
     monkeypatch.setenv("UNIT_TEST_PREBUILT", str(library))
-    monkeypatch.setattr(cpp_module.torch.ops, "load_library", lambda path: load_calls.append(path))
+    monkeypatch.setattr(
+        cpp_module.torch.ops, "load_library", lambda path: load_calls.append(path)
+    )
     monkeypatch.setattr(loader, "_refresh_runtime_cache", lambda: True)
 
     assert loader.load() is True
@@ -531,7 +533,60 @@ def test_torch_ops_jit_extension_explicit_prebuilt_is_authoritative_and_reused(m
     assert source_calls == []
 
 
-def test_torch_ops_jit_extension_prebuilt_clear_cache_does_not_touch_jit_root(monkeypatch, tmp_path):
+def test_torch_ops_jit_extension_rejects_prebuilt_when_ops_are_already_registered(
+    monkeypatch, tmp_path
+):
+    library = tmp_path / "machete.so"
+    library.write_bytes(b"prebuilt")
+    loader = _make_loader(tmp_path, prebuilt_library_env="UNIT_TEST_PREBUILT")
+    monkeypatch.setenv("UNIT_TEST_PREBUILT", str(library))
+    monkeypatch.setattr(loader, "_ops_available", lambda: True)
+    monkeypatch.setattr(
+        cpp_module.torch.ops,
+        "load_library",
+        lambda _path: pytest.fail("an unverified prebuilt library was loaded"),
+    )
+
+    assert loader.load() is False
+    assert "already registered" in loader.last_error_message()
+    assert "start a new process" in loader.last_error_message()
+
+
+def test_torch_ops_jit_extension_rejects_in_process_prebuilt_path_switch(
+    monkeypatch, tmp_path
+):
+    first_library = tmp_path / "first.so"
+    second_library = tmp_path / "second.so"
+    first_library.write_bytes(b"first")
+    second_library.write_bytes(b"second")
+    loader = _make_loader(tmp_path, prebuilt_library_env="UNIT_TEST_PREBUILT")
+    state = {"ops_available": False}
+    load_calls: list[str] = []
+
+    def fake_load_library(path: str):
+        load_calls.append(path)
+        state["ops_available"] = True
+
+    monkeypatch.setenv("UNIT_TEST_PREBUILT", str(first_library))
+    monkeypatch.setattr(loader, "_ops_available", lambda: state["ops_available"])
+    monkeypatch.setattr(
+        loader, "_refresh_runtime_cache", lambda: state["ops_available"]
+    )
+    monkeypatch.setattr(cpp_module.torch.ops, "load_library", fake_load_library)
+
+    assert loader.load() is True
+    monkeypatch.setenv("UNIT_TEST_PREBUILT", str(second_library))
+    loader.clear_cache()
+
+    assert loader.load() is False
+    assert load_calls == [str(first_library)]
+    assert str(first_library) in loader.last_error_message()
+    assert str(second_library) in loader.last_error_message()
+
+
+def test_torch_ops_jit_extension_prebuilt_clear_cache_does_not_touch_jit_root(
+    monkeypatch, tmp_path
+):
     library = tmp_path / "machete.so"
     library.write_bytes(b"prebuilt")
     source_calls: list[str] = []
@@ -539,7 +594,8 @@ def test_torch_ops_jit_extension_prebuilt_clear_cache_does_not_touch_jit_root(mo
     loader = _make_loader(
         tmp_path,
         sources=lambda: source_calls.append("sources") or ["never.cpp"],
-        default_build_root=lambda: source_calls.append("build_root") or tmp_path / "jit_build",
+        default_build_root=lambda: source_calls.append("build_root")
+        or tmp_path / "jit_build",
         prebuilt_library_env="UNIT_TEST_PREBUILT",
     )
     monkeypatch.setenv("UNIT_TEST_PREBUILT", str(library))


### PR DESCRIPTION
## Summary

- Move pinned CUTLASS checkouts and generated Machete sources into a versioned user cache.
- Verify the pinned CUTLASS archive with SHA256 before atomic publication; add safe extraction, file locking, completion manifests, and atomic cache publication.
- Support offline cache use, read-only configured CUTLASS checkouts, and an explicit precompiled-library path that never silently falls back to JIT.
- Keep generated artifacts out of the source distribution and document cache/prewarming controls.

## Validation

- Machete JIT tests: 34 passed, 3 CUDA skipped.
- Prebuilt-library tests: 3 passed.
- Real CUTLASS end-to-end generation: 10 sources.
- ruff, py_compile, and git diff --check: passed.
- Transparent note: the full tests/test_torch_ops_jit_extension.py suite still has one pre-existing Python ABI marker failure in logic not touched by this change; the new prebuilt-path tests pass.
