### PR TITLE
test(kernels): expand edge-case coverage

### DIFF
--- a/gptqmodel/nn_modules/qlinear/swordfish.py
+++ b/gptqmodel/nn_modules/qlinear/swordfish.py
@@ -306,7 +306,8 @@ class SwordfishLinear(GPTQQuantLinear):
         if self.input_rows(x) == 0:
             return self.empty_linear_output(x)
 
-        input_2d = x.reshape(-1, x.shape[-1])
+        # The native ABI requires a contiguous [M, K] activation.
+        input_2d = x.reshape(-1, x.shape[-1]).contiguous()
 
         if self.input_perm.numel() > 0:
             perm = self.input_perm
@@ -673,7 +674,8 @@ class AwqSwordfishLinear(AWQuantLinear):
         if self.input_rows(x) == 0:
             return self.empty_linear_output(x)
 
-        input_2d = x.reshape(-1, x.shape[-1])
+        # Keep the native ABI independent of the caller's input strides.
+        input_2d = x.reshape(-1, x.shape[-1]).contiguous()
 
         group_scales = self.scales
         if group_scales.dtype != input_2d.dtype:

--- a/tests/kernels/test_fallback.py
+++ b/tests/kernels/test_fallback.py
@@ -307,24 +307,24 @@ def test_kernel_output_fallback():
         assert qlinear.list_buffers()[0].device.type == "cuda", f"{label} buffers not on CUDA"
 
     total_samples = sum(samples for _, samples in shapes)
+    input_dims = [dim_0 for dim_0, samples in shapes for _ in range(samples)]
+    assert len(input_dims) == total_samples
     stats = {label: _init_stats() for label, _ in variants}
     with torch.inference_mode():
-        for _ in log.pb(total_samples).title("Forward Pass on Random Input"):
-            for dim_0, samples in shapes:
-                for _ in range(samples):
-                    x = torch.randn(
-                        (dim_0, down_proj.in_features),
-                        device=device,
-                        dtype=dtype,
-                    )
-                    assert x.device.type == "cuda"
-                    baseline = down_proj(x)
-                    variant_out = {label: qlinears[label](x) for label, _ in variants}
-                    assert baseline.device.type == "cuda"
-                    for label, out in variant_out.items():
-                        assert out.device.type == "cuda"
-                        diff = torch.abs(baseline - out).float()
-                        _update_stats(stats[label], diff)
+        for dim_0 in log.pb(input_dims).title("Forward Pass on Random Input"):
+            x = torch.randn(
+                (dim_0, down_proj.in_features),
+                device=device,
+                dtype=dtype,
+            )
+            assert x.device.type == "cuda"
+            baseline = down_proj(x)
+            variant_out = {label: qlinears[label](x) for label, _ in variants}
+            assert baseline.device.type == "cuda"
+            for label, out in variant_out.items():
+                assert out.device.type == "cuda"
+                diff = torch.abs(baseline - out).float()
+                _update_stats(stats[label], diff)
 
     finalized = {}
     for label, _ in variants:
@@ -403,25 +403,25 @@ def test_kernel_output_fallback_mad_sweep():
         assert qlinear.list_buffers()[0].device.type == "cuda", f"{label} buffers not on CUDA"
 
     total_samples = sum(samples for _, samples in shapes)
+    input_dims = [dim_0 for dim_0, samples in shapes for _ in range(samples)]
+    assert len(input_dims) == total_samples
     stats = {label: _init_stats() for label, _ in variants}
     with torch.inference_mode():
-        for _ in log.pb(total_samples).title("Forward Pass on Random Input (MAD Sweep)"):
-            for dim_0, samples in shapes:
-                for _ in range(samples):
-                    x = torch.randn(
-                        (dim_0, down_proj.in_features),
-                        device=device,
-                        dtype=dtype,
-                    )
-                    assert x.device.type == "cuda"
-                    baseline = down_proj(x)
-                    variant_out = {label: qlinears[label](x) for label, _ in variants}
-                    assert baseline.device.type == "cuda"
+        for dim_0 in log.pb(input_dims).title("Forward Pass on Random Input (MAD Sweep)"):
+            x = torch.randn(
+                (dim_0, down_proj.in_features),
+                device=device,
+                dtype=dtype,
+            )
+            assert x.device.type == "cuda"
+            baseline = down_proj(x)
+            variant_out = {label: qlinears[label](x) for label, _ in variants}
+            assert baseline.device.type == "cuda"
 
-                    for label, out in variant_out.items():
-                        assert out.device.type == "cuda"
-                        diff = torch.abs(baseline - out).float()
-                        _update_stats(stats[label], diff)
+            for label, out in variant_out.items():
+                assert out.device.type == "cuda"
+                diff = torch.abs(baseline - out).float()
+                _update_stats(stats[label], diff)
 
     finalized = {}
     for label, _ in variants:

--- a/tests/kernels/test_gptq.py
+++ b/tests/kernels/test_gptq.py
@@ -60,6 +60,14 @@ def _bitblas_supports_gptq_case(dtype: torch.dtype) -> bool:
     return valid
 
 
+def _expand_input_dims(shapes: List[Tuple[int, int]]) -> List[int]:
+    return [dim_0 for dim_0, samples in shapes for _ in range(samples)]
+
+
+def test_input_shape_plan_expands_each_sample_once():
+    assert _expand_input_dims([(1, 2), (16, 3)]) == [1, 1, 16, 16, 16]
+
+
 class Data:
     def __init__(self):
         self.m = 1
@@ -152,12 +160,10 @@ class TestKernelOutput(unittest.TestCase):
             data.adapter.post_init(cls.target, device=DEVICE) # trigger adapter weight load from disk
             data.k = data.adapter.lora_A.shape[0]
 
-            for _ in log.pb(cls.random_input_sample_size).title("Generate Random Inputs"):
-                for dim_0, samples in cls.m:
-
-                    for _ in range(samples):
-                        inputs = torch.rand((dim_0, data.k), device=DEVICE, dtype=dtype)
-                        data.x.append(inputs)
+            input_dims = _expand_input_dims(cls.m)
+            for dim_0 in log.pb(input_dims).title("Generate Random Inputs"):
+                data.x.append(torch.rand((dim_0, data.k), device=DEVICE, dtype=dtype))
+            assert len(data.x) == cls.random_input_sample_size
 
             AdapterCache.reset() # allow next load to complete since we are hacking to get consume only 1 lora module
 
@@ -192,8 +198,8 @@ class TestKernelOutput(unittest.TestCase):
                     self._synchronize(DEVICE)
                     module(warmup)
                     self._synchronize(DEVICE)
-                for i in log.pb(self.random_input_sample_size).title("Forward Pass on Random Input"):
-                    sample = data.x[i]
+                assert len(data.x) == self.random_input_sample_size
+                for sample in log.pb(data.x).title("Forward Pass on Random Input"):
                     assert sample.dtype == dtype
 
                     # Direct layer calls bypass accelerate's cross-device routing,

--- a/tests/kernels/test_swordfish.py
+++ b/tests/kernels/test_swordfish.py
@@ -3,8 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 
+from __future__ import annotations
+
 import unittest
 
+import pytest
 import torch
 import torch.nn as nn
 from parameterized import parameterized
@@ -13,50 +16,78 @@ from gptqmodel.nn_modules.qlinear.swordfish import SwordfishLinear
 from gptqmodel.nn_modules.qlinear.torch import TorchLinear
 from gptqmodel.utils.swordfish import (
     prewarm_swordfish_extension,
+    _validate_swordfish_device_support,
+    swordfish_runtime_available,
+    swordfish_runtime_error,
 )
+
+
+def _supported_swordfish_device(device_index: int) -> bool:
+    try:
+        with torch.cuda.device(device_index):
+            return _validate_swordfish_device_support()
+    except (RuntimeError, AssertionError):
+        return False
 
 
 def _skip_reason() -> str | None:
     if not torch.cuda.is_available():
         return "CUDA not available"
-    major, minor = torch.cuda.get_device_capability()
-    if major < 10:
-        return f"Swordfish requires Blackwell (sm100+); found sm{major}{minor}"
+    if not _supported_swordfish_device(torch.cuda.current_device()):
+        major, minor = torch.cuda.get_device_capability()
+        return f"Swordfish does not support the current CUDA device (sm{major}{minor})"
     return None
 
 
 _SKIP_REASON = _skip_reason()
 
 
-def _quantize_sym(
+def _quantize_weight(
     weight: torch.Tensor,
     bits: int,
     group_size: int,
+    sym: bool,
     g_idx: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Make deterministic GPTQ codes in the same [out, group] convention as pack()."""
+
     out_features, in_features = weight.shape
-    half_range = 1 << (bits - 1)
+    effective_group_size = in_features if group_size == -1 else group_size
     if g_idx is None:
-        g_idx = (torch.arange(in_features, device=weight.device, dtype=torch.int32) // group_size)
+        g_idx = torch.arange(in_features, dtype=torch.int32) // effective_group_size
     num_groups = int(g_idx.max().item()) + 1
+    levels = (1 << bits) - 1
+    half_range = 1 << (bits - 1)
 
     q = torch.empty_like(weight)
-    scales = torch.zeros((out_features, num_groups), dtype=weight.dtype, device=weight.device)
-    for g in range(num_groups):
-        mask = g_idx == g
-        block = weight[:, mask]
-        max_abs = block.abs().max(dim=1, keepdim=True).values
-        max_abs[max_abs == 0] = 1.0
-        scale = max_abs / (half_range - 1)
-        q_block = torch.round(block / scale).clamp(-(half_range), half_range - 1) + half_range
-        q[:, mask] = q_block
-        scales[:, g : g + 1] = scale
-
-    zeros = torch.full((out_features, num_groups), half_range, dtype=weight.dtype, device=weight.device)
+    scales = torch.empty(
+        (out_features, num_groups), dtype=weight.dtype, device=weight.device
+    )
+    zeros = torch.empty_like(scales)
+    for group in range(num_groups):
+        block = weight[:, g_idx == group]
+        if sym:
+            scale = block.abs().amax(dim=1, keepdim=True) / (half_range - 1)
+            zero = torch.full_like(scale, half_range)
+        else:
+            block_min = block.amin(dim=1, keepdim=True)
+            block_max = block.amax(dim=1, keepdim=True)
+            scale = (block_max - block_min) / levels
+            zero = torch.round(
+                -block_min / scale.clamp_min(torch.finfo(weight.dtype).eps)
+            )
+            zero.clamp_(0, levels)
+        scale = scale.clamp_min(torch.finfo(weight.dtype).eps)
+        codes = torch.round(block / scale + (half_range if sym else zero))
+        codes.clamp_(0, levels)
+        q[:, g_idx == group] = codes
+        scales[:, group : group + 1] = scale
+        zeros[:, group : group + 1] = zero
     return q, scales, zeros, g_idx
 
 
 def _pack_torch_reference(
+    *,
     bits: int,
     group_size: int,
     sym: bool,
@@ -67,9 +98,11 @@ def _pack_torch_reference(
     scales: torch.Tensor,
     zeros: torch.Tensor,
     g_idx: torch.Tensor,
-    bias: bool = False,
+    device: torch.device,
 ) -> TorchLinear:
-    linear = nn.Linear(in_features, out_features, bias=bias, dtype=weight.dtype, device="cpu")
+    linear = nn.Linear(
+        in_features, out_features, bias=False, dtype=weight.dtype, device="cpu"
+    )
     with torch.no_grad():
         linear.weight.copy_(weight)
 
@@ -81,80 +114,389 @@ def _pack_torch_reference(
         in_features=in_features,
         out_features=out_features,
         register_buffers=True,
+        pack_dtype=torch.int32,
     )
     torch_linear.pack(linear=linear, scales=scales, zeros=zeros, g_idx=g_idx)
-    torch_linear = torch_linear.to(device=weight.device)
+    torch_linear = torch_linear.to(device=device)
     torch_linear.post_init()
     return torch_linear
+
+
+def _copy_to_swordfish(
+    torch_linear: TorchLinear,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> SwordfishLinear:
+    sf = SwordfishLinear(
+        bits=torch_linear.bits,
+        group_size=torch_linear.requested_group_size,
+        desc_act=torch_linear.desc_act,
+        sym=torch_linear.sym,
+        in_features=torch_linear.in_features,
+        out_features=torch_linear.out_features,
+        bias=False,
+        pack_dtype=torch.int32,
+        dtype=dtype,
+    )
+    sf.qweight = nn.Parameter(
+        torch_linear.qweight.data.detach().clone().to(device=device).contiguous(),
+        requires_grad=False,
+    )
+    sf.scales = nn.Parameter(
+        torch_linear.scales.data.detach()
+        .clone()
+        .to(device=device, dtype=dtype)
+        .contiguous(),
+        requires_grad=False,
+    )
+    if torch_linear.g_idx is not None and torch_linear.g_idx.numel() > 0:
+        sf.g_idx = nn.Parameter(
+            torch_linear.g_idx.data.detach().clone().to(device=device).contiguous(),
+            requires_grad=False,
+        )
+    if torch_linear.qzeros is not None and torch_linear.qzeros.numel() > 0:
+        sf.qzeros = nn.Parameter(
+            torch_linear.qzeros.data.detach().clone().to(device=device).contiguous(),
+            requires_grad=False,
+        )
+    sf.post_init()
+    return sf
+
+
+def _make_pair(
+    *,
+    in_features: int,
+    out_features: int,
+    group_size: int,
+    sym: bool,
+    desc_act: bool,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> tuple[TorchLinear, SwordfishLinear]:
+    torch.manual_seed(17 + in_features + out_features + group_size)
+    weight = torch.randn((out_features, in_features), dtype=dtype, device="cpu") * 0.5
+    g_idx = None
+    if desc_act:
+        permutation = torch.randperm(in_features)
+        weight = weight[:, permutation]
+        effective_group_size = in_features if group_size == -1 else group_size
+        g_idx = (torch.arange(in_features, dtype=torch.int32) // effective_group_size)[
+            permutation
+        ]
+    _, scales, zeros, g_idx = _quantize_weight(
+        weight, bits=4, group_size=group_size, sym=sym, g_idx=g_idx
+    )
+    torch_linear = _pack_torch_reference(
+        bits=4,
+        group_size=group_size,
+        sym=sym,
+        desc_act=desc_act,
+        in_features=in_features,
+        out_features=out_features,
+        weight=weight,
+        scales=scales,
+        zeros=zeros,
+        g_idx=g_idx,
+        device=device,
+    )
+    return torch_linear, _copy_to_swordfish(torch_linear, device, dtype)
+
+
+def _shape_for_rows(rows: int, in_features: int, rank: int) -> tuple[int, ...]:
+    if rank == 2:
+        return rows, in_features
+    if rank == 3:
+        return 1, rows, in_features
+    if rank == 4:
+        return 1, 1, rows, in_features
+    raise ValueError(f"unsupported test rank {rank}")
+
+
+def _assert_pair(
+    torch_linear: TorchLinear,
+    sf: SwordfishLinear,
+    x: torch.Tensor,
+) -> torch.Tensor:
+    with torch.inference_mode():
+        ref = torch.matmul(x, torch_linear.dequantize_weight().to(dtype=x.dtype))
+        actual = sf(x)
+    assert actual.shape == ref.shape
+    assert actual.dtype == x.dtype
+    assert actual.device == x.device
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(actual, ref, rtol=0, atol=0.15)
+    assert (actual - ref).abs().float().mean().item() < 0.05
+    return actual
 
 
 @unittest.skipIf(_SKIP_REASON is not None, _SKIP_REASON or "")
 class TestSwordfishKernel(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        prewarm_swordfish_extension()
+        try:
+            prewarm_swordfish_extension()
+        except Exception as exc:
+            raise unittest.SkipTest(
+                f"Swordfish runtime unavailable: {swordfish_runtime_error() or exc}"
+            ) from exc
+        if not swordfish_runtime_available():
+            raise unittest.SkipTest(
+                f"Swordfish runtime unavailable: {swordfish_runtime_error()}"
+            )
 
-    def _copy_to_swordfish(self, torch_linear: TorchLinear) -> SwordfishLinear:
-        sf = SwordfishLinear(
-            bits=torch_linear.bits,
-            group_size=torch_linear.requested_group_size,
-            desc_act=torch_linear.desc_act,
-            sym=torch_linear.sym,
-            in_features=torch_linear.in_features,
-            out_features=torch_linear.out_features,
-            bias=False,
-            dtype=torch_linear.scales.dtype,
+    @parameterized.expand(
+        [
+            (
+                "fp16_channelwise_decode_edges",
+                64,
+                64,
+                -1,
+                True,
+                False,
+                torch.float16,
+                2,
+                (1, 16, 17, 32, 33),
+            ),
+            (
+                "bf16_asym_rank3_kn_tails",
+                192,
+                320,
+                32,
+                False,
+                False,
+                torch.bfloat16,
+                3,
+                (47, 48, 49, 64, 65),
+            ),
+            (
+                "fp16_desc_act_rank4_n_tail",
+                256,
+                320,
+                64,
+                True,
+                True,
+                torch.float16,
+                4,
+                (95, 96, 127, 128),
+            ),
+            (
+                "bf16_asym_desc_act_n_tail",
+                256,
+                192,
+                128,
+                False,
+                True,
+                torch.bfloat16,
+                2,
+                (1, 17, 65, 129),
+            ),
+            (
+                "bf16_prefill_edges",
+                256,
+                256,
+                128,
+                True,
+                False,
+                torch.bfloat16,
+                2,
+                (55, 56, 57, 95, 96, 97),
+            ),
+        ]
+    )
+    def test_swordfish_matches_deterministic_torch_reference(
+        self,
+        _case_name,
+        in_features,
+        out_features,
+        group_size,
+        sym,
+        desc_act,
+        dtype,
+        rank,
+        rows,
+    ):
+        device = torch.device("cuda", torch.cuda.current_device())
+        torch_linear, sf = _make_pair(
+            in_features=in_features,
+            out_features=out_features,
+            group_size=group_size,
+            sym=sym,
+            desc_act=desc_act,
+            dtype=dtype,
+            device=device,
         )
-        sf.qweight = nn.Parameter(torch_linear.qweight.data.detach().clone().contiguous(), requires_grad=False)
-        sf.scales = nn.Parameter(torch_linear.scales.data.detach().clone().contiguous(), requires_grad=False)
-        if torch_linear.g_idx is not None and torch_linear.g_idx.numel() > 0:
-            sf.g_idx = nn.Parameter(torch_linear.g_idx.data.detach().clone().contiguous(), requires_grad=False)
-        if torch_linear.qzeros is not None and torch_linear.qzeros.numel() > 0:
-            sf.qzeros = nn.Parameter(torch_linear.qzeros.data.detach().clone().contiguous(), requires_grad=False)
-        if torch_linear.bias is not None:
-            sf.bias = nn.Parameter(torch_linear.bias.data.detach().clone().contiguous(), requires_grad=False)
-        sf.post_init()
-        return sf
+        sf.eval()
+        for row_count in rows:
+            x = torch.randn(
+                _shape_for_rows(row_count, in_features, rank),
+                dtype=dtype,
+                device=device,
+            )
+            _assert_pair(torch_linear, sf, x)
 
-    @parameterized.expand([
-        (4, 128, True, False, torch.bfloat16),
-        (4, -1, True, False, torch.bfloat16),
-        (4, 64, True, True, torch.bfloat16),
-        (4, 128, True, True, torch.bfloat16),
-        (4, 128, True, False, torch.bfloat16),
-    ])
-    def test_swordfish_matches_torch(self, bits, group_size, sym, desc_act, dtype):
-        in_features = 256
-        out_features = 512
-        device = torch.device("cuda:0")
-
-        torch.manual_seed(42)
-        weight = torch.randn((out_features, in_features), dtype=dtype, device="cpu") * 0.5
-        g_idx = None
-        if desc_act:
-            perm = torch.randperm(in_features)
-            weight = weight[:, perm]
-            g_idx = (torch.arange(in_features, dtype=torch.int32) // group_size)[perm]
-
-        effective_group_size = group_size if group_size > 0 else in_features
-        _, scales, zeros, g_idx = _quantize_sym(weight, bits, effective_group_size, g_idx)
-
-        torch_linear = _pack_torch_reference(
-            bits, group_size, sym, desc_act, in_features, out_features, weight, scales, zeros, g_idx
+    def test_swordfish_accepts_only_int32_packing(self):
+        kwargs = dict(
+            bits=4,
+            group_size=64,
+            desc_act=False,
+            sym=True,
+            in_features=64,
+            out_features=64,
+            dtype=torch.float16,
         )
-        torch_linear = torch_linear.to(device)
-        sf = self._copy_to_swordfish(torch_linear)
-        sf = sf.to(device)
+        ok, error = SwordfishLinear.validate(pack_dtype=torch.int32, **kwargs)
+        self.assertTrue(ok, error)
+        self.assertIsNone(error)
+        for pack_dtype in (torch.int8, torch.int16, torch.int64):
+            ok, error = SwordfishLinear.validate(pack_dtype=pack_dtype, **kwargs)
+            self.assertFalse(ok)
+            self.assertIsInstance(error, NotImplementedError)
 
-        for m in (1, 8, 64):
-            x = torch.randn((m, in_features), dtype=dtype, device=device) * 0.5
-            with torch.no_grad():
-                ref = x @ torch_linear.dequantize_weight().to(dtype)
-                if torch_linear.bias is not None:
-                    ref = ref + torch_linear.bias.to(dtype)
-                out = sf(x)
-            diff = (out - ref).abs()
-            max_err = diff.max().item()
-            mae = diff.mean().item()
-            self.assertLess(max_err, 0.15, f"m={m}: max error too high ({max_err})")
-            self.assertLess(mae, 0.05, f"m={m}: MAE too high ({mae})")
+    def test_swordfish_rejects_trainable_nonempty_configuration(self):
+        ok, error = SwordfishLinear.validate(
+            bits=4,
+            group_size=64,
+            desc_act=False,
+            sym=True,
+            in_features=64,
+            out_features=64,
+            pack_dtype=torch.int32,
+            dtype=torch.float16,
+            trainable=True,
+        )
+        self.assertFalse(ok)
+        self.assertIsInstance(error, NotImplementedError)
+
+        device = torch.device("cuda", torch.cuda.current_device())
+        _, sf = _make_pair(
+            in_features=64,
+            out_features=64,
+            group_size=64,
+            sym=True,
+            desc_act=False,
+            dtype=torch.float16,
+            device=device,
+        )
+        sf.eval()
+        with self.assertRaises(NotImplementedError):
+            sf.train()
+
+    def test_swordfish_noncontiguous_activation(self):
+        device = torch.device("cuda", torch.cuda.current_device())
+        torch_linear, sf = _make_pair(
+            in_features=192,
+            out_features=320,
+            group_size=32,
+            sym=True,
+            desc_act=False,
+            dtype=torch.float16,
+            device=device,
+        )
+        x = torch.randn((17, 384), dtype=torch.float16, device=device)[:, ::2]
+        self.assertFalse(x.is_contiguous())
+        _assert_pair(torch_linear, sf, x)
+
+    def test_swordfish_empty_backward_is_supported(self):
+        device = torch.device("cuda", torch.cuda.current_device())
+        torch_linear, sf = _make_pair(
+            in_features=64,
+            out_features=64,
+            group_size=-1,
+            sym=True,
+            desc_act=False,
+            dtype=torch.float16,
+            device=device,
+        )
+        del torch_linear
+        sf.eval()
+        x = torch.empty((0, 64), dtype=torch.float16, device=device, requires_grad=True)
+        out = sf(x)
+        self.assertEqual(tuple(out.shape), (0, 64))
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertEqual(tuple(x.grad.shape), tuple(x.shape))
+        self.assertEqual(int(torch.count_nonzero(x.grad)), 0)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Swordfish torch.ops do not yet register fake/meta kernels for fullgraph capture",
+    )
+    def test_swordfish_compile_fullgraph_eager_contract(self):
+        device = torch.device("cuda", torch.cuda.current_device())
+        torch_linear, sf = _make_pair(
+            in_features=64,
+            out_features=64,
+            group_size=-1,
+            sym=True,
+            desc_act=False,
+            dtype=torch.float16,
+            device=device,
+        )
+        del torch_linear
+        sf.eval()
+        x = torch.randn((1, 64), dtype=torch.float16, device=device)
+        compiled = torch.compile(sf, fullgraph=True, backend="eager")
+        with torch.inference_mode():
+            eager = sf(x)
+            actual = compiled(x)
+        torch.testing.assert_close(actual, eager, rtol=0, atol=0)
+
+    def test_swordfish_cuda_graph_capture_and_replay(self):
+        device = torch.device("cuda", torch.cuda.current_device())
+        _, sf = _make_pair(
+            in_features=64,
+            out_features=64,
+            group_size=-1,
+            sym=True,
+            desc_act=False,
+            dtype=torch.float16,
+            device=device,
+        )
+        sf.eval()
+        static_x = torch.randn((1, 64), dtype=torch.float16, device=device)
+        replay_inputs = (torch.randn_like(static_x), torch.randn_like(static_x))
+        with torch.inference_mode():
+            sf(static_x)
+            torch.cuda.synchronize(device)
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                captured = sf(static_x)
+            for replay_x in replay_inputs:
+                static_x.copy_(replay_x)
+                graph.replay()
+                actual = captured.clone()
+                expected = sf(replay_x)
+                torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+
+    def test_swordfish_uses_tensor_device_when_current_device_differs(self):
+        supported = [
+            index
+            for index in range(torch.cuda.device_count())
+            if _supported_swordfish_device(index)
+        ]
+        if len(supported) < 2:
+            self.skipTest("requires at least two supported Blackwell GPUs")
+
+        current_device = supported[0]
+        tensor_device = torch.device("cuda", supported[1])
+        previous_device = torch.cuda.current_device()
+        with torch.cuda.device(current_device):
+            self.assertEqual(torch.cuda.current_device(), current_device)
+            torch_linear, sf = _make_pair(
+                in_features=64,
+                out_features=64,
+                group_size=-1,
+                sym=True,
+                desc_act=False,
+                dtype=torch.float16,
+                device=tensor_device,
+            )
+            x = torch.randn((1, 64), dtype=torch.float16, device=tensor_device)
+            actual = _assert_pair(torch_linear, sf, x)
+            self.assertEqual(actual.device, tensor_device)
+            self.assertEqual(torch.cuda.current_device(), current_device)
+        self.assertEqual(torch.cuda.current_device(), previous_device)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/kernels/test_swordfish_speed.py
+++ b/tests/kernels/test_swordfish_speed.py
@@ -4,6 +4,7 @@
 # Contact: qubitium@modelcloud.ai, x.com/qubitium
 
 import os
+import statistics
 import unittest
 
 import torch
@@ -11,7 +12,11 @@ import torch.nn as nn
 
 from gptqmodel.nn_modules.qlinear.swordfish import SwordfishLinear
 from gptqmodel.nn_modules.qlinear.torch import TorchLinear
-from gptqmodel.utils.swordfish import prewarm_swordfish_extension
+from gptqmodel.utils.swordfish import (
+    prewarm_swordfish_extension,
+    swordfish_runtime_available,
+    swordfish_runtime_error,
+)
 
 
 def _skip_reason() -> str | None:
@@ -68,7 +73,7 @@ def _pack_torch_reference(bits, group_size, in_features, out_features, weight, s
     return torch_linear
 
 
-def _copy_to_swordfish(torch_linear: TorchLinear) -> SwordfishLinear:
+def _copy_to_swordfish(torch_linear: TorchLinear, dtype: torch.dtype) -> SwordfishLinear:
     sf = SwordfishLinear(
         bits=torch_linear.bits,
         group_size=torch_linear.requested_group_size,
@@ -77,9 +82,10 @@ def _copy_to_swordfish(torch_linear: TorchLinear) -> SwordfishLinear:
         in_features=torch_linear.in_features,
         out_features=torch_linear.out_features,
         bias=False,
+        dtype=dtype,
     )
     sf.qweight = nn.Parameter(torch_linear.qweight.data.detach().clone().contiguous(), requires_grad=False)
-    sf.scales = nn.Parameter(torch_linear.scales.data.detach().clone().to(torch.bfloat16).contiguous(), requires_grad=False)
+    sf.scales = nn.Parameter(torch_linear.scales.data.detach().clone().to(dtype).contiguous(), requires_grad=False)
     if torch_linear.g_idx is not None and torch_linear.g_idx.numel() > 0:
         sf.g_idx = nn.Parameter(torch_linear.g_idx.data.detach().clone().contiguous(), requires_grad=False)
     sf.post_init()
@@ -90,20 +96,32 @@ def _copy_to_swordfish(torch_linear: TorchLinear) -> SwordfishLinear:
 class TestSwordfishSpeed(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        prewarm_swordfish_extension()
+        try:
+            prewarm_swordfish_extension()
+        except Exception as exc:
+            raise unittest.SkipTest(
+                f"Swordfish runtime unavailable: {swordfish_runtime_error() or exc}"
+            ) from exc
+        if not swordfish_runtime_available():
+            raise unittest.SkipTest(
+                f"Swordfish runtime unavailable: {swordfish_runtime_error()}"
+            )
 
-    def _measure(self, fn, x, warmup=5, iters=20):
+    def _measure(self, fn, x, warmup=5, iters=20, blocks=5):
         for _ in range(warmup):
             fn(x)
         torch.cuda.synchronize()
-        start = torch.cuda.Event(enable_timing=True)
-        end = torch.cuda.Event(enable_timing=True)
-        start.record()
-        for _ in range(iters):
-            fn(x)
-        end.record()
-        torch.cuda.synchronize()
-        return start.elapsed_time(end) / iters
+        block_times = []
+        for _ in range(blocks):
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            for _ in range(iters):
+                fn(x)
+            end.record()
+            end.synchronize()
+            block_times.append(start.elapsed_time(end) / iters)
+        return statistics.median(block_times)
 
     def test_swordfish_speed_vs_machete(self):
         in_features = 4096
@@ -117,15 +135,45 @@ class TestSwordfishSpeed(unittest.TestCase):
         weight = torch.randn((out_features, in_features), dtype=dtype, device="cpu") * 0.5
         q, scales, zeros = _quantize_sym(weight, bits, group_size)
         torch_linear = _pack_torch_reference(bits, group_size, in_features, out_features, q, scales, zeros, device)
-        sf = _copy_to_swordfish(torch_linear)
+        sf = _copy_to_swordfish(torch_linear, dtype)
 
-        # Dense FP16 baseline from the same quantized checkpoint.
+        # Dense baseline in the same activation dtype and from the same checkpoint.
         with torch.no_grad():
             dense_weight = torch_linear.dequantize_weight().to(device=device, dtype=dtype)
 
         baseline = {}
         machete = {}
         swordfish = {}
+
+        # Build the optional comparator once so allocator churn does not skew
+        # the small-M timing samples.
+        mach = None
+        try:
+            from gptqmodel.nn_modules.qlinear.machete import MacheteLinear
+            from gptqmodel.utils.machete import machete_runtime_available
+
+            if machete_runtime_available():
+                mach = MacheteLinear(
+                    bits=bits,
+                    group_size=group_size,
+                    desc_act=False,
+                    sym=True,
+                    in_features=in_features,
+                    out_features=out_features,
+                    bias=False,
+                )
+                mach.qweight = nn.Parameter(
+                    torch_linear.qweight.data.detach().clone().contiguous(),
+                    requires_grad=False,
+                )
+                mach.scales = nn.Parameter(
+                    torch_linear.scales.data.detach().clone().to(dtype).contiguous(),
+                    requires_grad=False,
+                )
+                mach.post_init()
+                mach = mach.to(device)
+        except Exception:
+            mach = None
 
         m_values = [1, 8, 16, 32, 64, 128, 256]
         for m in m_values:
@@ -144,44 +192,35 @@ class TestSwordfishSpeed(unittest.TestCase):
             baseline[m] = flops / (baseline_ms * 1e-3) / 1e12
             swordfish[m] = flops / (sf_ms * 1e-3) / 1e12
 
-            # Compare with Machete when the runtime reports support.
-            try:
-                from gptqmodel.nn_modules.qlinear.machete import MacheteLinear
-                from gptqmodel.utils.machete import machete_runtime_available
-
-                if machete_runtime_available():
-                    mach = MacheteLinear(
-                        bits=bits,
-                        group_size=group_size,
-                        desc_act=False,
-                        sym=True,
-                        in_features=in_features,
-                        out_features=out_features,
-                        bias=False,
-                    )
-                    mach.qweight = nn.Parameter(torch_linear.qweight.data.detach().clone().contiguous(), requires_grad=False)
-                    mach.scales = nn.Parameter(torch_linear.scales.data.detach().clone().to(torch.bfloat16).contiguous(), requires_grad=False)
-                    mach.post_init()
-                    mach = mach.to(device)
-
-                    def mach_fn(x):
-                        return mach(x)
-
-                    mach_ms = self._measure(mach_fn, x)
-                    machete[m] = flops / (mach_ms * 1e-3) / 1e12
-            except Exception:
-                pass
+            if mach is not None:
+                mach_ms = self._measure(mach, x)
+                machete[m] = flops / (mach_ms * 1e-3) / 1e12
 
         print(f"\nSwordfish speed benchmark (in={in_features}, out={out_features}, bits={bits}, group={group_size})")
         print(f"{'M':>5} {'Swordfish TFLOPS':>18} {'Dense TFLOPS':>15} {'Machete TFLOPS':>18}")
         for m in m_values:
             print(f"{m:>5} {swordfish[m]:>18.3f} {baseline[m]:>15.3f} {machete.get(m, float('nan')):>18.3f}")
 
-        # Swordfish should not be dramatically slower than the dense baseline
-        # for the small-batch decode window where it is designed to win.
-        if 1 in swordfish and 1 in baseline:
-            self.assertGreater(swordfish[1], baseline[1] * 0.25,
-                               "Swordfish bs=1 throughput should be within 4x of dense GEMM")
+        ratios = {m: swordfish[m] / baseline[m] for m in m_values}
+        print("Swordfish/dense ratios: " + ", ".join(f"M={m}: {ratio:.3f}" for m, ratio in ratios.items()))
+        failures = [
+            f"M={m} ratio={ratios[m]:.3f} "
+            f"(Swordfish={swordfish[m]:.3f} TFLOPS, dense={baseline[m]:.3f} TFLOPS)"
+            for m in (1, 8, 16)
+            if ratios[m] < 0.8
+        ]
+        self.assertFalse(
+            failures,
+            "Swordfish must reach at least 0.8x dense throughput at decode sizes: "
+            + "; ".join(failures),
+        )
+        median_ratio = statistics.median(ratios[m] for m in (1, 8, 16))
+        self.assertGreaterEqual(
+            median_ratio,
+            1.0,
+            "Swordfish median decode throughput ratio must be >= 1.0; "
+            f"median={median_ratio:.3f}, ratios={ratios}",
+        )
 
         if os.environ.get("GPTQMODEL_SWORDFISH_WRITE_SPEED_JSON"):
             import json
@@ -193,6 +232,8 @@ class TestSwordfishSpeed(unittest.TestCase):
                 "swordfish": swordfish,
                 "dense": baseline,
                 "machete": machete,
+                "swordfish_over_dense": ratios,
+                "decode_median_ratio": median_ratio,
             }
             with open("/tmp/swordfish_speed.json", "w") as f:
                 json.dump(out, f, indent=2)

--- a/tests/test_awq_rank_and_empty.py
+++ b/tests/test_awq_rank_and_empty.py
@@ -102,7 +102,7 @@ def test_awq_gemm_autograd_supports_arbitrary_rank(monkeypatch, backend, shape):
 
 
 @pytest.mark.parametrize("backend", ["jit", "triton"])
-@pytest.mark.parametrize("shape", [(3, 0, 8), (0, 3, 8)])
+@pytest.mark.parametrize("shape", [(0, 8), (3, 0, 8), (0, 3, 8), (2, 3, 0, 8)])
 def test_awq_gemm_empty_input_skips_forward_and_backward_backends(
     monkeypatch, backend, shape
 ):
@@ -119,19 +119,39 @@ def test_awq_gemm_empty_input_skips_forward_and_backward_backends(
     assert calls == {"dequant": 0, "gemm": 0}
 
 
-@pytest.mark.parametrize("backend, rows", [("jit", 1025), ("triton", 129)])
-def test_awq_gemm_heuristic_uses_logical_rows_for_2d_input(monkeypatch, backend, rows):
+@pytest.mark.parametrize(
+    "backend, threshold, shape",
+    [
+        ("jit", 1024, (1023, 8)),
+        ("jit", 1024, (1024, 8)),
+        ("jit", 1024, (1025, 8)),
+        ("jit", 1024, (32, 32, 8)),
+        ("triton", 128, (127, 8)),
+        ("triton", 128, (128, 8)),
+        ("triton", 128, (129, 8)),
+        ("triton", 128, (8, 16, 8)),
+    ],
+)
+def test_awq_gemm_heuristic_uses_logical_rows_at_threshold(
+    monkeypatch, backend, threshold, shape
+):
     calls = {"dequant": 0, "gemm": 0}
     fn = _patch_backend(monkeypatch, backend, calls)
     qweight, scales, qzeros = _fake_quant_tensors()
-    x = torch.ones((rows, 8), dtype=torch.float16)
+    x = torch.ones(shape, dtype=torch.float16)
+    rows = x.numel() // x.shape[-1]
 
     out = fn.apply(x, qweight, qzeros, scales, 4, 8, None, 8)
-    assert out.shape == (rows, 8)
-    assert calls == {"dequant": 1, "gemm": 0}
+    assert out.shape == shape[:-1] + (8,)
+    assert calls == {
+        "dequant": int(rows > threshold),
+        "gemm": int(rows <= threshold),
+    }
 
 
-@pytest.mark.parametrize("shape", [(3, 0, 8), (0, 3, 8), (2, 3, 4, 8)])
+@pytest.mark.parametrize(
+    "shape", [(0, 8), (3, 0, 8), (0, 3, 8), (2, 3, 0, 8), (2, 3, 4, 8)]
+)
 def test_linear_shape_helpers_preserve_rank_dtype_and_device(shape):
     x = torch.empty(shape, dtype=torch.bfloat16)
     assert input_rows(x) == x.numel() // x.shape[-1]
@@ -141,8 +161,9 @@ def test_linear_shape_helpers_preserve_rank_dtype_and_device(shape):
     assert out.device == x.device
 
 
-def test_empty_linear_output_keeps_autograd_connection():
-    x = torch.empty((2, 0, 8), dtype=torch.float32, requires_grad=True)
+@pytest.mark.parametrize("shape", [(0, 8), (2, 0, 8), (2, 3, 0, 8)])
+def test_empty_linear_output_keeps_autograd_connection(shape):
+    x = torch.empty(shape, dtype=torch.float32, requires_grad=True)
     out = empty_linear_output(x, 11)
     out.sum().backward()
     assert x.grad is not None


### PR DESCRIPTION
## Summary

- fix GPTQ random input generation so each planned sample is materialized exactly once
- expand kernel coverage for empty/boundary shapes, ranks, non-contiguous inputs, tile tails, dtypes, quantization modes, device selection, backward, torch.compile, and CUDA graphs
- strengthen the Swordfish performance regression threshold

## Validation

- tests/kernels/test_gptq.py: 17 passed, 8 skipped (default 496-sample CUDA matrix)
- tests/kernels/test_fallback.py: 2 passed
- tests/test_awq_rank_and_empty.py: 47 passed
- Swordfish correctness/speed: 13 skipped because the available GPUs are sm80 and Swordfish requires Blackwell sm100+
- ruff check, py_compile, and git diff --check passed

Total on available hardware: 66 passed, 21 skipped, 0 failed.