### PR TITLE
[MODEL] add `qwen_drive` quantization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 ## Latest News 🗞️🚀
 
+* 09/11/2026 7.5.0-dev `main`: ✨ Added `qwen_drive` quantization support.
 * 09/09/2026 7.5.0-dev `main`: 🛠️ Fixed quantized-linear empty-input handling, AWQ higher-rank inputs, and AWQ/ParoQuant CUDA validation and device/stream dispatch ([#3069](https://github.com/ModelCloud/GPTQModel/pull/3069)). Removed full-model scans during per-module finalization ([#3068](https://github.com/ModelCloud/GPTQModel/pull/3068)), fixed GPTQ calibration mask indexing across GPUs ([#3067](https://github.com/ModelCloud/GPTQModel/pull/3067)), and corrected the startup banner to report the package checkout's Git commit ([#3066](https://github.com/ModelCloud/GPTQModel/pull/3066)).
 * 09/08/2026 7.5.0-dev `main`: ✨ Added `k2_horizon` quantization support for K2-Horizon dense and MoVA/MoE models ([#3065](https://github.com/ModelCloud/GPTQModel/pull/3065)).
 * 09/07/2026 [7.4.0](https://github.com/ModelCloud/GPTQModel/releases/tag/v7.4.0): 🎉 Added resumable quantization checkpoints, shared-input Hessian deduplication, `lm_head` and embedding requantization, and updated native GGUF support. Added GLM-5.3-Flash, Apertus 1.5, and XHToken `ouro` / `spark2_5` quantization support, plus quantization, JIT cache, and Triton compatibility fixes.
@@ -325,6 +326,7 @@ The table mirrors every explicit registration in `gptqmodel.models.auto.MODEL_MA
 | Qwen 1-4 / 3.5 / 3.6 / 3.8 / MoE / Next | `qwen`, `qwen2`, `qwen2_moe`, `qwen3`, `qwen3_moe`, `qwen3_next`, `qwen3_5`, `qwen3_5_text`, `qwen3_5_moe`, `qwen3_5_moe_text`, `qwen4_exp` |
 | Qwen 2 / 2.5 / 3 VL | `qwen2_vl`, `qwen2_vl_text`, `qwen2_5_vl`, `qwen2_5_vl_text`, `qwen3_vl` |
 | Qwen 2.5 / 3 Omni | `qwen2_5_omni`, `qwen3_omni_moe` |
+| Qwen-Drive 1.0 | `qwen_drive` |
 | RefinedWeb | `refinedWeb`, `refinedWebModel` |
 | Seed-OSS | `seed_oss` |
 | SmolLM3 | `smollm3` |
@@ -339,6 +341,8 @@ The table mirrors every explicit registration in `gptqmodel.models.auto.MODEL_MA
 | Yi | `yi` |
 | Zamba / Zamba2 | `zamba`, `zamba2` |
 <!-- model-types:end -->
+
+Qwen-Drive support quantizes the Qwen3.5 VLM stored at the checkpoint root. It requires the official [`qwen_drive`](https://github.com/QwenLM/Qwen-Drive-1.0) inference package to register the architecture. The separately released `planner-sft`, `planner-rl`, and `perception` heads are not quantized or copied into the root-VLM output.
 
 
 Prism Bonsai GGUF checkpoints are supported for inference only through GPT-QModel's native GGUF path and internal GGUF runtime. Bonsai checkpoints load through the normal model path or repo argument and do not require the external `gguf` package. Prism model quantization is not included.

--- a/gptqmodel/models/auto.py
+++ b/gptqmodel/models/auto.py
@@ -187,6 +187,7 @@ from .definitions.qwen3_moe import Qwen3MoeQModel  # noqa: E402
 from .definitions.qwen3_next import Qwen3NextGPTQ  # noqa: E402
 from .definitions.qwen3_omni_moe import Qwen3OmniMoeGPTQ
 from .definitions.qwen3_vl import Qwen3_VLQModel
+from .definitions.qwen_drive import QwenDriveQModel  # noqa: E402
 from .definitions.qwen4_exp import Qwen4ExpQModel  # noqa: E402
 from .definitions.rw import RwgQModel  # noqa: E402
 from .definitions.solar_open import SolarOpenQModel  # noqa: E402
@@ -282,6 +283,7 @@ MODEL_MAP = {
     "mixtral": MixtralQModel,
     "qwen2": Qwen2QModel,
     "qwen3": Qwen3QModel,
+    "qwen_drive": QwenDriveQModel,
     "longllama": LlamaQModel,  # 100% llama clone
     "gemma": LlamaQModel, # 100% llama clone
     "gemma2": Gemma2QModel,

--- a/gptqmodel/models/definitions/__init__.py
+++ b/gptqmodel/models/definitions/__init__.py
@@ -98,6 +98,7 @@ from .qwen2_moe import Qwen2MoeQModel
 from .qwen2_vl import Qwen2VLQModel
 from .qwen3 import Qwen3QModel
 from .qwen3_moe import Qwen3MoeQModel
+from .qwen_drive import QwenDriveQModel
 from .qwen3_vl import Qwen3_VLQModel
 from .qwen4_exp import Qwen4ExpQModel
 from .rw import RwgQModel

--- a/gptqmodel/models/definitions/qwen_drive.py
+++ b/gptqmodel/models/definitions/qwen_drive.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+"""GPT-QModel support for the text/VLM portion of Qwen-Drive.
+
+The released Qwen-Drive checkpoint stores its Qwen3.5 VLM under ``vlm``.  The
+planning expert and perception model are separate artifacts, so this
+definition deliberately quantizes and delegates only the VLM text path.
+"""
+
+from transformers import AutoModel
+
+from .qwen3_5 import Qwen3_5QModel
+
+
+class QwenDriveQModel(Qwen3_5QModel):
+    """Quantization definition for the ``vlm.*`` part of Qwen-Drive."""
+
+    loader = AutoModel
+
+    # The official package is imported by the GPT-QModel HF registration hook.
+    # Qwen-Drive's top-level model is natively registered there and does not
+    # use Transformers' trust_remote_code mechanism.
+    require_trust_remote_code = False
+    require_load_processor = False
+    # The official package is imported by ``ensure_qwen_drive_registered``.
+    # Do not use ``require_pkgs`` here: a source checkout made importable via
+    # PYTHONPATH has no distribution metadata for ``check_versions`` to read.
+
+    layer_modules_strict = False
+
+    lm_head = "vlm.lm_head"
+    pre_lm_head_norm_module = "vlm.model.language_model.norm"
+    rotary_embedding = "vlm.model.language_model.rotary_emb"
+
+    # This is the Qwen3.5 decoder topology with the additional ``vlm`` root
+    # used by QwenDriveForPlanning.  Vision modules and the planning expert
+    # remain base/pass-through modules and are not quantized by this tree.
+    module_tree = [
+        "vlm",
+        "model",
+        "language_model",
+        "layers",
+        "#",
+        {
+            "input_layernorm": ("input_layernorm:!",),
+            "self_attn": (
+                "q_norm:!",
+                "q_proj:0:in=x",
+                "k_norm:!",
+                "k_proj:0:in=x",
+                "v_proj:0:in=x",
+                "o_proj:1",
+            ),
+            "linear_attn": (
+                "norm:!",
+                "conv1d:!",
+                "in_proj_qkv:0:in=x",
+                "in_proj_z:1:in=x",
+                "in_proj_b:!:1",
+                "in_proj_a:!:1",
+                "out_proj:2",
+            ),
+            "post_attention_layernorm": ("post_attention_layernorm:!",),
+            "mlp": ("gate_proj:0:in=x", "up_proj:0:in=x", "down_proj:1"),
+        },
+    ]
+
+    def after_model_load(self, model, load_quantized_model=False):
+        # QwenDriveForPlanning constructs this module from config even when
+        # loading the root VLM checkpoint.  The released root safetensors do
+        # not contain planner tensors, and planning is intentionally outside
+        # this quantization definition.  Remove the module before the lazy
+        # source, materialization, or save logic can observe it.
+        del load_quantized_model
+        modules = getattr(model, "_modules", None)
+        if isinstance(modules, dict):
+            modules.pop("planning_expert", None)
+        # StageInputsCapture invokes the wrapped HF model directly while it
+        # intercepts the first decoder layer.  The official planning wrapper
+        # has no generic forward method, so make its supported root-VLM path
+        # explicit for calibration as well as ordinary inference.
+        model.forward = model.vlm.forward
+        return model
+
+    def forward(self, *args, **kwargs):
+        """Run the text/VLM forward path, excluding the absent planner."""
+
+        return self.model.vlm(*args, **kwargs)
+
+    def generate(self, *args, **kwargs):
+        """Delegate text generation to the wrapped Qwen3.5 VLM."""
+
+        return self.model.vlm.generate(*args, **kwargs)
+
+    def prepare_inputs_for_generation(self, *args, **kwargs):
+        return self.model.vlm.prepare_inputs_for_generation(*args, **kwargs)
+
+    def get_input_embeddings(self):
+        return self.model.vlm.get_input_embeddings()
+
+    def get_output_embeddings(self):
+        return self.model.vlm.get_output_embeddings()
+
+
+__all__ = ["QwenDriveQModel"]

--- a/gptqmodel/models/writer.py
+++ b/gptqmodel/models/writer.py
@@ -44,6 +44,7 @@ from ..utils.backend import BACKEND
 from ..utils.exllamav3 import build_exllamav3_tensor_storage
 from ..utils.hf import (
     _normalize_legacy_tied_weights_keys,
+    ensure_qwen_drive_registered,
     prepare_remote_code_compat,
     sanitize_generation_config_file,
     sanitize_model_config,
@@ -1191,6 +1192,7 @@ def ModelWriter(cls):
 
     def get_model_with_quantize(self, qcfg, model_id_or_path):
 
+        ensure_qwen_drive_registered(model_id_or_path)
         config = AutoConfig.from_pretrained(
             model_id_or_path,
             trust_remote_code=True,

--- a/gptqmodel/utils/hf.py
+++ b/gptqmodel/utils/hf.py
@@ -67,6 +67,7 @@ __all__ = [
     "has_native_transformers_causallm_support",
     "get_hf_gguf_load_kwargs",
     "normalize_model_id_or_path_for_hf_gguf",
+    "ensure_qwen_drive_registered",
     "resolve_trust_remote_code",
     "set_hf_config_dtype",
     "load_hf_tokenizer",
@@ -80,6 +81,57 @@ INTERNAL_HF_GGUF_FILE_KWARG = "_gptqmodel_hf_gguf_file"
 _DENSE_MODEL_FILE_EXTENSIONS = (".safetensors", ".bin", ".pt", ".pth", ".ckpt")
 _INTERNAL_GGUF_TORCH_LOADER_ENV = "GPTQMODEL_INTERNAL_GGUF_TORCH_LOADER"
 _FALSEY_ENV_VALUES = {"", "0", "false", "off", "no"}
+
+_QWEN_DRIVE_MODEL_TYPE = "qwen_drive"
+_QWEN_DRIVE_INSTALL_HINT = (
+    "Qwen-Drive checkpoints require the official `qwen_drive` package. "
+    "Install it from `https://github.com/QwenLM/Qwen-Drive-1.0` "
+    "(or make that repository's `src` directory importable) "
+    "before loading this model."
+)
+
+
+def _local_config_model_type(model_id_or_path: Optional[str]) -> Optional[str]:
+    """Read a local model type without invoking Transformers' AutoConfig."""
+
+    if not model_id_or_path or not os.path.isdir(model_id_or_path):
+        return None
+
+    config_path = os.path.join(model_id_or_path, "config.json")
+    if not os.path.isfile(config_path):
+        return None
+
+    try:
+        with open(config_path, encoding="utf-8") as handle:
+            config = json.load(handle)
+    except (OSError, TypeError, ValueError):
+        return None
+
+    model_type = config.get("model_type") if isinstance(config, dict) else None
+    return str(model_type).lower() if model_type is not None else None
+
+
+def ensure_qwen_drive_registered(model_id_or_path: Optional[str] = None) -> bool:
+    """Register the official Qwen-Drive config before any ``AutoConfig`` call.
+
+    Qwen-Drive is intentionally not bundled with GPT-QModel.  Importing its
+    package performs the official ``AutoConfig``/``AutoModel`` registrations.
+    A missing package is made actionable for a local Qwen-Drive directory
+    instead of surfacing Transformers' generic unknown ``model_type`` error.
+    Other model types are left untouched so importing GPT-QModel does not load
+    an unrelated optional planning stack.
+    """
+
+    local_model_type = _local_config_model_type(model_id_or_path)
+    if local_model_type != _QWEN_DRIVE_MODEL_TYPE:
+        return False
+
+    try:
+        import qwen_drive  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(_QWEN_DRIVE_INSTALL_HINT) from exc
+
+    return True
 
 
 def _sync_local_remote_code_cache(model_id_or_path: Optional[str]) -> None:
@@ -504,6 +556,9 @@ def normalize_model_id_or_path_for_hf_gguf(
 
 @lru_cache(maxsize=None)
 def _detect_native_transformers_causallm_support(model_id_or_path: str) -> tuple[bool, Optional[str], Optional[str]]:
+    # Qwen-Drive's top-level config is registered by the optional official
+    # package, so it must be imported before Transformers first sees config.json.
+    ensure_qwen_drive_registered(model_id_or_path)
     config_load_kwargs: dict[str, Any] = {}
     normalized_model_id_or_path = normalize_model_id_or_path_for_hf_gguf(
         model_id_or_path,
@@ -536,6 +591,10 @@ def _detect_native_transformers_causallm_support(model_id_or_path: str) -> tuple
 
 
 def resolve_trust_remote_code(model_id_or_path: Optional[str], *, trust_remote_code: bool) -> bool:
+    # Keep registration ahead of the trust-remote-code probe as well as the
+    # main loader's AutoConfig call.  The probe runs very early in every public
+    # GPTQModel entry point when callers explicitly pass trust_remote_code.
+    ensure_qwen_drive_registered(model_id_or_path)
     if not trust_remote_code or not model_id_or_path:
         return trust_remote_code
 

--- a/tests/models/test_qwen_drive.py
+++ b/tests/models/test_qwen_drive.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+from model_test import ModelTest
+
+
+class TestQwenDrive(ModelTest):
+    NATIVE_MODEL_ID = "/monster/data/model/Qwen-Drive-1.0-4B" # Qwen/Qwen-Drive-1.0-4B
+    TRUST_REMOTE_CODE = False
+    GROUP_SIZE = 32
+    HESSIAN_CHUNK_SIZE = 256 * 1024 * 1024
+    DATASET_CONCAT_SIZE = 2048
+    EVAL_BATCH_SIZE = 32
+    EVAL_TASKS_SLOW = {
+        "arc_challenge": {
+            "acc": {"value": 0.5315699658703071, "floor_pct": 0.04},
+            "acc_norm": {"value": 0.5349829351535836, "floor_pct": 0.04},
+        },
+    }
+    EVAL_TASKS_FAST = ModelTest.derive_fast_eval_tasks(EVAL_TASKS_SLOW)
+    MODEL_COMPAT_FAST_LAYER_POSITION = "first"
+
+    def test_qwen_drive(self):
+        self.quantize_and_evaluate()
+
+
+__all__ = ["TestQwenDrive"]

--- a/tests/test_qwen_drive_support.py
+++ b/tests/test_qwen_drive_support.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+import builtins
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+from torch import nn
+from transformers import AutoModel
+
+from gptqmodel.models import auto
+from gptqmodel.models.definitions.qwen_drive import QwenDriveQModel
+from gptqmodel.quantization import QuantizeConfig
+from gptqmodel.utils import hf
+
+
+def test_qwen_drive_model_type_selects_definition(monkeypatch):
+    fake_config = SimpleNamespace(model_type="qwen_drive")
+    monkeypatch.setattr(auto, "resolve_trust_remote_code", lambda path, trust_remote_code=False: trust_remote_code)
+    monkeypatch.setattr(auto, "patch_remote_code_before_config_load", lambda path: None)
+    monkeypatch.setattr(auto.AutoConfig, "from_pretrained", lambda *args, **kwargs: fake_config)
+
+    assert auto.check_and_get_model_definition("/tmp/qwen-drive") is QwenDriveQModel
+
+
+def test_qwen_drive_registration_imports_official_package(monkeypatch, tmp_path):
+    model_dir = tmp_path / "qwen-drive"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text('{"model_type": "qwen_drive"}', encoding="utf-8")
+    monkeypatch.setitem(sys.modules, "qwen_drive", ModuleType("qwen_drive"))
+
+    assert hf.ensure_qwen_drive_registered(str(model_dir)) is True
+
+
+def test_qwen_drive_registration_error_points_to_official_source(monkeypatch, tmp_path):
+    model_dir = tmp_path / "qwen-drive"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text('{"model_type": "qwen_drive"}', encoding="utf-8")
+    monkeypatch.delitem(sys.modules, "qwen_drive", raising=False)
+    original_import = builtins.__import__
+
+    def fail_qwen_drive_import(name, *args, **kwargs):
+        if name == "qwen_drive":
+            raise ImportError("not installed")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_qwen_drive_import)
+
+    with pytest.raises(ImportError, match="QwenLM/Qwen-Drive-1.0"):
+        hf.ensure_qwen_drive_registered(str(model_dir))
+
+
+def test_qwen_drive_registration_ignores_other_model_types(monkeypatch, tmp_path):
+    model_dir = tmp_path / "qwen3"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text('{"model_type": "qwen3"}', encoding="utf-8")
+
+    def unexpected_import(name, *args, **kwargs):
+        if name == "qwen_drive":
+            raise AssertionError("qwen_drive should not be imported for another model type")
+        return original_import(name, *args, **kwargs)
+
+    original_import = builtins.__import__
+    monkeypatch.setattr(builtins, "__import__", unexpected_import)
+
+    assert hf.ensure_qwen_drive_registered(str(model_dir)) is False
+
+
+def test_qwen_drive_definition_contract_and_module_tree():
+    assert QwenDriveQModel.loader is AutoModel
+    assert QwenDriveQModel.require_trust_remote_code is False
+    assert QwenDriveQModel.require_load_processor is False
+    assert QwenDriveQModel.lm_head == "vlm.lm_head"
+    assert QwenDriveQModel.pre_lm_head_norm_module == "vlm.model.language_model.norm"
+    assert QwenDriveQModel.rotary_embedding == "vlm.model.language_model.rotary_emb"
+    assert QwenDriveQModel.extract_layers_node() == ["vlm.model.language_model.layers"]
+
+    blocks = QwenDriveQModel.simple_layer_modules(
+        model_config=SimpleNamespace(),
+        quantize_config=QuantizeConfig(),
+    )
+    flat = {name for block in blocks for name in block}
+    assert {
+        "self_attn.q_proj",
+        "self_attn.k_proj",
+        "self_attn.v_proj",
+        "self_attn.o_proj",
+        "linear_attn.in_proj_qkv",
+        "linear_attn.in_proj_z",
+        "linear_attn.out_proj",
+        "mlp.gate_proj",
+        "mlp.up_proj",
+        "mlp.down_proj",
+    } <= flat
+    assert {
+        "self_attn.q_norm",
+        "self_attn.k_norm",
+        "linear_attn.norm",
+        "linear_attn.conv1d",
+        "linear_attn.in_proj_a",
+        "linear_attn.in_proj_b",
+    }.isdisjoint(flat)
+
+
+class _FakeVLM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(2, 2, bias=False)
+        self.forward_kwargs = None
+        self.generate_kwargs = None
+
+    def forward(self, *args, **kwargs):
+        self.forward_kwargs = (args, kwargs)
+        return "forwarded"
+
+    def generate(self, *args, **kwargs):
+        self.generate_kwargs = (args, kwargs)
+        return "generated"
+
+
+class _FakeQwenDrive(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.vlm = _FakeVLM()
+        self.planning_expert = nn.Linear(2, 2, bias=False)
+
+
+def _definition_for(model):
+    definition = QwenDriveQModel.__new__(QwenDriveQModel)
+    nn.Module.__init__(definition)
+    definition.model = model
+    return definition
+
+
+def test_qwen_drive_text_calls_delegate_to_vlm():
+    wrapped = _FakeQwenDrive()
+    definition = _definition_for(wrapped)
+
+    assert definition.forward(input_ids="ids") == "forwarded"
+    assert wrapped.vlm.forward_kwargs == ((), {"input_ids": "ids"})
+    assert definition.generate(input_ids="ids") == "generated"
+    assert wrapped.vlm.generate_kwargs == ((), {"input_ids": "ids"})
+
+
+def test_qwen_drive_discards_unreleased_random_planner_state():
+    wrapped = _FakeQwenDrive()
+    definition = _definition_for(wrapped)
+
+    definition.after_model_load(wrapped)
+
+    assert "planning_expert" not in wrapped._modules
+    assert wrapped(input_ids="ids") == "forwarded"
+    assert wrapped.vlm.forward_kwargs == ((), {"input_ids": "ids"})
+    assert all(not name.startswith("planning_expert.") for name in wrapped.state_dict())
+    assert any(name.startswith("vlm.") for name in wrapped.state_dict())


### PR DESCRIPTION
## Summary

- register the `qwen_drive` model type and add a Qwen3.5-based module tree for the root VLM
- import the official `qwen_drive` package before Transformers reads the custom top-level config
- delegate calibration and text inference to the wrapped VLM because the official planning wrapper has no generic `forward`
- remove the config-created `planning_expert` from root-VLM artifacts; the released root safetensors contain only `vlm.*` tensors, while planner and perception weights are distributed separately
- add focused support tests, a `ModelTest` ARC-Challenge regression, and README documentation

## Evaluation

Full ARC-Challenge test split (1,172 samples), Evalution TransformersCompat, BF16 dense versus GPTQ W4 G32 (`sym=true`, `desc_act=false`, `act_group_aware=true`), 512 calibration rows and concat size 2048:

| Variant | acc | acc_norm |
|---|---:|---:|
| BF16 dense | 0.5366894197952219 | 0.5358361774744027 |
| GPTQ W4 G32 | 0.5315699658703071 | 0.5349829351535836 |

Normalized-score recovery versus dense: 99.84%.

Tokenizer normalization was also checked against direct `AutoTokenizer` loading: rendered prompts and input token IDs were identical, so no Tokenicer change was needed.

## Validation

- `pytest -q tests/test_qwen_drive_support.py tests/module_tree/test_moe_tags.py` (64 passed)
- Ruff checks for the new model definition and tests
- `git diff --check`
- end-to-end 32-layer quantization, save, reload, Torch quantized inference, and complete ARC-Challenge evaluation
