### PR TITLE
fix: make kernel selection device-aware

### DIFF
--- a/gptqmodel/extension.py
+++ b/gptqmodel/extension.py
@@ -79,7 +79,7 @@ _EXTENSION_SPECS = (
         name="machete",
         aliases=("gptq_machete", "awq_machete"),
         resolve=lambda: _resolve_extension_attr("gptqmodel.utils.machete", "_MACHETE_TORCH_OPS_EXTENSION"),
-        supported=lambda: _resolve_attr("gptqmodel.utils.machete", "_validate_machete_device_support")(),
+        supported=lambda: _resolve_attr("gptqmodel.utils.machete", "_validate_machete_build_support")(),
         unsupported_error=lambda: _resolve_attr("gptqmodel.utils.machete", "machete_runtime_error")(),
     ),
     _ExtensionSpec(
@@ -96,7 +96,7 @@ _EXTENSION_SPECS = (
         name="swordfish",
         aliases=("gptq_swordfish", "awq_swordfish"),
         resolve=lambda: _resolve_extension_attr("gptqmodel.utils.swordfish", "_SWORDFISH_TORCH_OPS_EXTENSION"),
-        supported=lambda: _resolve_attr("gptqmodel.utils.swordfish", "_validate_swordfish_device_support")(),
+        supported=lambda: _resolve_attr("gptqmodel.utils.swordfish", "_validate_swordfish_build_support")(),
         unsupported_error=lambda: _resolve_attr("gptqmodel.utils.swordfish", "swordfish_runtime_error")(),
     ),
     _ExtensionSpec(

--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -58,15 +58,14 @@ from ..utils.hf import (
 )
 from ..utils.importer import (
     auto_select_device,
+    expand_selector_device_family,
     get_kernel_for_backend,
     normalize_device_device_map,
     select_quant_linear,
+    selector_device_family,
 )
 from ..utils.inspect import safe_kwargs_call
 from ..utils.logger import setup_logger
-from ..utils.machete import _validate_machete_device_support
-from ..utils.marlin import _marlin_capability_supported, _validate_marlin_device_support
-from ..utils.swordfish import _validate_swordfish_device_support
 from ..utils.model import (
     apply_no_placement_to_device_map,
     auto_dtype,
@@ -114,11 +113,12 @@ def _validate_external_backend_format(backend: BACKEND, format_code: FORMAT) -> 
 
 
 def _external_runtime_device_kwargs(
-    device: DEVICE,
+    device,
     requested_device_map: Optional[Union[str, Dict[str, Union[str, int]]]],
 ) -> Dict[str, Union[str, int]]:
-    runtime_kwargs: Dict[str, Union[str, int]] = {"device": device.type}
-    if not requested_device_map or device not in {DEVICE.CUDA, DEVICE.ROCM, DEVICE.XPU, DEVICE.NPU}:
+    device_family = selector_device_family(device) or DEVICE.CPU
+    runtime_kwargs: Dict[str, Union[str, int]] = {"device": device_family.type}
+    if not requested_device_map or device_family not in {DEVICE.CUDA, DEVICE.ROCM, DEVICE.XPU, DEVICE.NPU}:
         return runtime_kwargs
 
     targets = (
@@ -314,6 +314,9 @@ def _setup_rotation_online_had(model, rotation: Optional[str]) -> None:
 
 def _is_accelerated_attention_device(device: object) -> bool:
     """Return True when the selected device can run CUDA/ROCm flash attention."""
+
+    if isinstance(device, (tuple, list)):
+        return bool(device) and _is_accelerated_attention_device(device[0])
 
     if isinstance(device, torch.device):
         return device.type in {"cuda", "hip"}
@@ -707,7 +710,11 @@ def ModelLoader(cls):
         if cls.require_dtype:
             dtype = cls.require_dtype
         elif dtype is None or dtype == "auto" or not isinstance(dtype, torch.dtype):
-            dtype = auto_dtype(config=config, device=resolved_device, quant_inference=False)
+            dtype = auto_dtype(
+                config=config,
+                device=selector_device_family(resolved_device),
+                quant_inference=False,
+            )
 
         if isinstance(dtype, torch.dtype) and get_hf_config_dtype(config) != dtype:
             # Align config metadata with the dtype we will materialize weights in.
@@ -1017,6 +1024,11 @@ def ModelLoader(cls):
         # Keep string inputs compatible while allowing canonical method-prefixed names.
         backend = normalize_backend(backend)
         device = auto_select_device(device, backend)
+        if requested_device_map is None:
+            # The default layer-wise map below spans every visible accelerator.
+            # Expand the family now so kernel validation sees the same concrete
+            # devices (and rejects heterogeneous GPU capabilities explicitly).
+            device = expand_selector_device_family(device)
 
         model_local_path = get_model_local_path(model_id_or_path, **kwargs_without_internal)
         trust_remote_code = resolve_trust_remote_code(model_local_path, trust_remote_code=trust_remote_code)
@@ -1074,7 +1086,11 @@ def ModelLoader(cls):
 
         if dtype is None or dtype == "auto" or not isinstance(dtype, torch.dtype) :
             # TODO FIX ME for `dynamic`, non-quantized modules should be in native type
-            dtype = auto_dtype(config=config, device=device, quant_inference=True)
+            dtype = auto_dtype(
+                config=config,
+                device=selector_device_family(device),
+                quant_inference=True,
+            )
 
         if isinstance(dtype, torch.dtype) and get_hf_config_dtype(config) != dtype:
             # Ensure flash attention kernels see an explicit dtype instead of relying on defaults.
@@ -1121,14 +1137,14 @@ def ModelLoader(cls):
             if backend not in (BACKEND.AUTO, BACKEND.EXL3_EXLLAMA_V3, BACKEND.EXL3_TORCH):
                 raise TypeError("FORMAT.EXL3 requires BACKEND.AUTO, BACKEND.EXL3_EXLLAMA_V3, or BACKEND.EXL3_TORCH.")
             if backend == BACKEND.AUTO:
-                if torch.cuda.is_available() and device in (DEVICE.CUDA, DEVICE.ROCM):
+                if torch.cuda.is_available() and selector_device_family(device) in (DEVICE.CUDA, DEVICE.ROCM):
                     backend = BACKEND.EXL3_EXLLAMA_V3
                 else:
                     backend = BACKEND.EXL3_TORCH
             if backend == BACKEND.EXL3_EXLLAMA_V3:
                 if not torch.cuda.is_available():
                     raise ValueError("EXL3 CUDA loading requires CUDA/HIP.")
-                if device not in (DEVICE.CUDA, DEVICE.ROCM):
+                if selector_device_family(device) not in (DEVICE.CUDA, DEVICE.ROCM):
                     raise ValueError("EXL3 CUDA loading requires a CUDA/HIP device.")
         elif format_code == FORMAT.BITSANDBYTES:
             if backend not in (BACKEND.AUTO, BACKEND.BITSANDBYTES):
@@ -1292,7 +1308,7 @@ def ModelLoader(cls):
                 supports_flash_attn = None
 
             args = {}
-            if supports_flash_attn and device in [DEVICE.CUDA, DEVICE.ROCM]:
+            if supports_flash_attn and selector_device_family(device) in [DEVICE.CUDA, DEVICE.ROCM]:
                 if attn_implementation is not None:
                     args[ATTN_IMPLEMENTATION] = attn_implementation
                 elif is_flash_attn_2_available():
@@ -1466,17 +1482,18 @@ def ModelLoader(cls):
             device_map: Dict[str, str] = {}
             mod2name = {m: n for n, m in model.named_modules()}
 
-            if device == DEVICE.CUDA:
+            device_family = selector_device_family(device) or DEVICE.CPU
+            if device_family == DEVICE.CUDA:
                 if torch.cuda.is_available():
                     device_strs = [f"cuda:{i}" for i in range(num_gpus)]
                 else:
                     raise RuntimeError("CUDA is not available")
-            elif device == DEVICE.XPU:
+            elif device_family == DEVICE.XPU:
                 if hasattr(torch, "xpu") and torch.xpu.is_available():
                     device_strs = [f"xpu:{i}" for i in range(num_gpus)]
                 else:
                     raise RuntimeError("XPU is not available")
-            elif device == DEVICE.NPU:
+            elif device_family == DEVICE.NPU:
                 if HAS_NPU:
                     device_strs = [f"npu:{i}" for i in range(num_gpus)]
                 else:
@@ -1627,11 +1644,11 @@ def ModelLoader(cls):
         if explicit_device_map is None:
             layers, _ = get_layers_with_prefixes(model, extract_layers_node)
             num_gpus = 1
-            if device is DEVICE.CUDA:
+            if selector_device_family(device) is DEVICE.CUDA:
                 num_gpus = torch.cuda.device_count()
-            elif device is DEVICE.XPU:
+            elif selector_device_family(device) is DEVICE.XPU:
                 num_gpus = torch.xpu.device_count()
-            elif device is DEVICE.NPU:
+            elif selector_device_family(device) is DEVICE.NPU:
                 num_gpus = torch.npu.device_count()
             device_map = build_layerwise_device_map(model, device, layers, ignore_modules, num_gpus)
         else:
@@ -1689,10 +1706,6 @@ def ModelLoader(cls):
                 raise ValueError(
                     "Format: The loading of sharded checkpoints with Machete is currently not supported."
                 )
-            if not _validate_machete_device_support():
-                raise ValueError(
-                    f"Kernel: Machete kernel requires compute capability >= 9.0. Detected capability: {torch.cuda.get_device_capability()}"
-                )
 
         if backend in [BACKEND.GPTQ_MARLIN, BACKEND.AWQ_MARLIN] and (
                 preload_qlinear_kernel == ExllamaV2Linear or format_code == FORMAT.MARLIN):
@@ -1700,25 +1713,6 @@ def ModelLoader(cls):
                 raise ValueError(
                     "Format: The loading of sharded checkpoints with Marlin is currently not supported."
                 )
-            device_capability = torch.cuda.get_device_capability()
-            if backend == BACKEND.GPTQ_MARLIN:
-                if not _validate_marlin_device_support():
-                    raise ValueError(
-                        "Kernel: Marlin kernel requires compute capability >= 7.5 for the "
-                        f"GPTQ Marlin backend. Detected capability: `{device_capability}`."
-                    )
-                if device_capability == (7, 5) and dtype == torch.bfloat16:
-                    raise ValueError(
-                        "Kernel: GPTQ Marlin on Turing (compute capability 7.5) supports "
-                        "dtype=torch.float16 only."
-                    )
-            elif backend == BACKEND.AWQ_MARLIN:
-                if not _marlin_capability_supported(*device_capability) or device_capability[0] < 8:
-                    raise ValueError(
-                        "Kernel: AWQ Marlin requires compute capability >= 8.0. "
-                        f"Detected capability: `{device_capability}`."
-                    )
-
             # GPTQ Marlin and AWQ Marlin support fp16 and bf16 compute on Ampere+.
             if backend == BACKEND.GPTQ_MARLIN and dtype not in (torch.float16, torch.bfloat16):
                 raise ValueError("Marlin kernel requires dtype=torch.float16 or dtype=torch.bfloat16.")
@@ -1730,9 +1724,6 @@ def ModelLoader(cls):
                 raise ValueError(
                     "Format: The loading of sharded checkpoints with Swordfish is currently not supported."
                 )
-            if not _validate_swordfish_device_support():
-                from ..utils.swordfish import swordfish_runtime_error
-                raise ValueError(f"Kernel: {swordfish_runtime_error()}")
             if dtype not in (torch.float16, torch.bfloat16):
                 raise ValueError("Swordfish kernel requires dtype=torch.float16 or dtype=torch.bfloat16.")
 

--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -112,6 +112,36 @@ def _validate_external_backend_format(backend: BACKEND, format_code: FORMAT) -> 
     raise ValueError(f"{backend} backend only supports {supported}: actual = {format_code}")
 
 
+def _layerwise_device_count(device) -> int:
+    """Return the visible device count for layer-wise checkpoint placement."""
+    family = selector_device_family(device) or DEVICE.CPU
+    if family in (DEVICE.CUDA, DEVICE.ROCM):
+        return torch.cuda.device_count()
+    if family == DEVICE.XPU:
+        return torch.xpu.device_count()
+    if family == DEVICE.NPU:
+        return torch.npu.device_count()
+    return 1
+
+
+def _layerwise_device_strings(device, num_gpus: int) -> list[str]:
+    """Render layer-wise placement targets using the selected accelerator."""
+    family = selector_device_family(device) or DEVICE.CPU
+    if family in (DEVICE.CUDA, DEVICE.ROCM):
+        if torch.cuda.is_available():
+            return [f"cuda:{index}" for index in range(num_gpus)]
+        raise RuntimeError("CUDA is not available")
+    if family == DEVICE.XPU:
+        if hasattr(torch, "xpu") and torch.xpu.is_available():
+            return [f"xpu:{index}" for index in range(num_gpus)]
+        raise RuntimeError("XPU is not available")
+    if family == DEVICE.NPU:
+        if HAS_NPU:
+            return [f"npu:{index}" for index in range(num_gpus)]
+        raise RuntimeError("NPU is not available")
+    return ["cpu"] * num_gpus
+
+
 def _external_runtime_device_kwargs(
     device,
     requested_device_map: Optional[Union[str, Dict[str, Union[str, int]]]],
@@ -1474,32 +1504,16 @@ def ModelLoader(cls):
             """
 
             if num_gpus is None:
-                num_gpus = torch.cuda.device_count()
+                num_gpus = _layerwise_device_count(device)
             if num_gpus < 1:
-                raise RuntimeError("No CUDA devices detected")
+                family = selector_device_family(device) or DEVICE.CPU
+                raise RuntimeError(f"No devices detected for accelerator family `{family.value}`")
 
             device_ids = list(range(num_gpus))
             device_map: Dict[str, str] = {}
             mod2name = {m: n for n, m in model.named_modules()}
 
-            device_family = selector_device_family(device) or DEVICE.CPU
-            if device_family == DEVICE.CUDA:
-                if torch.cuda.is_available():
-                    device_strs = [f"cuda:{i}" for i in range(num_gpus)]
-                else:
-                    raise RuntimeError("CUDA is not available")
-            elif device_family == DEVICE.XPU:
-                if hasattr(torch, "xpu") and torch.xpu.is_available():
-                    device_strs = [f"xpu:{i}" for i in range(num_gpus)]
-                else:
-                    raise RuntimeError("XPU is not available")
-            elif device_family == DEVICE.NPU:
-                if HAS_NPU:
-                    device_strs = [f"npu:{i}" for i in range(num_gpus)]
-                else:
-                    raise RuntimeError("NPU is not available")
-            else:
-                device_strs = ["cpu"] * num_gpus
+            device_strs = _layerwise_device_strings(device, num_gpus)
 
             def assign(mod, device_id):
                 if mod is None:
@@ -1643,13 +1657,7 @@ def ModelLoader(cls):
         log.info(f"Loader: device = {device}")
         if explicit_device_map is None:
             layers, _ = get_layers_with_prefixes(model, extract_layers_node)
-            num_gpus = 1
-            if selector_device_family(device) is DEVICE.CUDA:
-                num_gpus = torch.cuda.device_count()
-            elif selector_device_family(device) is DEVICE.XPU:
-                num_gpus = torch.xpu.device_count()
-            elif selector_device_family(device) is DEVICE.NPU:
-                num_gpus = torch.npu.device_count()
+            num_gpus = _layerwise_device_count(device)
             device_map = build_layerwise_device_map(model, device, layers, ignore_modules, num_gpus)
         else:
             device_map = dict(explicit_device_map)

--- a/gptqmodel/nn_modules/qlinear/__init__.py
+++ b/gptqmodel/nn_modules/qlinear/__init__.py
@@ -325,7 +325,7 @@ class BaseQuantLinear(nn.Module):
             pack_dtype:t.dtype=None,
             dtype: Optional[t.dtype]=None,
             dynamic:Optional[dict]=None,
-            device:Optional[DEVICE]=None,
+            device:Optional[DEVICE | t.device]=None,
             trainable:Optional[bool]=None,
             adapter:Optional[Adapter]=None,
     ) -> Tuple[
@@ -380,7 +380,7 @@ class BaseQuantLinear(nn.Module):
         *,
         pack_dtype:t.dtype=None,
         dtype: Optional[t.dtype]=None,
-        device:Optional[DEVICE]=None,
+        device:Optional[DEVICE | t.device]=None,
         trainable:Optional[bool]=None,
         adapter:Optional[Adapter]=None,
     ) -> Tuple[bool, Optional[Exception]]:
@@ -464,7 +464,7 @@ class BaseQuantLinear(nn.Module):
 
     @classmethod
     def _validate(cls, bits: int=4, group_size: int=128, desc_act: bool=False, sym: bool=False, pack_dtype:t.dtype=None, dtype: Optional[t.dtype]=None, dynamic:Optional[dict]=None, in_features:int=None,
-                  out_features:int=None, device:Optional[DEVICE]=None, trainable:Optional[bool]=None, adapter:Optional[Adapter]=None) -> Tuple[bool, Optional[Exception]]:
+                  out_features:int=None, device:Optional[DEVICE | t.device]=None, trainable:Optional[bool]=None, adapter:Optional[Adapter]=None) -> Tuple[bool, Optional[Exception]]:
         ok, err = cls._validate_shared(
             pack_dtype=pack_dtype,
             dtype=dtype,
@@ -489,10 +489,19 @@ class BaseQuantLinear(nn.Module):
         )
 
     @classmethod
-    def validate_device(cls, device: DEVICE):
-        assert isinstance(device, DEVICE)
+    def validate_device(cls, device: DEVICE | t.device):
+        # DEVICE declarations describe support families.  Keep concrete
+        # torch.device values intact for specialized kernels, while mapping
+        # them to a family for this common declaration check.
+        if isinstance(device, t.device):
+            try:
+                family = DEVICE(device.type)
+            except ValueError:
+                family = device.type
+        else:
+            family = device
 
-        if device not in cls.SUPPORTS_DEVICES:
+        if family not in cls.SUPPORTS_DEVICES:
             raise NotImplementedError(f"{cls} only supports `{cls.SUPPORTS_DEVICES}`: actual device = `{device}`")
 
     # use optimize so we don't override native module.compile()
@@ -640,7 +649,7 @@ class GroupedQuantLinear(BaseQuantLinear):
 
     @classmethod
     def _validate(cls, bits: int=4, group_size: int=128, desc_act: bool=False, sym: bool=False, pack_dtype:t.dtype=None, dtype: Optional[t.dtype]=None, dynamic:Optional[dict]=None, in_features:int=None,
-                  out_features:int=None, device:Optional[DEVICE]=None, trainable:Optional[bool]=None, adapter:Optional[Adapter]=None) -> Tuple[bool, Optional[Exception]]:
+                  out_features:int=None, device:Optional[DEVICE | t.device]=None, trainable:Optional[bool]=None, adapter:Optional[Adapter]=None) -> Tuple[bool, Optional[Exception]]:
         ok, err = super()._validate(
             bits=bits,
             group_size=group_size,
@@ -839,7 +848,7 @@ class GPTQQuantLinear(PackedGroupedQuantLinear):
 
     @classmethod
     def _validate(cls, bits: int=4, group_size: int=128, desc_act: bool=False, sym: bool=False, pack_dtype:t.dtype=None, dtype: Optional[t.dtype]=None, dynamic:Optional[dict]=None, in_features:int=None,
-                  out_features:int=None, device:Optional[DEVICE]=None, trainable:Optional[bool]=None, adapter:Optional[Adapter]=None) -> Tuple[bool, Optional[Exception]]:
+                  out_features:int=None, device:Optional[DEVICE | t.device]=None, trainable:Optional[bool]=None, adapter:Optional[Adapter]=None) -> Tuple[bool, Optional[Exception]]:
         ok, err = super()._validate(
             bits=bits,
             group_size=group_size,

--- a/gptqmodel/nn_modules/qlinear/machete.py
+++ b/gptqmodel/nn_modules/qlinear/machete.py
@@ -19,9 +19,10 @@ from ...utils.logger import setup_logger
 from ...utils.machete import (
     _validate_machete_device_support,
     check_machete_supports_shape,
+    machete_extension_available,
+    machete_extension_error,
     machete_mm,
     machete_prepack_B,
-    machete_runtime_available,
     machete_runtime_error,
     pack_quantized_values_into_int32,
     query_machete_supported_group_sizes,
@@ -160,8 +161,8 @@ class MacheteLinear(GPTQQuantLinear):
 
     @classmethod
     def validate_once(cls) -> Tuple[bool, Optional[Exception]]:
-        if not machete_runtime_available():
-            return False, ImportError(machete_runtime_error())
+        if not machete_extension_available():
+            return False, ImportError(machete_extension_error())
         return True, None
 
     @classmethod
@@ -195,13 +196,21 @@ class MacheteLinear(GPTQQuantLinear):
         return True, None
 
     @classmethod
-    def validate_device(cls, device: DEVICE):
+    def validate_device(cls, device: DEVICE | torch.device):
         super().validate_device(device)
-        if device == DEVICE.CUDA:
+        if (device.type if isinstance(device, torch.device) else device) in ("cuda", DEVICE.CUDA):
             if IS_ROCM:
                 raise NotImplementedError("Machete kernel is not supported on ROCm.")
-            if not _validate_machete_device_support():
-                raise NotImplementedError(machete_runtime_error())
+            targets = (
+                (device,)
+                if isinstance(device, torch.device)
+                else tuple(torch.device(f"cuda:{index}") for index in range(torch.cuda.device_count()))
+            )
+            if not targets:
+                raise NotImplementedError("Machete kernel requires CUDA.")
+            for target in targets:
+                if not _validate_machete_device_support(target):
+                    raise NotImplementedError(machete_runtime_error(target))
 
     def post_init(self):
         device = self.qweight.device

--- a/gptqmodel/nn_modules/qlinear/machete_awq.py
+++ b/gptqmodel/nn_modules/qlinear/machete_awq.py
@@ -16,9 +16,10 @@ from ...utils.backend import BACKEND
 from ...utils.logger import setup_logger
 from ...utils.machete import (
     _validate_machete_device_support,
+    machete_extension_available,
+    machete_extension_error,
     machete_mm,
     machete_prepack_B,
-    machete_runtime_available,
     machete_runtime_error,
     pack_quantized_values_into_int32,
 )
@@ -137,18 +138,26 @@ class AwqMacheteLinear(AWQuantLinear):
 
     @classmethod
     def validate_once(cls) -> Tuple[bool, Optional[Exception]]:
-        if not machete_runtime_available():
-            return False, ImportError(machete_runtime_error())
+        if not machete_extension_available():
+            return False, ImportError(machete_extension_error())
         return True, None
 
     @classmethod
-    def validate_device(cls, device: DEVICE):
+    def validate_device(cls, device: DEVICE | torch.device):
         super().validate_device(device)
-        if device == DEVICE.CUDA:
+        if (device.type if isinstance(device, torch.device) else device) in ("cuda", DEVICE.CUDA):
             if IS_ROCM:
                 raise NotImplementedError("Machete kernel is not supported on ROCm.")
-            if not _validate_machete_device_support():
-                raise NotImplementedError("Machete kernel requires compute capability >= 9.0.")
+            targets = (
+                (device,)
+                if isinstance(device, torch.device)
+                else tuple(torch.device(f"cuda:{index}") for index in range(torch.cuda.device_count()))
+            )
+            if not targets:
+                raise NotImplementedError("Machete kernel requires CUDA.")
+            for target in targets:
+                if not _validate_machete_device_support(target):
+                    raise NotImplementedError(machete_runtime_error(target))
 
     def post_init(self):
         device = self.qweight.device

--- a/gptqmodel/nn_modules/qlinear/marlin.py
+++ b/gptqmodel/nn_modules/qlinear/marlin.py
@@ -269,6 +269,22 @@ class MarlinLinear(GPTQQuantLinear):
         out_features = args.get("out_features")
         desc_act = args.get("desc_act", False)
         group_size = args.get("group_size", -1)
+        device = args.get("device")
+        dtype = args.get("dtype")
+        if dtype == torch.bfloat16 and not IS_ROCM:
+            if isinstance(device, torch.device) and device.type == "cuda":
+                capabilities = (torch.cuda.get_device_capability(device),)
+            elif device == DEVICE.CUDA:
+                capabilities = tuple(
+                    torch.cuda.get_device_capability(index)
+                    for index in range(torch.cuda.device_count())
+                )
+            else:
+                capabilities = ()
+            if _MARLIN_SM75_CAPABILITY in capabilities:
+                return False, NotImplementedError(
+                    "GPTQ Marlin on compute capability 7.5 requires dtype=torch.float16."
+                )
         if in_features is None or out_features is None:
             return True, None
 
@@ -294,19 +310,24 @@ class MarlinLinear(GPTQQuantLinear):
         return True, None
 
     @classmethod
-    def validate_device(cls, device: DEVICE):
+    def validate_device(cls, device: DEVICE | torch.device):
         super().validate_device(device)
-        if device == DEVICE.CUDA:
+        if (device.type if isinstance(device, torch.device) else device) in ("cuda", DEVICE.CUDA):
             if IS_ROCM:
                 raise NotImplementedError("Marlin kernel is not supported on ROCm.")
-
-            has_supported_cuda = _marlin_all_visible_devices_supported(
-                _MARLIN_MIN_CAPABILITY
-            )
-            if not has_supported_cuda:
-                raise NotImplementedError(
-                    "Marlin kernel only supports compute capability >= 7.5."
+            if isinstance(device, DEVICE):
+                if not _marlin_all_visible_devices_supported(_MARLIN_MIN_CAPABILITY):
+                    raise NotImplementedError("Marlin kernel only supports compute capability >= 7.5.")
+                return
+            target = device if isinstance(device, torch.device) else device.to_torch_device()
+            try:
+                marlin_validate_runtime_device(
+                    target,
+                    min_capability=_MARLIN_MIN_CAPABILITY,
+                    backend_name="GPTQ Marlin",
                 )
+            except ValueError as exc:
+                raise NotImplementedError(str(exc)) from exc
 
     def post_init(self):
         device = self.qweight.device

--- a/gptqmodel/nn_modules/qlinear/marlin_awq.py
+++ b/gptqmodel/nn_modules/qlinear/marlin_awq.py
@@ -234,16 +234,24 @@ class AwqMarlinLinear(AWQuantLinear):
         return True, None
 
     @classmethod
-    def validate_device(cls, device: DEVICE):
+    def validate_device(cls, device: DEVICE | torch.device):
         super().validate_device(device)
-        if device == DEVICE.CUDA:
+        if (device.type if isinstance(device, torch.device) else device) in ("cuda", DEVICE.CUDA):
             if IS_ROCM:
                 raise NotImplementedError("Marlin kernel is not supported on ROCm.")
-
-            if not _marlin_all_visible_devices_supported(
-                _AWQ_MARLIN_MIN_CAPABILITY
-            ):
-                raise NotImplementedError("Marlin kernel only supports compute capability >= 8.0.")
+            if isinstance(device, DEVICE):
+                if not _marlin_all_visible_devices_supported(_AWQ_MARLIN_MIN_CAPABILITY):
+                    raise NotImplementedError("Marlin kernel only supports compute capability >= 8.0.")
+                return
+            target = device if isinstance(device, torch.device) else device.to_torch_device()
+            try:
+                marlin_validate_runtime_device(
+                    target,
+                    min_capability=_AWQ_MARLIN_MIN_CAPABILITY,
+                    backend_name="AWQ Marlin",
+                )
+            except ValueError as exc:
+                raise NotImplementedError(str(exc)) from exc
 
     def post_init(self):
         device = self.qweight.device

--- a/gptqmodel/nn_modules/qlinear/qqq.py
+++ b/gptqmodel/nn_modules/qlinear/qqq.py
@@ -254,9 +254,12 @@ class QQQLinear(GroupedQuantLinear):
     @classmethod
     def validate_device(cls, device: DEVICE | torch.device):
         super().validate_device(device)
+        # QQQ has an independent ROCm implementation. ROCm exposes CUDA
+        # device values through torch, so an exact cuda:N target must not
+        # be mistaken for the unsupported CUDA Marlin path.
+        if IS_ROCM:
+            return
         if (device.type if isinstance(device, torch.device) else device) in ("cuda", DEVICE.CUDA):
-            if IS_ROCM:
-                raise NotImplementedError("Marlin kernel is not supported on ROCm.")
             targets = (
                 (device,)
                 if isinstance(device, torch.device)

--- a/gptqmodel/nn_modules/qlinear/qqq.py
+++ b/gptqmodel/nn_modules/qlinear/qqq.py
@@ -5,7 +5,6 @@
 
 # Adapted from vllm at https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/quantization/gptq_marlin.py
 
-import os
 from typing import List, Optional, Tuple
 
 import numpy as np
@@ -253,18 +252,17 @@ class QQQLinear(GroupedQuantLinear):
         return cls._validate(**args)
 
     @classmethod
-    def validate_device(cls, device: DEVICE):
+    def validate_device(cls, device: DEVICE | torch.device):
         super().validate_device(device)
-        CUDA_VISIBLE_DEVICES = os.environ.get("CUDA_VISIBLE_DEVICES")
-        if device == DEVICE.CUDA:
+        if (device.type if isinstance(device, torch.device) else device) in ("cuda", DEVICE.CUDA):
             if IS_ROCM:
                 raise NotImplementedError("Marlin kernel is not supported on ROCm.")
-
-            if CUDA_VISIBLE_DEVICES is None:
-                has_cuda_v8 = all(torch.cuda.get_device_capability(i)[0] >= 8 for i in range(torch.cuda.device_count()))
-            else:
-                has_cuda_v8 = all(torch.cuda.get_device_capability(i)[0] >= 8 for i in range(len(CUDA_VISIBLE_DEVICES.split(","))))
-            if not has_cuda_v8:
+            targets = (
+                (device,)
+                if isinstance(device, torch.device)
+                else tuple(torch.device(f"cuda:{index}") for index in range(torch.cuda.device_count()))
+            )
+            if not targets or any(torch.cuda.get_device_capability(target)[0] < 8 for target in targets):
                 raise NotImplementedError("Marlin kernel only supports compute capability >= 8.0.")
 
     def post_init(self):

--- a/gptqmodel/nn_modules/qlinear/swordfish.py
+++ b/gptqmodel/nn_modules/qlinear/swordfish.py
@@ -26,9 +26,10 @@ from ...utils.swordfish import (
     check_swordfish_supports_shape,
     query_swordfish_supported_group_sizes,
     query_swordfish_supported_quant_types,
+    swordfish_extension_available,
+    swordfish_extension_error,
     swordfish_mm,
     swordfish_prepack_B,
-    swordfish_runtime_available,
     swordfish_runtime_error,
 )
 
@@ -162,8 +163,8 @@ class SwordfishLinear(GPTQQuantLinear):
 
     @classmethod
     def validate_once(cls) -> Tuple[bool, Optional[Exception]]:
-        if not swordfish_runtime_available():
-            return False, ImportError(swordfish_runtime_error())
+        if not swordfish_extension_available():
+            return False, ImportError(swordfish_extension_error())
         return True, None
 
     @classmethod
@@ -210,13 +211,21 @@ class SwordfishLinear(GPTQQuantLinear):
         return True, None
 
     @classmethod
-    def validate_device(cls, device: DEVICE):
+    def validate_device(cls, device: DEVICE | torch.device):
         super().validate_device(device)
-        if device == DEVICE.CUDA:
+        if (device.type if isinstance(device, torch.device) else device) in ("cuda", DEVICE.CUDA):
             if IS_ROCM:
                 raise NotImplementedError("Swordfish kernel is not supported on ROCm.")
-            if not _validate_swordfish_device_support():
-                raise NotImplementedError(swordfish_runtime_error())
+            targets = (
+                (device,)
+                if isinstance(device, torch.device)
+                else tuple(torch.device(f"cuda:{index}") for index in range(torch.cuda.device_count()))
+            )
+            if not targets:
+                raise NotImplementedError("Swordfish kernel requires CUDA.")
+            for target in targets:
+                if not _validate_swordfish_device_support(target):
+                    raise NotImplementedError(swordfish_runtime_error(target))
 
     def post_init(self):
         device = self.qweight.device
@@ -507,8 +516,8 @@ class AwqSwordfishLinear(AWQuantLinear):
 
     @classmethod
     def validate_once(cls) -> Tuple[bool, Optional[Exception]]:
-        if not swordfish_runtime_available():
-            return False, ImportError(swordfish_runtime_error())
+        if not swordfish_extension_available():
+            return False, ImportError(swordfish_extension_error())
         return True, None
 
     @classmethod
@@ -551,13 +560,21 @@ class AwqSwordfishLinear(AWQuantLinear):
         return True, None
 
     @classmethod
-    def validate_device(cls, device: DEVICE):
+    def validate_device(cls, device: DEVICE | torch.device):
         super().validate_device(device)
-        if device == DEVICE.CUDA:
+        if (device.type if isinstance(device, torch.device) else device) in ("cuda", DEVICE.CUDA):
             if IS_ROCM:
                 raise NotImplementedError("Swordfish kernel is not supported on ROCm.")
-            if not _validate_swordfish_device_support():
-                raise NotImplementedError(swordfish_runtime_error())
+            targets = (
+                (device,)
+                if isinstance(device, torch.device)
+                else tuple(torch.device(f"cuda:{index}") for index in range(torch.cuda.device_count()))
+            )
+            if not targets:
+                raise NotImplementedError("Swordfish kernel requires CUDA.")
+            for target in targets:
+                if not _validate_swordfish_device_support(target):
+                    raise NotImplementedError(swordfish_runtime_error(target))
 
     def post_init(self):
         device = self.qweight.device

--- a/gptqmodel/utils/importer.py
+++ b/gptqmodel/utils/importer.py
@@ -58,6 +58,29 @@ def _device_family(device: SelectorDevice) -> DEVICE:
         raise ValueError(f"Unsupported selector device family `{device.type}`") from exc
 
 
+def _current_accelerator_type() -> Optional[str]:
+    """Return the runtime device type used by integer device-map ordinals."""
+    accelerator_api = getattr(torch, "accelerator", None)
+    current_accelerator = getattr(accelerator_api, "current_accelerator", None)
+    if current_accelerator is None:
+        return None
+    try:
+        accelerator = current_accelerator()
+    except Exception:
+        return None
+    if accelerator is None:
+        return None
+    accelerator_type = getattr(accelerator, "type", None)
+    if accelerator_type is None:
+        try:
+            accelerator_type = torch.device(accelerator).type
+        except (RuntimeError, ValueError):
+            return None
+    # ROCm uses CUDA's torch device namespace. _device_family maps it back to
+    # DEVICE.ROCM when the HIP runtime is active.
+    return str(accelerator_type).lower()
+
+
 def _as_selector_device(value) -> SelectorDevice:
     """Convert one public device value without discarding an ordinal."""
     if isinstance(value, DEVICE):
@@ -67,12 +90,19 @@ def _as_selector_device(value) -> SelectorDevice:
     if isinstance(value, torch.device):
         return value
     if isinstance(value, int):
-        # Accelerate uses integer device-map values as CUDA ordinals.
-        return torch.device(f"cuda:{value}")
+        # Accelerate uses integer device-map values as ordinals in the active
+        # accelerator namespace (CUDA/ROCm, XPU, or NPU), not always CUDA.
+        accelerator_type = _current_accelerator_type()
+        if accelerator_type is None:
+            raise ValueError("Integer device-map values require an active accelerator")
+        return torch.device(f"{accelerator_type}:{value}")
     if isinstance(value, str):
         text = value.strip().lower()
         if text == DEVICE.ROCM.value:
-            return torch.device("cuda:0")
+            # ROCm is represented by CUDA torch.device values at runtime, but
+            # keep the support family so non-ROCm mocks and kernel selection do
+            # not silently turn it into NVIDIA CUDA.
+            return DEVICE.ROCM
         try:
             return torch.device(text)
         except (RuntimeError, ValueError) as exc:

--- a/gptqmodel/utils/importer.py
+++ b/gptqmodel/utils/importer.py
@@ -6,14 +6,15 @@
 import importlib
 import os
 import pkgutil
+import threading
 from collections import OrderedDict
-from typing import Dict, List, Optional, Type, Union
+from typing import Dict, List, Optional, Sequence, Type, Union
 
 import torch
 
 from gptqmodel.adapter.adapter import Adapter
 
-from ..models._const import DEVICE, normalize_device
+from ..models._const import DEVICE
 from ..nn_modules.qlinear import BaseQuantLinear, PackableQuantLinear
 from ..quantization import FORMAT, METHOD
 from ..quantization.config import _normalize_quant_bits, quant_bits_width
@@ -32,6 +33,246 @@ ACCELERATE_OFFLOAD_TARGETS = {"disk", "meta"}
 
 message_logged = False
 log = setup_logger()
+
+
+# A selector device is deliberately kept separate from ``DEVICE``.  DEVICE is
+# the kernel declaration's *support family* (CUDA, CPU, ...), whereas a
+# torch.device carries the concrete ordinal needed for capability checks and
+# per-device module placement.
+SelectorDevice = Union[DEVICE, torch.device]
+SelectorDevices = Union[SelectorDevice, Sequence[SelectorDevice]]
+_VALIDATION_CACHE_MAXSIZE = 1024
+_VALIDATION_CACHE = OrderedDict()
+_VALIDATION_CACHE_LOCK = threading.RLock()
+
+
+def _device_family(device: SelectorDevice) -> DEVICE:
+    if isinstance(device, DEVICE):
+        return device
+    device = torch.device(device)
+    if IS_ROCM and device.type == "cuda":
+        return DEVICE.ROCM
+    try:
+        return DEVICE(device.type)
+    except ValueError as exc:
+        raise ValueError(f"Unsupported selector device family `{device.type}`") from exc
+
+
+def _as_selector_device(value) -> SelectorDevice:
+    """Convert one public device value without discarding an ordinal."""
+    if isinstance(value, DEVICE):
+        if value == DEVICE.ALL:
+            return value
+        return value
+    if isinstance(value, torch.device):
+        return value
+    if isinstance(value, int):
+        # Accelerate uses integer device-map values as CUDA ordinals.
+        return torch.device(f"cuda:{value}")
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text == DEVICE.ROCM.value:
+            return torch.device("cuda:0")
+        try:
+            return torch.device(text)
+        except (RuntimeError, ValueError) as exc:
+            # Preserve the old DEVICE error wording for symbolic families.
+            try:
+                return DEVICE(text)
+            except ValueError:
+                raise ValueError(f"Invalid device `{value}`") from exc
+    raise ValueError(f"device must be a string, int, torch.device, or DEVICE, got {type(value)}")
+
+
+def _selector_devices(device: Optional[SelectorDevices]) -> Optional[tuple[SelectorDevice, ...]]:
+    if device is None:
+        return None
+    if isinstance(device, (str, int, torch.device, DEVICE)):
+        values = (_as_selector_device(device),)
+    else:
+        if isinstance(device, (bytes, bytearray)):
+            raise ValueError("device sequence must contain device values")
+        values = tuple(_as_selector_device(item) for item in device)
+    if not values:
+        raise ValueError("device sequence must not be empty")
+
+    # Keep first-seen ordering.  This makes multi-GPU selection deterministic
+    # while still avoiding repeated capability probes for duplicate map values.
+    result = []
+    for value in values:
+        if value not in result:
+            result.append(value)
+    return tuple(result)
+
+
+def _device_capability(device: SelectorDevice):
+    """Return one device's capability, if its runtime exposes one."""
+    if isinstance(device, DEVICE):
+        if device not in (DEVICE.CUDA, DEVICE.ROCM):
+            return None
+        target = device.to_torch_device()
+    else:
+        target = torch.device(device)
+    if target.type == "cuda":
+        try:
+            return tuple(torch.cuda.get_device_capability(target))
+        except Exception:
+            return None
+    getter = getattr(getattr(torch, target.type, None), "get_device_capability", None)
+    if getter is not None:
+        try:
+            return tuple(getter(target))
+        except Exception:
+            return None
+    return None
+
+
+def _selector_device_descriptor(device: SelectorDevice):
+    if isinstance(device, DEVICE):
+        target = device.to_torch_device() if device != DEVICE.ALL else None
+        return (
+            "family",
+            device.value,
+            None if target is None else target.type,
+            None if target is None else target.index,
+            _device_capability(device),
+        )
+    target = torch.device(device)
+    return ("torch", target.type, target.index, _device_capability(target))
+
+
+def _freeze_validation_value(value):
+    if isinstance(value, (str, int, float, bool, type(None), torch.dtype)):
+        return value
+    if isinstance(value, (torch.device, DEVICE)):
+        return _selector_device_descriptor(value)
+    if isinstance(value, dict):
+        return tuple(sorted((_freeze_validation_value(k), _freeze_validation_value(v)) for k, v in value.items()))
+    if isinstance(value, (list, tuple, set, frozenset)):
+        items = (_freeze_validation_value(item) for item in value)
+        return tuple(sorted(items, key=repr)) if isinstance(value, (set, frozenset)) else tuple(items)
+    if isinstance(value, Adapter):
+        # Adapters can carry mutable runtime state.  Never retain one in the
+        # cache value or use its mutable representation as a cache key.
+        return (type(value), id(value))
+    try:
+        hash(value)
+    except TypeError:
+        return (type(value), id(value))
+    return value
+
+
+def _validation_method_identity(cls, name: str):
+    for parent in cls.__mro__:
+        descriptor = parent.__dict__.get(name)
+        if descriptor is not None:
+            return id(descriptor)
+    return None
+
+
+def _new_validation_error(error_type, message):
+    if error_type is None:
+        return None
+    try:
+        return error_type(message)
+    except Exception:
+        return ValueError(message)
+
+
+def validate_quant_linear(cls: Type[BaseQuantLinear], **kwargs):
+    """Validate one kernel contract with a bounded, device-aware cache.
+
+    The cache stores only immutable status/error metadata.  In particular, an
+    exception object (which carries traceback and mutable state) is recreated
+    for every caller.
+    """
+    requested_device = kwargs.get("device")
+    if isinstance(requested_device, (str, int)):
+        kwargs = dict(kwargs)
+        kwargs["device"] = _as_selector_device(requested_device)
+        requested_device = kwargs["device"]
+    if requested_device is not None and not isinstance(requested_device, (str, int, torch.device, DEVICE)):
+        targets = _selector_devices(requested_device)
+        assert targets is not None
+        last_result = (True, None)
+        for target in targets:
+            target_kwargs = dict(kwargs)
+            target_kwargs["device"] = target
+            last_result = validate_quant_linear(cls, **target_kwargs)
+            if not last_result[0]:
+                return last_result
+        return last_result
+
+    key = (
+        cls,
+        _validation_method_identity(cls, "validate"),
+        _validation_method_identity(cls, "cached_validate_once"),
+        tuple(sorted((name, _freeze_validation_value(value)) for name, value in kwargs.items())),
+    )
+    with _VALIDATION_CACHE_LOCK:
+        cached = _VALIDATION_CACHE.get(key)
+        if cached is not None:
+            _VALIDATION_CACHE.move_to_end(key)
+            ok, error_type, error_message = cached
+            return ok, _new_validation_error(error_type, error_message)
+
+    try:
+        result = cls.validate(**kwargs)
+        ok, error = result
+    except Exception as exc:
+        ok, error = False, exc
+
+    error_type = type(error) if isinstance(error, BaseException) else (ValueError if error is not None else None)
+    error_message = str(error) if error is not None else None
+    cached = (bool(ok), error_type, error_message)
+    with _VALIDATION_CACHE_LOCK:
+        _VALIDATION_CACHE[key] = cached
+        _VALIDATION_CACHE.move_to_end(key)
+        while len(_VALIDATION_CACHE) > _VALIDATION_CACHE_MAXSIZE:
+            _VALIDATION_CACHE.popitem(last=False)
+    return bool(ok), _new_validation_error(error_type, error_message)
+
+
+def clear_validation_cache() -> None:
+    with _VALIDATION_CACHE_LOCK:
+        _VALIDATION_CACHE.clear()
+
+
+def selector_device_family(device: Optional[SelectorDevices]) -> Optional[DEVICE]:
+    """Return the support family for placement-only loader decisions."""
+    targets = _selector_devices(device)
+    if not targets:
+        return None
+    _validate_selector_device_families(targets)
+    return _device_family(targets[0])
+
+
+def expand_selector_device_family(device: SelectorDevices) -> SelectorDevice | tuple[SelectorDevice, ...]:
+    """Expand one abstract accelerator family to all visible physical devices."""
+    targets = _selector_devices(device)
+    assert targets is not None
+    if len(targets) != 1 or not isinstance(targets[0], DEVICE):
+        return targets[0] if len(targets) == 1 else targets
+
+    family = targets[0]
+    if family not in (DEVICE.CUDA, DEVICE.ROCM, DEVICE.XPU, DEVICE.NPU):
+        return family
+
+    runtime_type = "cuda" if family == DEVICE.ROCM else family.type
+    runtime = getattr(torch, runtime_type, None)
+    count_getter = getattr(runtime, "device_count", None)
+    if count_getter is None:
+        return family
+    try:
+        count = count_getter()
+    except Exception:
+        return family
+    if count < 1:
+        return family
+
+    devices = tuple(torch.device(f"{runtime_type}:{index}") for index in range(count))
+    _validate_selector_device_families(devices)
+    return devices[0] if len(devices) == 1 else devices
 
 
 def _supports_pack_api(cls: Type[BaseQuantLinear]) -> bool:
@@ -305,46 +546,96 @@ def _is_accelerate_offload_target(value: str) -> bool:
     return value.strip().lower() in ACCELERATE_OFFLOAD_TARGETS
 
 
-def hf_normalize_device_device_map(device: Optional[Union[str, torch.device]], device_map: Optional[Union[str, Dict]]) -> DEVICE:
+def _validate_selector_device_families(devices: Sequence[SelectorDevice]) -> None:
+    families = {_device_family(device) for device in devices if device != DEVICE.ALL}
+    if len(families) > 1:
+        raise ValueError(
+            "Quantized kernel selection does not support a device map spanning "
+            f"different accelerator families: {', '.join(sorted(f.value for f in families))}."
+        )
+
+    device_capabilities = [
+        (device, _device_capability(device))
+        for device in devices
+        if _device_family(device) in (DEVICE.CUDA, DEVICE.ROCM)
+    ]
+    capabilities = {capability for _, capability in device_capabilities if capability is not None}
+    if len(capabilities) > 1:
+        rendered = ", ".join(
+            f"{device}=" + ".".join(str(part) for part in capability)
+            for device, capability in device_capabilities
+            if capability is not None
+        )
+        raise ValueError(
+            "Quantized kernel selection does not support a device map spanning "
+            f"different GPU compute capabilities: {rendered}."
+        )
+
+
+def _accelerate_keyword_device(accelerator) -> SelectorDevice | tuple[SelectorDevice, ...]:
+    if accelerator is None:
+        return DEVICE.CPU
+
+    family = _device_family(torch.device(accelerator.type))
+    return expand_selector_device_family(family)
+
+
+def hf_normalize_device_device_map(
+    device: Optional[Union[str, torch.device]],
+    device_map: Optional[Union[str, Dict]],
+) -> SelectorDevice | tuple[SelectorDevice, ...]:
     return normalize_device_device_map(device=device, device_map=device_map, default=DEVICE.CPU)
 
 
-def normalize_device_device_map(device: Optional[Union[str, torch.device]], device_map: Optional[Union[str, Dict]], default: Optional[DEVICE] = None) -> DEVICE:
-    normalized_device = default
+def normalize_device_device_map(
+    device: Optional[Union[str, int, torch.device, DEVICE]],
+    device_map: Optional[Union[str, Dict]],
+    default: Optional[SelectorDevice] = None,
+) -> SelectorDevice | tuple[SelectorDevice, ...]:
+    normalized_device: Optional[SelectorDevice] = default
     accelerator = torch.accelerator.current_accelerator()
     if device is None:
         if device_map is not None:
             if isinstance(device_map, str):
                 if _is_accelerate_device_map_keyword(device_map):
-                    return DEVICE(accelerator.type) if accelerator is not None else DEVICE.CPU
-                devices = {device_map}
+                    return _accelerate_keyword_device(accelerator)
+                devices = (device_map,)
             else:
-                devices = set(device_map.values())
-            normalized_devices = set()
-            for device in devices:
-                # Returning None means quant linear will be automatically selected.
-                if device is None:
+                # Preserve map order and concrete ordinals.  A set here would
+                # make cuda:0/cuda:1 indistinguishable from each other.
+                devices = tuple(device_map.values())
+            normalized_devices = []
+            for map_device in devices:
+                if map_device is None:
                     continue
-                if isinstance(device, str):
-                    if _is_accelerate_device_map_keyword(device) or device == "auto":
-                        return DEVICE(accelerator.type) if accelerator is not None else DEVICE.CPU
-                    if _is_accelerate_offload_target(device):
+                if isinstance(map_device, str):
+                    if _is_accelerate_device_map_keyword(map_device) or map_device == "auto":
+                        return _accelerate_keyword_device(accelerator)
+                    if _is_accelerate_offload_target(map_device):
                         continue
-                normalized_devices.add(normalize_device(device))
-            if len(normalized_devices) == 1:
-                d = normalized_devices.pop()
-                if d in DEVICE:
-                    normalized_device = d
-            elif len(normalized_devices) > 1:
-                normalized_devices.discard(DEVICE.CPU)
-                normalized_device = normalized_devices.pop()
+                candidate = _as_selector_device(map_device)
+                if candidate not in normalized_devices:
+                    normalized_devices.append(candidate)
+
+            # CPU offload entries do not determine the accelerator kernel.  If
+            # all entries are CPU, retain CPU as the target.
+            accelerator_devices = [
+                candidate for candidate in normalized_devices
+                if _device_family(candidate) != DEVICE.CPU
+            ]
+            selected_devices = accelerator_devices or normalized_devices
+            if selected_devices:
+                _validate_selector_device_families(selected_devices)
+                normalized_device = (
+                    selected_devices[0]
+                    if len(selected_devices) == 1
+                    else tuple(selected_devices)
+                )
     else:
-        if isinstance(device, str):
-            normalized_device = normalize_device(device)
-        elif isinstance(device, torch.device):
-            normalized_device = DEVICE(device.type)
-        else:
-            raise ValueError(f"device must be a string or torch.device, got {type(device)}")
+        normalized = _selector_devices(device)
+        assert normalized is not None
+        _validate_selector_device_families(normalized)
+        normalized_device = normalized[0] if len(normalized) == 1 else normalized
 
     # map fake cuda to actual rocm
     if normalized_device == DEVICE.CUDA and IS_ROCM:
@@ -352,8 +643,11 @@ def normalize_device_device_map(device: Optional[Union[str, torch.device]], devi
     return normalized_device
 
 
-def auto_select_device(device: Optional[DEVICE], backend: Optional[BACKEND]) -> DEVICE:
-    assert device is None or isinstance(device, DEVICE)
+def auto_select_device(
+    device: Optional[SelectorDevices],
+    backend: Optional[BACKEND],
+) -> SelectorDevice | tuple[SelectorDevice, ...]:
+    assert device is None or isinstance(device, (DEVICE, torch.device, str, int, tuple, list))
     assert backend is None or isinstance(backend, BACKEND)
 
     if device is None:
@@ -497,7 +791,7 @@ def select_quant_linear(
         group_size: int,
         desc_act: bool,
         sym: bool,
-        device: Optional[Union[DEVICE, str, int, torch.device]],
+        device: Optional[SelectorDevices],
         backend: BACKEND = BACKEND.AUTO,
         format: FORMAT = FORMAT.GPTQ,
         quant_method: METHOD = METHOD.GPTQ,
@@ -516,9 +810,10 @@ def select_quant_linear(
         quant_method = METHOD(quant_method.lower())
     backend = normalize_backend(backend, quant_method=quant_method)
     if device is not None:
-        device = normalize_device(device)
-        if device == DEVICE.CUDA and IS_ROCM:
-            device = DEVICE.ROCM
+        targets = _selector_devices(device)
+        assert targets is not None
+        _validate_selector_device_families(targets)
+        device = targets[0] if len(targets) == 1 else targets
 
     bits = quant_bits_width(_normalize_quant_bits(bits, format_value=format))
 
@@ -531,6 +826,32 @@ def select_quant_linear(
     backend = BACKEND.AUTO if backend is None else backend
 
     trainable = backend == BACKEND.AUTO_TRAINABLE
+    marlin_backends = {
+        BACKEND.GPTQ_MARLIN,
+        BACKEND.AWQ_MARLIN,
+    }
+    if not allow_marlin and backend in marlin_backends:
+        raise ValueError("Marlin kernel selection was disabled by allow_marlin=False.")
+
+    selector_targets = _selector_devices(device) if device is not None else None
+    selector_families = (
+        {_device_family(target) for target in selector_targets}
+        if selector_targets is not None
+        else set()
+    )
+
+    def validate_candidate(cls, **kwargs):
+        # A kernel selected for a multi-GPU model must be valid on every target
+        # ordinal.  Validate each exact target so device-sensitive kernels query
+        # the correct capability rather than the process's current device.
+        if selector_targets is None:
+            return validate_quant_linear(cls, **kwargs, device=None)
+        last_result = (True, None)
+        for target in selector_targets:
+            last_result = validate_quant_linear(cls, **kwargs, device=target)
+            if not last_result[0]:
+                return last_result
+        return last_result
 
     validated_qlinears = []
     # Handle the case where backend is AUTO.
@@ -550,7 +871,17 @@ def select_quant_linear(
         if multi_select:
             contracts = list(_iter_dynamic_contracts(dynamic, bits, group_size, desc_act, sym, pack_dtype, format))
         for k, cls in allow_quant_linears:
-            if DEVICE.ALL not in cls.SUPPORTS_DEVICES and device is not None and device not in cls.SUPPORTS_DEVICES:
+            if not allow_marlin and marlin_backends.intersection(
+                get_kernel_backends(cls) if getattr(cls, "SUPPORTS_BACKENDS", None) else ()
+            ):
+                if os.environ.get("DEBUG"):
+                    log.info(f"skip {k} because Marlin selection is disabled")
+                continue
+            if (
+                DEVICE.ALL not in cls.SUPPORTS_DEVICES
+                and selector_families
+                and not selector_families.intersection(set(cls.SUPPORTS_DEVICES))
+            ):
                 if os.environ.get("DEBUG"):
                     log.info(f"skip {k} for unsupported device `{device}`")
                 continue
@@ -566,7 +897,7 @@ def select_quant_linear(
             contract_err = None
             if multi_select:
                 for contract in contracts:
-                    validated, contract_err = cls.validate(
+                    validated, contract_err = validate_candidate(cls,
                         bits=contract["bits"],
                         group_size=contract["group_size"],
                         desc_act=contract["desc_act"],
@@ -574,14 +905,13 @@ def select_quant_linear(
                         pack_dtype=contract["pack_dtype"],
                         dtype=dtype,
                         dynamic=None,
-                        device=device,
                         trainable=trainable,
                         adapter=adapter,
                     )
                     if validated:
                         break
             else:
-                validated, contract_err = cls.validate(
+                validated, contract_err = validate_candidate(cls,
                     bits=bits,
                     group_size=group_size,
                     desc_act=desc_act,
@@ -589,7 +919,6 @@ def select_quant_linear(
                     pack_dtype=pack_dtype,
                     dtype=dtype,
                     dynamic=dynamic,
-                    device=device,
                     trainable=trainable,
                     adapter=adapter,
                 )
@@ -631,7 +960,7 @@ def select_quant_linear(
     if is_sharded and not supports_sharded_load:
         raise ValueError(f"Selected backend `{backend}` with kernel `{qlinear.__name__}` does not support sharded checkpoints.")
 
-    validate, err = qlinear.validate(
+    validate, err = validate_candidate(qlinear,
         bits=bits,
         group_size=group_size,
         desc_act=desc_act,
@@ -639,7 +968,6 @@ def select_quant_linear(
         pack_dtype=pack_dtype,
         dtype=dtype,
         dynamic=dynamic,
-        device=device,
         trainable=trainable,
     )
 

--- a/gptqmodel/utils/importer.py
+++ b/gptqmodel/utils/importer.py
@@ -14,7 +14,7 @@ import torch
 
 from gptqmodel.adapter.adapter import Adapter
 
-from ..models._const import DEVICE
+from ..models._const import DEVICE, normalize_device
 from ..nn_modules.qlinear import BaseQuantLinear, PackableQuantLinear
 from ..quantization import FORMAT, METHOD
 from ..quantization.config import _normalize_quant_bits, quant_bits_width
@@ -251,10 +251,17 @@ def expand_selector_device_family(device: SelectorDevices) -> SelectorDevice | t
     """Expand one abstract accelerator family to all visible physical devices."""
     targets = _selector_devices(device)
     assert targets is not None
-    if len(targets) != 1 or not isinstance(targets[0], DEVICE):
+    if len(targets) != 1:
         return targets[0] if len(targets) == 1 else targets
 
-    family = targets[0]
+    target = targets[0]
+    if isinstance(target, DEVICE):
+        family = target
+    elif isinstance(target, torch.device) and target.index is None and target.type in {"cuda", "xpu", "npu"}:
+        family = _device_family(target)
+    else:
+        return target
+
     if family not in (DEVICE.CUDA, DEVICE.ROCM, DEVICE.XPU, DEVICE.NPU):
         return family
 
@@ -632,10 +639,15 @@ def normalize_device_device_map(
                     else tuple(selected_devices)
                 )
     else:
-        normalized = _selector_devices(device)
-        assert normalized is not None
-        _validate_selector_device_families(normalized)
-        normalized_device = normalized[0] if len(normalized) == 1 else normalized
+        if isinstance(device, int):
+            # Public loader arguments use the historical active-accelerator
+            # meaning for integers; only device-map values are CUDA ordinals.
+            normalized_device = normalize_device(device)
+        else:
+            normalized = _selector_devices(device)
+            assert normalized is not None
+            _validate_selector_device_families(normalized)
+            normalized_device = normalized[0] if len(normalized) == 1 else normalized
 
     # map fake cuda to actual rocm
     if normalized_device == DEVICE.CUDA and IS_ROCM:
@@ -810,10 +822,13 @@ def select_quant_linear(
         quant_method = METHOD(quant_method.lower())
     backend = normalize_backend(backend, quant_method=quant_method)
     if device is not None:
-        targets = _selector_devices(device)
-        assert targets is not None
-        _validate_selector_device_families(targets)
-        device = targets[0] if len(targets) == 1 else targets
+        if isinstance(device, int):
+            device = normalize_device(device)
+        else:
+            targets = _selector_devices(device)
+            assert targets is not None
+            _validate_selector_device_families(targets)
+            device = targets[0] if len(targets) == 1 else targets
 
     bits = quant_bits_width(_normalize_quant_bits(bits, format_value=format))
 

--- a/gptqmodel/utils/importer.py
+++ b/gptqmodel/utils/importer.py
@@ -138,7 +138,19 @@ def _selector_device_descriptor(device: SelectorDevice):
             _device_capability(device),
         )
     target = torch.device(device)
-    return ("torch", target.type, target.index, _device_capability(target))
+    try:
+        family = _device_family(target).value
+    except ValueError:
+        # Validation contracts may carry non-placement devices such as meta.
+        # Keep those cacheable without treating them as selector families.
+        family = target.type
+    return (
+        "torch",
+        family,
+        target.type,
+        target.index,
+        _device_capability(target),
+    )
 
 
 def _freeze_validation_value(value):

--- a/gptqmodel/utils/machete.py
+++ b/gptqmodel/utils/machete.py
@@ -431,20 +431,33 @@ def _extension_api():
     return extension_api
 
 
-def _machete_static_runtime_error() -> str:
+def _machete_static_runtime_error(device: Optional[torch.device] = None) -> str:
     if IS_ROCM:
         return "Machete kernel is not supported on ROCm."
     if not torch.cuda.is_available():
         return "Machete kernel requires CUDA."
-    capability = torch.cuda.get_device_capability()
+    target = torch.device(device) if device is not None else None
+    capability = (
+        torch.cuda.get_device_capability(target)
+        if target is not None
+        else torch.cuda.get_device_capability()
+    )
     if capability != _MACHETE_REQUIRED_COMPUTE_CAPABILITY:
-        props = torch.cuda.get_device_properties(torch.cuda.current_device())
+        props = (
+            torch.cuda.get_device_properties(target)
+            if target is not None
+            else torch.cuda.get_device_properties(torch.cuda.current_device())
+        )
         return (
             "Machete kernel is Hopper-only (SM90); its generated CUTLASS kernels "
             f"target arch::Sm90 and have no Blackwell image. Found `{props.name}` with "
             f"compute capability {capability[0]}.{capability[1]}."
         )
-    props = torch.cuda.get_device_properties(torch.cuda.current_device())
+    props = (
+        torch.cuda.get_device_properties(target)
+        if target is not None
+        else torch.cuda.get_device_properties(torch.cuda.current_device())
+    )
     shared_memory_per_block_optin = getattr(
         props,
         "shared_memory_per_block_optin",
@@ -463,30 +476,49 @@ def clear_machete_extension_cache() -> None:
     _MACHETE_TORCH_OPS_EXTENSION.clear_cache()
 
 
-def machete_runtime_available() -> bool:
-    static_error = _machete_static_runtime_error()
-    if static_error:
-        return False
+def machete_extension_available() -> bool:
+    """Return extension availability without consulting the current GPU."""
     return _extension_api().is_available("machete")
 
 
-def machete_runtime_error() -> str:
-    static_error = _machete_static_runtime_error()
-    if static_error:
-        return static_error
-
+def machete_extension_error() -> str:
     extension_api = _extension_api()
     if extension_api.is_available("machete"):
         return ""
     return extension_api.error("machete") or "Machete runtime unavailable."
 
 
+def machete_runtime_available(device: Optional[torch.device] = None) -> bool:
+    static_error = _machete_static_runtime_error(device)
+    if static_error:
+        return False
+    return machete_extension_available()
+
+
+def machete_runtime_error(device: Optional[torch.device] = None) -> str:
+    static_error = _machete_static_runtime_error(device)
+    if static_error:
+        return static_error
+
+    return machete_extension_error()
+
+
 def prewarm_machete_extension() -> bool:
     return _extension_api().load(name="machete")["machete"]
 
 
-def _validate_machete_device_support() -> bool:
-    return _machete_static_runtime_error() == ""
+def _validate_machete_device_support(device: Optional[torch.device] = None) -> bool:
+    return _machete_static_runtime_error(device) == ""
+
+
+def _validate_machete_build_support() -> bool:
+    """Return whether any visible GPU can use the device-independent extension."""
+    if IS_ROCM or not torch.cuda.is_available():
+        return False
+    return any(
+        _machete_static_runtime_error(torch.device(f"cuda:{index}")) == ""
+        for index in range(torch.cuda.device_count())
+    )
 
 
 def query_machete_supported_quant_types(zero_points: bool) -> List[ScalarType]:
@@ -634,6 +666,8 @@ __all__ = [
     "_validate_machete_device_support",
     "check_machete_supports_shape",
     "clear_machete_extension_cache",
+    "machete_extension_available",
+    "machete_extension_error",
     "machete_mm",
     "machete_prepack_B",
     "machete_runtime_available",

--- a/gptqmodel/utils/marlin.py
+++ b/gptqmodel/utils/marlin.py
@@ -87,11 +87,18 @@ def marlin_validate_runtime_device(
     return capability
 
 
-def _marlin_environment_error() -> str:
+def _marlin_build_environment_error() -> str:
     if IS_ROCM:
         return "Marlin kernel is not supported on ROCm."
     if not torch.cuda.is_available():
         return "Marlin kernel requires CUDA."
+    return ""
+
+
+def _marlin_environment_error() -> str:
+    build_error = _marlin_build_environment_error()
+    if build_error:
+        return build_error
     try:
         major, minor = torch.cuda.get_device_capability()
     except Exception as exc:  # pragma: no cover - depends on host CUDA runtime
@@ -101,7 +108,9 @@ def _marlin_environment_error() -> str:
     return ""
 
 
-marlin_import_exception = _marlin_environment_error() or None
+# Import/JIT availability must not freeze the capability of whichever device
+# happened to be current. Exact capability checks run in validate_device().
+marlin_import_exception = _marlin_build_environment_error() or None
 
 
 def _marlin_root() -> Path:
@@ -321,7 +330,7 @@ def _marlin_resolve_op(
 
 
 # Validate marlin support
-def _validate_marlin_device_support() -> bool:
+def _validate_marlin_device_support(device: Optional[torch.device] = None) -> bool:
     """
     Validates if the current device is compatible for Marlin.
     ref: https://github.com/IST-DASLab/marlin?tab=readme-ov-file#requirements
@@ -331,7 +340,12 @@ def _validate_marlin_device_support() -> bool:
     """
     if IS_ROCM or not torch.cuda.is_available():
         return False
-    major, minor = torch.cuda.get_device_capability()
+    target = torch.device(device) if device is not None else None
+    major, minor = (
+        torch.cuda.get_device_capability(target)
+        if target is not None
+        else torch.cuda.get_device_capability()
+    )
     return _marlin_capability_supported(major, minor)
 
 

--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -65,7 +65,7 @@ from .ctx import ctx
 from .device import get_device
 from .hf import get_hf_config_dtype
 from .hub import hf_hub_download, model_info
-from .importer import select_quant_linear
+from .importer import select_quant_linear, validate_quant_linear
 from .logger import log_time_block, setup_logger
 from .model_dequant import _correct_gptq_v1_qzeros, _revert_gptq_v1_qzeros_correction
 from .torch import HAS_CUDA, torch_empty_cache
@@ -612,14 +612,11 @@ def create_quant_module(
     if issubclass(linear_cls, GPTQQuantLinear):
         tmp_init_kwargs.setdefault("format", format)
 
-    # when loading a quantized model, device is the target passed through the GPT-QModel load path
-    # check in_features and out_features validate
-    validation_device = device
-    if isinstance(device, torch.device):
-        validation_device = DEVICE(device.type)
-    elif isinstance(device, str):
-        validation_device = DEVICE(device.split(":", 1)[0])
-    _, err = linear_cls.validate(
+    # Keep concrete device ordinals through per-module validation.  The shared
+    # selector cache validates every target in a multi-GPU selector and lets
+    # device-sensitive kernels query the capability of that exact target.
+    _, err = validate_quant_linear(
+        linear_cls,
         bits=validate_bits,
         group_size=tmp_group_size,
         desc_act=tmp_desc_act,
@@ -628,7 +625,7 @@ def create_quant_module(
         dtype=dtype,
         in_features=in_features,
         out_features=out_features,
-        device=validation_device,
+        device=device,
         adapter=adapter, # TODO FIX ME..need to pass Eora if loaded
     )
     if err is not None:

--- a/gptqmodel/utils/swordfish.py
+++ b/gptqmodel/utils/swordfish.py
@@ -226,7 +226,11 @@ _SWORDFISH_SUPPORTED_CAPABILITIES: Tuple[
 ] = _swordfish_supported_compute_capabilities()
 
 
-def _swordfish_static_runtime_error() -> str:
+def _swordfish_static_runtime_error(
+    device: Optional[torch.device] = None,
+    *,
+    check_capability: bool = True,
+) -> str:
     if IS_ROCM:
         return "Swordfish kernel is not supported on ROCm."
     torch_public = torch.__version__.partition("+")[0]
@@ -247,7 +251,14 @@ def _swordfish_static_runtime_error() -> str:
         )
     if not torch.cuda.is_available():
         return "Swordfish kernel requires CUDA."
-    major, minor = torch.cuda.get_device_capability()
+    if not check_capability:
+        return ""
+    target = torch.device(device) if device is not None else None
+    major, minor = (
+        torch.cuda.get_device_capability(target)
+        if target is not None
+        else torch.cuda.get_device_capability()
+    )
     exact_caps, ptx_forward, ptx_exact = _SWORDFISH_SUPPORTED_CAPABILITIES
     if (
         (major, minor) in exact_caps
@@ -265,26 +276,44 @@ def _swordfish_static_runtime_error() -> str:
     )
 
 
-def _validate_swordfish_device_support() -> bool:
-    return _swordfish_static_runtime_error() == ""
+def _validate_swordfish_device_support(device: Optional[torch.device] = None) -> bool:
+    return _swordfish_static_runtime_error(device) == ""
 
 
-def swordfish_runtime_available() -> bool:
-    static_error = _swordfish_static_runtime_error()
-    if static_error:
+def _validate_swordfish_build_support() -> bool:
+    if _swordfish_static_runtime_error(check_capability=False):
         return False
+    return any(
+        _swordfish_static_runtime_error(torch.device(f"cuda:{index}")) == ""
+        for index in range(torch.cuda.device_count())
+    )
+
+
+def swordfish_extension_available() -> bool:
+    """Return extension availability without consulting the current GPU."""
     return _extension_api().is_available("swordfish")
 
 
-def swordfish_runtime_error() -> str:
-    static_error = _swordfish_static_runtime_error()
-    if static_error:
-        return static_error
-
+def swordfish_extension_error() -> str:
     extension_api = _extension_api()
     if extension_api.is_available("swordfish"):
         return ""
     return extension_api.error("swordfish") or "Swordfish runtime unavailable."
+
+
+def swordfish_runtime_available(device: Optional[torch.device] = None) -> bool:
+    static_error = _swordfish_static_runtime_error(device)
+    if static_error:
+        return False
+    return swordfish_extension_available()
+
+
+def swordfish_runtime_error(device: Optional[torch.device] = None) -> str:
+    static_error = _swordfish_static_runtime_error(device)
+    if static_error:
+        return static_error
+
+    return swordfish_extension_error()
 
 
 def clear_swordfish_extension_cache() -> None:
@@ -448,6 +477,8 @@ __all__ = [
     "query_swordfish_supported_group_sizes",
     "query_swordfish_supported_quant_types",
     "swordfish_dequant_dense",
+    "swordfish_extension_available",
+    "swordfish_extension_error",
     "swordfish_mm",
     "swordfish_moe_mm",
     "swordfish_prepack_B",

--- a/tests/kernels/test_selection.py
+++ b/tests/kernels/test_selection.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 import pytest
 import torch
 
+import gptqmodel.models._const as model_const
 from gptqmodel.models._const import DEVICE
 from gptqmodel.nn_modules.qlinear import BaseQuantLinear
 from gptqmodel.nn_modules.qlinear.gguf import GGUFTorchLinear
@@ -724,6 +725,56 @@ def test_expand_selector_device_family_preserves_all_visible_ordinals(monkeypatc
         torch.device("cuda:0"),
         torch.device("cuda:1"),
     )
+
+
+def test_expand_selector_device_family_expands_unindexed_torch_device(monkeypatch):
+    monkeypatch.setattr(importer.torch.cuda, "device_count", lambda: 2)
+    monkeypatch.setattr(importer.torch.cuda, "get_device_capability", lambda device=None: (8, 0))
+
+    assert expand_selector_device_family(torch.device("cuda")) == (
+        torch.device("cuda:0"),
+        torch.device("cuda:1"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("has_cuda", "has_xpu", "has_npu", "expected"),
+    [
+        (False, True, False, DEVICE.XPU),
+        (False, False, True, DEVICE.NPU),
+    ],
+)
+def test_public_integer_device_uses_active_accelerator(monkeypatch, has_cuda, has_xpu, has_npu, expected):
+    monkeypatch.setattr(model_const, "HAS_CUDA", has_cuda)
+    monkeypatch.setattr(model_const, "HAS_XPU", has_xpu)
+    monkeypatch.setattr(model_const, "HAS_NPU", has_npu)
+    monkeypatch.setattr(model_const, "HAS_MPS", False)
+
+    assert normalize_device_device_map(0, None) is expected
+
+    class ActiveAcceleratorKernel:
+        SUPPORTS_DEVICES = [expected]
+
+        @classmethod
+        def validate(cls, **_kwargs):
+            return True, None
+
+    monkeypatch.setitem(
+        AUTO_BACKEND_KERNEL_MAPPING[METHOD.QQQ],
+        FORMAT.QQQ,
+        OrderedDict([(BACKEND.QQQ, ActiveAcceleratorKernel)]),
+    )
+    assert select_quant_linear(
+        bits=4,
+        group_size=128,
+        desc_act=False,
+        sym=True,
+        device=0,
+        backend=BACKEND.AUTO,
+        format=FORMAT.QQQ,
+        quant_method=METHOD.QQQ,
+        pack_dtype=torch.int32,
+    ) is ActiveAcceleratorKernel
 
 
 def test_validation_cache_partitions_capability_and_index(monkeypatch):

--- a/tests/kernels/test_selection.py
+++ b/tests/kernels/test_selection.py
@@ -737,6 +737,36 @@ def test_expand_selector_device_family_expands_unindexed_torch_device(monkeypatc
     )
 
 
+def test_selector_device_descriptor_has_consistent_shape():
+    assert importer._selector_device_descriptor(DEVICE.ALL) == (
+        "family",
+        "all",
+        None,
+        None,
+        None,
+    )
+    assert importer._selector_device_descriptor(torch.device("cpu")) == (
+        "torch",
+        "cpu",
+        "cpu",
+        None,
+        None,
+    )
+
+
+def test_selector_device_descriptor_uses_rocm_family_for_cuda_device(monkeypatch):
+    monkeypatch.setattr(importer, "IS_ROCM", True)
+    monkeypatch.setattr(importer, "_device_capability", lambda _device: (9, 0))
+
+    assert importer._selector_device_descriptor(torch.device("cuda:1")) == (
+        "torch",
+        "rocm",
+        "cuda",
+        1,
+        (9, 0),
+    )
+
+
 @pytest.mark.parametrize(
     ("has_cuda", "has_xpu", "has_npu", "expected"),
     [

--- a/tests/kernels/test_selection.py
+++ b/tests/kernels/test_selection.py
@@ -30,8 +30,12 @@ from gptqmodel.utils.importer import (
     _iter_dynamic_contracts,
     auto_select_device,
     build_kernel_support_maps,
+    clear_validation_cache,
+    expand_selector_device_family,
     iter_quant_linear_kernels,
+    normalize_device_device_map,
     select_quant_linear,
+    validate_quant_linear,
 )
 from gptqmodel.utils.rocm import IS_ROCM
 from gptqmodel.utils.torch import HAS_CUDA, HAS_MPS, HAS_XPU
@@ -647,3 +651,209 @@ def test_sharded_select_tolerates_kernel_without_shard_attrs(monkeypatch):
     )
 
     assert qlinear_cls is BareKernel
+
+
+def test_select_quant_linear_validates_each_exact_multi_gpu_target(monkeypatch):
+    calls = []
+
+    class IndexedKernel:
+        SUPPORTS_DEVICES = [DEVICE.CUDA]
+
+        @classmethod
+        def validate(cls, **kwargs):
+            calls.append(kwargs["device"])
+            return True, None
+
+    monkeypatch.setitem(
+        AUTO_BACKEND_KERNEL_MAPPING[METHOD.QQQ],
+        FORMAT.QQQ,
+        OrderedDict([(BACKEND.QQQ, IndexedKernel)]),
+    )
+
+    selected = select_quant_linear(
+        bits=4,
+        group_size=128,
+        desc_act=False,
+        sym=True,
+        device=[torch.device("cuda:0"), torch.device("cuda:1")],
+        backend=BACKEND.AUTO,
+        format=FORMAT.QQQ,
+        quant_method=METHOD.QQQ,
+        pack_dtype=torch.int32,
+    )
+
+    assert selected is IndexedKernel
+    assert calls == [torch.device("cuda:0"), torch.device("cuda:1")]
+
+
+def test_device_map_preserves_ordinals_and_rejects_mixed_capabilities(monkeypatch):
+    monkeypatch.setattr(
+        importer.torch.cuda,
+        "get_device_capability",
+        lambda device=None: (8, 0) if torch.device(device).index == 0 else (9, 0),
+    )
+
+    with pytest.raises(ValueError, match="different GPU compute capabilities"):
+        normalize_device_device_map(None, {"first": "cuda:0", "second": "cuda:1"})
+
+    monkeypatch.setattr(importer.torch.cuda, "get_device_capability", lambda device=None: (8, 0))
+    assert normalize_device_device_map(None, {"first": "cuda:0", "second": "cuda:1"}) == (
+        torch.device("cuda:0"),
+        torch.device("cuda:1"),
+    )
+
+
+def test_auto_device_map_rejects_mixed_visible_capabilities(monkeypatch):
+    monkeypatch.setattr(importer.torch.accelerator, "current_accelerator", lambda: torch.device("cuda"))
+    monkeypatch.setattr(importer.torch.cuda, "device_count", lambda: 2)
+    monkeypatch.setattr(
+        importer.torch.cuda,
+        "get_device_capability",
+        lambda device=None: (8, 0) if torch.device(device).index == 0 else (9, 0),
+    )
+
+    with pytest.raises(ValueError, match=r"cuda:0=8\.0, cuda:1=9\.0"):
+        normalize_device_device_map(None, "auto")
+
+
+def test_expand_selector_device_family_preserves_all_visible_ordinals(monkeypatch):
+    monkeypatch.setattr(importer.torch.cuda, "device_count", lambda: 2)
+    monkeypatch.setattr(importer.torch.cuda, "get_device_capability", lambda device=None: (8, 0))
+
+    assert expand_selector_device_family(DEVICE.CUDA) == (
+        torch.device("cuda:0"),
+        torch.device("cuda:1"),
+    )
+
+
+def test_validation_cache_partitions_capability_and_index(monkeypatch):
+    clear_validation_cache()
+    capability = {0: (8, 0), 1: (8, 0)}
+    monkeypatch.setattr(
+        importer.torch.cuda,
+        "get_device_capability",
+        lambda device=None: capability[torch.device(device).index],
+    )
+    calls = []
+
+    class DeviceKernel:
+        @classmethod
+        def validate(cls, **kwargs):
+            calls.append(kwargs["device"])
+            return True, None
+
+    contract = dict(bits=4, group_size=128, trainable=False)
+    validate_quant_linear(DeviceKernel, **contract, device=torch.device("cuda:0"))
+    validate_quant_linear(DeviceKernel, **contract, device=torch.device("cuda:0"))
+    validate_quant_linear(DeviceKernel, **contract, device=torch.device("cuda:1"))
+    capability[0] = (9, 0)
+    validate_quant_linear(DeviceKernel, **contract, device=torch.device("cuda:0"))
+
+    assert calls == [
+        torch.device("cuda:0"),
+        torch.device("cuda:1"),
+        torch.device("cuda:0"),
+    ]
+
+
+def test_validation_cache_is_contract_and_device_sensitive():
+    clear_validation_cache()
+    calls = []
+
+    class ContractKernel:
+        SUPPORTS_DEVICES = [DEVICE.CPU]
+
+        @classmethod
+        def validate(cls, **kwargs):
+            calls.append(kwargs)
+            return True, None
+
+    common = dict(
+        bits=4,
+        group_size=128,
+        desc_act=False,
+        sym=True,
+        pack_dtype=torch.int32,
+        dtype=torch.float16,
+        dynamic=None,
+        trainable=False,
+        adapter=None,
+    )
+    validate_quant_linear(ContractKernel, **common, device=torch.device("cpu"), in_features=128, out_features=256)
+    validate_quant_linear(ContractKernel, **common, device=torch.device("cpu"), in_features=128, out_features=256)
+
+    variants = [
+        {"device": torch.device("meta")},
+        {"in_features": 256},
+        {"out_features": 512},
+        {"bits": 3},
+        {"group_size": 64},
+        {"dtype": torch.bfloat16},
+        {"pack_dtype": torch.int16},
+        {"desc_act": True},
+        {"sym": False},
+        {"trainable": True},
+    ]
+    for variant in variants:
+        contract = dict(common, device=torch.device("cpu"), in_features=128, out_features=256)
+        contract.update(variant)
+        validate_quant_linear(ContractKernel, **contract)
+
+    assert len(calls) == 1 + len(variants)
+
+
+def test_allow_marlin_false_filters_auto_and_rejects_explicit(monkeypatch):
+    class MarlinKernel:
+        SUPPORTS_DEVICES = [DEVICE.CPU]
+        SUPPORTS_BACKENDS = [BACKEND.GPTQ_MARLIN]
+
+        @classmethod
+        def validate(cls, **_kwargs):
+            return True, None
+
+    class FallbackKernel:
+        SUPPORTS_DEVICES = [DEVICE.CPU]
+        SUPPORTS_BACKENDS = [BACKEND.GPTQ_TORCH]
+
+        @classmethod
+        def validate(cls, **_kwargs):
+            return True, None
+
+    monkeypatch.setitem(
+        AUTO_BACKEND_KERNEL_MAPPING[METHOD.GPTQ],
+        FORMAT.GPTQ,
+        OrderedDict(
+            [
+                (BACKEND.GPTQ_MARLIN, MarlinKernel),
+                (BACKEND.GPTQ_TORCH, FallbackKernel),
+            ]
+        ),
+    )
+
+    selected = select_quant_linear(
+        bits=4,
+        group_size=128,
+        desc_act=False,
+        sym=True,
+        device=torch.device("cpu"),
+        backend=BACKEND.AUTO,
+        format=FORMAT.GPTQ,
+        quant_method=METHOD.GPTQ,
+        pack_dtype=torch.int32,
+        allow_marlin=False,
+    )
+    assert selected is FallbackKernel
+
+    with pytest.raises(ValueError, match="allow_marlin=False"):
+        select_quant_linear(
+            bits=4,
+            group_size=128,
+            desc_act=False,
+            sym=True,
+            device=torch.device("cpu"),
+            backend=BACKEND.GPTQ_MARLIN,
+            format=FORMAT.GPTQ,
+            quant_method=METHOD.GPTQ,
+            pack_dtype=torch.int32,
+            allow_marlin=False,
+        )

--- a/tests/kernels/test_selection.py
+++ b/tests/kernels/test_selection.py
@@ -4,6 +4,7 @@
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 
 from collections import OrderedDict
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -19,6 +20,7 @@ from gptqmodel.nn_modules.qlinear.machete import MacheteLinear
 from gptqmodel.nn_modules.qlinear.machete_awq import AwqMacheteLinear
 from gptqmodel.nn_modules.qlinear.marlin import MarlinLinear
 from gptqmodel.nn_modules.qlinear.marlin_awq import AwqMarlinLinear
+from gptqmodel.nn_modules.qlinear.qqq import QQQLinear
 from gptqmodel.nn_modules.qlinear.torch import TorchLinear, TorchQuantEmbeddings
 from gptqmodel.nn_modules.qlinear.torch_aten_kernel import TorchAtenLinear
 from gptqmodel.nn_modules.qlinear.tritonv2 import TritonV2Linear
@@ -765,6 +767,47 @@ def test_selector_device_descriptor_uses_rocm_family_for_cuda_device(monkeypatch
         1,
         (9, 0),
     )
+
+
+@pytest.mark.parametrize("accelerator_type", ["cuda", "xpu"])
+def test_integer_device_map_uses_active_accelerator(monkeypatch, accelerator_type):
+    monkeypatch.setattr(
+        importer.torch.accelerator,
+        "current_accelerator",
+        lambda: torch.device(accelerator_type),
+    )
+
+    assert importer._as_selector_device(2) == torch.device(f"{accelerator_type}:2")
+    assert normalize_device_device_map(None, {"layer": 2}) == torch.device(f"{accelerator_type}:2")
+
+
+def test_integer_device_map_uses_npu_without_torch_npu(monkeypatch):
+    class FakeDevice:
+        def __init__(self, spec):
+            self.spec = spec
+
+    monkeypatch.setattr(
+        importer.torch.accelerator,
+        "current_accelerator",
+        lambda: SimpleNamespace(type="npu"),
+    )
+    monkeypatch.setattr(importer.torch, "device", FakeDevice)
+
+    assert importer._as_selector_device(2).spec == "npu:2"
+
+
+def test_rocm_string_preserves_device_family_on_non_rocm_host(monkeypatch):
+    monkeypatch.setattr(importer, "IS_ROCM", False)
+
+    assert importer._as_selector_device("rocm") is DEVICE.ROCM
+    assert normalize_device_device_map(None, {"": "rocm"}) is DEVICE.ROCM
+
+
+def test_qqq_accepts_exact_rocm_cuda_device(monkeypatch):
+    monkeypatch.setattr("gptqmodel.nn_modules.qlinear.qqq.IS_ROCM", True)
+
+    QQQLinear.validate_device(torch.device("cuda:1"))
+    assert DEVICE.ROCM in QQQLinear.SUPPORTS_DEVICES
 
 
 @pytest.mark.parametrize(

--- a/tests/test_extension_load_api.py
+++ b/tests/test_extension_load_api.py
@@ -14,10 +14,12 @@ import gptqmodel.extension as extension_api
 import gptqmodel.utils.awq as awq_utils
 import gptqmodel.utils.cpp as cpp_utils
 import gptqmodel.utils.exllamav2 as exllamav2_utils
+import gptqmodel.utils.hadamard as hadamard_utils
 import gptqmodel.utils.machete as machete_utils
 import gptqmodel.utils.marlin as marlin_utils
 import gptqmodel.utils.paroquant as paroquant_utils
 import gptqmodel.utils.qqq as qqq_utils
+import gptqmodel.utils.swordfish as swordfish_utils
 
 
 class _FakeExtension:
@@ -72,6 +74,8 @@ def _install_fake_extensions(monkeypatch):
         "marlin_fp16": _FakeExtension("Marlin fp16"),
         "marlin_bf16": _FakeExtension("Marlin bf16"),
         "paroquant": _FakeExtension("ParoQuant rotation"),
+        "hadamard": _FakeExtension("Fast Hadamard transform"),
+        "swordfish": _FakeExtension("Swordfish"),
     }
 
     monkeypatch.setattr(cpp_utils, "_pack_block_extension", lambda: fakes["pack_block_cpu"])
@@ -82,10 +86,14 @@ def _install_fake_extensions(monkeypatch):
     monkeypatch.setattr(exllamav2_utils, "_EXLLAMAV2_AWQ_TORCH_OPS_EXTENSION", fakes["exllamav2_awq"])
     monkeypatch.setattr(exllamav3_ext, "_EXLLAMAV3_TORCH_OPS_EXTENSION", fakes["exllamav3"])
     monkeypatch.setattr(machete_utils, "_MACHETE_TORCH_OPS_EXTENSION", fakes["machete"])
-    monkeypatch.setattr(machete_utils, "_validate_machete_device_support", lambda: True)
+    monkeypatch.setattr(machete_utils, "_validate_machete_build_support", lambda: True)
     monkeypatch.setattr(marlin_utils, "_MARLIN_FP16_TORCH_OPS_EXTENSION", fakes["marlin_fp16"])
     monkeypatch.setattr(marlin_utils, "_MARLIN_BF16_TORCH_OPS_EXTENSION", fakes["marlin_bf16"])
     monkeypatch.setattr(paroquant_utils, "_PAROQUANT_ROTATION_EXTENSION", fakes["paroquant"])
+    monkeypatch.setattr(hadamard_utils, "_HADAMARD_TORCH_OPS_EXTENSION", fakes["hadamard"])
+    monkeypatch.setattr(hadamard_utils, "hadamard_supported", lambda: True)
+    monkeypatch.setattr(swordfish_utils, "_SWORDFISH_TORCH_OPS_EXTENSION", fakes["swordfish"])
+    monkeypatch.setattr(swordfish_utils, "_validate_swordfish_build_support", lambda: True)
 
     return fakes
 
@@ -103,25 +111,13 @@ def test_load_defaults_to_all_extensions(monkeypatch):
 
     result = extension_api.load()
 
-    assert result == {
-        "pack_block_cpu": True,
-        "floatx_cpu": True,
-        "awq": True,
-        "qqq": True,
-        "exllamav2": True,
-        "exllamav2_awq": True,
-        "exllamav3": True,
-        "machete": True,
-        "marlin_fp16": True,
-        "marlin_bf16": True,
-        "paroquant": True,
-    }
+    assert result == {name: True for name in fakes}
     assert all(fake.load_calls == 1 for fake in fakes.values())
 
 
 def test_load_all_skips_extensions_unsupported_on_this_host(monkeypatch):
     fakes = _install_fake_extensions(monkeypatch)
-    monkeypatch.setattr(machete_utils, "_validate_machete_device_support", lambda: False)
+    monkeypatch.setattr(machete_utils, "_validate_machete_build_support", lambda: False)
 
     result = extension_api.load()
 
@@ -131,7 +127,7 @@ def test_load_all_skips_extensions_unsupported_on_this_host(monkeypatch):
 
 def test_load_specific_unsupported_extension_raises_without_building(monkeypatch):
     fakes = _install_fake_extensions(monkeypatch)
-    monkeypatch.setattr(machete_utils, "_validate_machete_device_support", lambda: False)
+    monkeypatch.setattr(machete_utils, "_validate_machete_build_support", lambda: False)
     monkeypatch.setattr(machete_utils, "machete_runtime_error", lambda: "Machete unsupported on this device.")
 
     with pytest.raises(RuntimeError, match="Machete unsupported on this device."):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: 2026 ModelCloud.ai
 # SPDX-License-Identifier: Apache-2.0
 
+import torch
+
+from gptqmodel.models import loader
+from gptqmodel.models._const import DEVICE
 from gptqmodel.models.loader import _should_print_module_tree
 
 
@@ -13,3 +17,27 @@ def test_loader_module_tree_print_is_opt_in(monkeypatch):
 
     monkeypatch.setenv("GPTQMODEL_PRINT_MODULE_TREE", "off")
     assert _should_print_module_tree() is False
+
+
+def test_layerwise_rocm_uses_cuda_runtime_for_all_visible_devices(monkeypatch):
+    monkeypatch.setattr(loader.torch.cuda, "device_count", lambda: 3)
+    monkeypatch.setattr(loader.torch.cuda, "is_available", lambda: True)
+
+    assert loader._layerwise_device_count(DEVICE.ROCM) == 3
+    assert loader._layerwise_device_strings(DEVICE.ROCM, 3) == [
+        "cuda:0",
+        "cuda:1",
+        "cuda:2",
+    ]
+
+
+def test_layerwise_rocm_mock_does_not_fall_back_to_cpu(monkeypatch):
+    monkeypatch.setattr("gptqmodel.utils.importer.IS_ROCM", True)
+    monkeypatch.setattr(loader.torch.cuda, "device_count", lambda: 2)
+    monkeypatch.setattr(loader.torch.cuda, "is_available", lambda: True)
+
+    num_gpus = loader._layerwise_device_count(DEVICE.ROCM)
+    assert loader._layerwise_device_strings(torch.device("cuda"), num_gpus) == [
+        "cuda:0",
+        "cuda:1",
+    ]

--- a/tests/test_marlin_jit.py
+++ b/tests/test_marlin_jit.py
@@ -561,7 +561,7 @@ def test_sm75_turing_contract_is_present_in_marlin_sources():
     generator_py = (marlin_root / "generate_kernels.py").read_text(encoding="utf-8")
     template_h = (marlin_root / "marlin_template.h").read_text(encoding="utf-8")
     mma_h = (marlin_root / "marlin_mma.h").read_text(encoding="utf-8")
-    loader_py = (Path(marlin_utils.__file__).resolve().parents[1] / "models" / "loader.py").read_text(
+    qlinear_py = (Path(marlin_utils.__file__).resolve().parents[1] / "nn_modules" / "qlinear" / "marlin.py").read_text(
         encoding="utf-8"
     )
 
@@ -573,9 +573,9 @@ def test_sm75_turing_contract_is_present_in_marlin_sources():
     assert "constexpr bool use_fp16_accum" in template_h
     assert "__CUDA_ARCH__ == 750" in mma_h
     assert "m16n8k8.row.col.f16.f16.f16.f16" in mma_h
-    assert "compute capability >= 7.5" in loader_py
-    assert "GPTQ Marlin on Turing (compute capability 7.5)" in loader_py
-    assert "dtype=torch.float16 only." in loader_py
+    assert "compute capability >= 7.5" in qlinear_py
+    assert "GPTQ Marlin on compute capability 7.5" in qlinear_py
+    assert "requires dtype=torch.float16." in qlinear_py
 
 
 def test_stage2_dense_four_bit_tiles_stay_in_sync_between_selector_and_codegen():

--- a/tests/test_quant_module_device.py
+++ b/tests/test_quant_module_device.py
@@ -2,14 +2,13 @@
 import pytest
 import torch
 
-from gptqmodel.models._const import DEVICE
 from gptqmodel.utils.model import create_quant_module
 
 
 @pytest.mark.parametrize(
     "device", ["cuda:0", "cuda:1", torch.device("cuda:1"), "cpu", torch.device("cpu")]
 )
-def test_quant_module_validation_normalizes_indexed_devices(device):
+def test_quant_module_validation_preserves_indexed_devices(device):
     seen = []
 
     class Dummy(torch.nn.Module):
@@ -38,4 +37,4 @@ def test_quant_module_validation_normalizes_indexed_devices(device):
         lm_head_name="lm_head",
         pack_dtype=torch.int32,
     )
-    assert seen == [DEVICE.CUDA if "cuda" in str(device) else DEVICE.CPU]
+    assert seen == [torch.device(device)]


### PR DESCRIPTION
## Summary

- preserve concrete torch.device ordinals through device-map normalization and kernel validation
- validate every target GPU and reject mixed accelerator families or compute capabilities explicitly
- make validation caching sensitive to device index, capability, dtype, shape, quantization, and training dimensions
- honor allow_marlin=False and move Marlin, Machete, Swordfish, and QQQ capability checks to the selected physical device
- isolate extension API tests from host-specific Hadamard and Swordfish availability

## Validation

- targeted Ruff checks passed
- CPU/mock regression: 143 passed, 62 skipped, 0 failed
- GPU regression on NVIDIA PG506-232 / SM80: 181 passed, 17 skipped, 0 failed
- Marlin FP16 and BF16 clean JIT builds passed
- two-GPU probe preserved cuda:0 and cuda:1 and queried both capabilities as 8.0

The remaining GPU skips are expected for optional backends and architectures unavailable on SM80, including Machete SM90 and Swordfish Blackwell runtime paths.