### PR TITLE
Fix partial packing words in the Torch fallback

### DIFF
--- a/gptqmodel/nn_modules/qlinear/__init__.py
+++ b/gptqmodel/nn_modules/qlinear/__init__.py
@@ -1016,7 +1016,8 @@ class PackableQuantLinear(GPTQQuantLinear):
                 t.unsqueeze(self.qzeros, 2).expand(-1, -1, self.pack_factor),
                 self.wf_unsqueeze_zero  # self.wf.unsqueeze(0),
             ).to(self.dequant_dtype)
-            zeros = t.bitwise_and(zeros, self.maxq).reshape(self.scales.shape)
+            zeros = t.bitwise_and(zeros, self.maxq).reshape(self.qzeros.shape[0], -1)
+            zeros = zeros[:, :self.scales.shape[1]]
 
             weight = t.bitwise_and(
                 _torch_right_shift(
@@ -1601,16 +1602,8 @@ class PackableQuantLinear(GPTQQuantLinear):
             qweight = np.zeros((math.ceil(int_weight.shape[0] * self.bits / self.pack_dtype_bits), int_weight.shape[1]),
                                dtype=self.pack_np_math_dtype)
             if self.bits in [2, 4, 8]:
-                if is_embedding:
-                    packed_rows = qweight.shape[0] * self.pack_factor
-                    if int_weight.shape[0] < packed_rows:
-                        int_weight = np.pad(
-                            int_weight,
-                            ((0, packed_rows - int_weight.shape[0]), (0, 0)),
-                            mode="constant",
-                        )
                 for row in range(qweight.shape[0]):
-                    for j in range(self.pack_factor):
+                    for j in range(min(self.pack_factor, int_weight.shape[0] - row * self.pack_factor)):
                         qweight[row] |= int_weight[row * self.pack_factor + j] << (self.bits * j)
             elif self.bits == 3 and not self.planar:
                 i = 0
@@ -1654,7 +1647,7 @@ class PackableQuantLinear(GPTQQuantLinear):
             qzeros = np.zeros((zeros.shape[0], math.ceil(zeros.shape[1] * self.bits / self.pack_dtype_bits)), dtype=self.pack_np_math_dtype)
             if self.bits in [2, 4, 8]:
                 for col in range(qzeros.shape[1]):
-                    for j in range(self.pack_factor):
+                    for j in range(min(self.pack_factor, zeros.shape[1] - col * self.pack_factor)):
                         qzeros[:, col] |= zeros[:, col * self.pack_factor + j] << (self.bits * j)
             elif self.bits == 3 and not self.planar:
                 i = 0

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -454,6 +454,7 @@ class TorchLinear(PackableQuantLinear):
         )
         weight = torch.bitwise_and(weight, self.maxq)
         weight = weight.reshape(weight.shape[0] * weight.shape[1], weight.shape[2])
+        weight = weight[:self.in_features]
 
         zeros_tile = zeros.narrow(1, start, width)
         scales_tile = self.scales.narrow(1, start, width)
@@ -472,7 +473,8 @@ class TorchLinear(PackableQuantLinear):
             self.wf_unsqueeze_zero,
             self.dequant_dtype,
         )
-        zeros = torch.bitwise_and(zeros, self.maxq).reshape(self.scales.shape)
+        zeros = torch.bitwise_and(zeros, self.maxq).reshape(self.qzeros.shape[0], -1)
+        zeros = zeros[:, :self.scales.shape[1]]
         self._zeros_cache = zeros
         self._zeros_cache_state = cache_state
         return zeros
@@ -714,7 +716,7 @@ class TorchLinear(PackableQuantLinear):
         weight = weight.reshape(weight.shape[0] * weight.shape[1], weight.shape[2])
 
         if num_itr == 1:
-            return self.scales[g_idx_long] * (weight - zeros[g_idx_long])
+            return self.scales[g_idx_long] * (weight[:self.in_features] - zeros[g_idx_long])
 
         num_dim = self.g_idx.shape[0] // num_itr
         out_dim = weight.shape[1] // num_itr

--- a/gptqmodel/nn_modules/qlinear/torch.py
+++ b/gptqmodel/nn_modules/qlinear/torch.py
@@ -677,6 +677,9 @@ class TorchLinear(PackableQuantLinear):
         # Planar 3-bit words do not match the continuous Triton decode layout.
         if self.planar:
             return False
+        # Triton assumes complete zero-point words when computing group strides.
+        if self.bits in (2, 4, 8) and self.out_features % self.pack_factor:
+            return False
         if not (self.qweight.is_contiguous() and self.qzeros.is_contiguous() and self.scales.is_contiguous()):
             return False
         # g_idx is stored as int32 tensor; ensure it resides on the same device.

--- a/tests/test_pack_tails.py
+++ b/tests/test_pack_tails.py
@@ -154,3 +154,52 @@ def test_embedding_partial_words_train_and_eval(bits: int) -> None:
         module.train(training)
         torch.testing.assert_close(module.dequantize_weight().float(), embedding.weight, rtol=0, atol=0)
         torch.testing.assert_close(module(input_ids).float(), embedding(input_ids), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "bits,pack_dtype,format,in_features,out_features,eligible",
+    [
+        (bits, torch.int32, FORMAT.GPTQ_V2, in_features, out_features, eligible)
+        for bits in (2, 4, 8)
+        for in_features, out_features, eligible in ((64, 19, False), (63, 32, True), (64, 32, True))
+    ]
+    + [
+        (3, torch.int32, FORMAT.GPTQ_V2, 64, 32, True),
+        (3, torch.int32, FORMAT.GPTQ_P, 64, 32, False),
+        (4, torch.int8, FORMAT.GPTQ_V2, 63, 19, False),
+        (8, torch.int8, FORMAT.GPTQ_V2, 63, 19, True),
+        (8, torch.int16, FORMAT.GPTQ_V2, 63, 19, False),
+    ],
+)
+def test_triton_dequant_partial_word_eligibility(
+    bits: int,
+    pack_dtype: torch.dtype,
+    format: FORMAT,
+    in_features: int,
+    out_features: int,
+    eligible: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = TorchLinear(
+        bits=bits,
+        group_size=32,
+        sym=False,
+        desc_act=False,
+        in_features=in_features,
+        out_features=out_features,
+        pack_dtype=pack_dtype,
+        format=format,
+    ).eval()
+    assert module.qzeros.shape[0] == 2
+    monkeypatch.setattr("gptqmodel.nn_modules.qlinear.torch._TRITON_DEQUANT_AVAILABLE", True)
+
+    # Device metadata stand-ins exercise the real eligibility check without CUDA.
+    class CudaBuffer:
+        device = torch.device("cuda:0")
+
+        def is_contiguous(self) -> bool:
+            return True
+
+    for name in ("qweight", "qzeros", "scales", "g_idx"):
+        monkeypatch.setitem(module._buffers, name, CudaBuffer())
+    assert module._can_use_triton_dequant() is eligible

--- a/tests/test_pack_tails.py
+++ b/tests/test_pack_tails.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import load_file, save_file
+
+from gptqmodel.nn_modules.qlinear.torch import TorchLinear, TorchQuantEmbeddings
+from gptqmodel.quantization import FORMAT, QuantizeConfig
+from gptqmodel.utils.model import pack_module
+
+
+def _pack_linear(
+    bits: int,
+    in_features: int,
+    out_features: int,
+    pack_impl: str,
+    desc_act: bool = False,
+    pack_dtype: torch.dtype = torch.int32,
+    group_size: int = 32,
+) -> tuple[TorchLinear, torch.nn.Linear]:
+    groups = 1 if group_size == -1 else math.ceil(in_features / group_size)
+    module = TorchLinear(
+        bits=bits,
+        group_size=group_size,
+        sym=False,
+        desc_act=desc_act,
+        in_features=in_features,
+        out_features=out_features,
+        bias=True,
+        pack_dtype=pack_dtype,
+        format=FORMAT.GPTQ_V2,
+    )
+    g_idx = module.g_idx.flip(0) if desc_act else module.g_idx
+    codes = torch.arange(in_features * out_features).reshape(in_features, out_features) % (1 << bits)
+    zeros = torch.arange(groups * out_features).reshape(groups, out_features) % (1 << bits)
+    scales = (torch.arange(groups * out_features).reshape(groups, out_features) % 3 + 1) / 8
+    weight = scales[g_idx] * (codes - zeros[g_idx])
+    linear = torch.nn.Linear(in_features, out_features, bias=True)
+    linear.weight.data.copy_(weight.T)
+    linear.bias.data.copy_(torch.arange(out_features) / 8)
+    config = QuantizeConfig(
+        bits=bits,
+        group_size=group_size,
+        sym=False,
+        desc_act=desc_act,
+        format=FORMAT.GPTQ_V2,
+        pack_impl=pack_impl,
+        pack_dtype=pack_dtype,
+        offload_to_disk=False,
+    )
+    pack_module(
+        "linear",
+        {"linear": module},
+        scales.T.contiguous(),
+        zeros.T.contiguous(),
+        g_idx,
+        {"linear": linear},
+        TorchLinear,
+        None,
+        quantize_config=config,
+    )
+    return module, linear
+
+
+def _assert_linear_round_trip(module: TorchLinear, linear: torch.nn.Linear) -> None:
+    x = (torch.arange(2 * module.in_features).reshape(2, module.in_features) % 7 - 3).float() / 4
+    for training in (True, False):
+        module.train(training)
+        dequantized = module.dequantize_weight()
+        assert dequantized.shape == (module.in_features, module.out_features)
+        torch.testing.assert_close(dequantized.T.float(), linear.weight, rtol=0, atol=0)
+        torch.testing.assert_close(module(x), linear(x), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("bits", [2, 4, 8])
+@pytest.mark.parametrize(
+    "in_features,out_features", [(64, 32), (64, 20), (64, 19), (63, 32), (63, 19), (1, 1), (640, 24)]
+)
+@pytest.mark.parametrize("pack_impl", ["cpu", "original"])
+def test_pack_module_partial_words(
+    bits: int, in_features: int, out_features: int, pack_impl: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GPTQMODEL_DISABLE_PACK_EXT", "1")
+    module, linear = _pack_linear(bits, in_features, out_features, pack_impl)
+    _assert_linear_round_trip(module, linear)
+
+
+@pytest.mark.parametrize("bits", [2, 4, 8])
+@pytest.mark.parametrize("pack_dtype", [torch.int8, torch.int16])
+def test_pack_original_partial_smaller_words(bits: int, pack_dtype: torch.dtype) -> None:
+    module, linear = _pack_linear(bits, 63, 19, "original", pack_dtype=pack_dtype)
+    _assert_linear_round_trip(module, linear)
+
+
+@pytest.mark.parametrize("bits", [2, 4, 8])
+@pytest.mark.parametrize("group_size", [-1, 32])
+def test_partial_words_desc_act(bits: int, group_size: int) -> None:
+    module, linear = _pack_linear(bits, 63, 19, "original", desc_act=True, group_size=group_size)
+    _assert_linear_round_trip(module, linear)
+
+
+@pytest.mark.parametrize("bits", [2, 4, 8])
+def test_partial_words_checkpoint_round_trip(bits: int, tmp_path: Path) -> None:
+    module, linear = _pack_linear(bits, 63, 19, "original")
+    checkpoint = tmp_path / "linear.safetensors"
+    save_file(module.state_dict(), str(checkpoint))
+    reloaded = TorchLinear(
+        bits=bits,
+        group_size=32,
+        sym=False,
+        desc_act=False,
+        in_features=63,
+        out_features=19,
+        bias=True,
+        format=FORMAT.GPTQ_V2,
+    )
+    reloaded.load_state_dict(load_file(str(checkpoint)))
+    _assert_linear_round_trip(reloaded, linear)
+
+
+@pytest.mark.parametrize("bits", [2, 4, 8])
+def test_stream_dequantize_partial_words(bits: int) -> None:
+    module, linear = _pack_linear(bits, 63, 19, "original")
+    module._init_wf_unsqueeze_buffers()
+    zeros = module._stream_decode_qzeros()
+    g_idx = module._stream_g_idx_long()
+    buffer = torch.empty((module.in_features, 8), dtype=torch.float32)
+    for start in range(0, module.out_features, 8):
+        end = min(start + 8, module.out_features)
+        width = module._stream_dequantize_tile(buffer, zeros, g_idx, start, end, buffer.dtype)
+        assert width == end - start
+        torch.testing.assert_close(buffer[:, :width].T, linear.weight[start:end], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("bits", [2, 4, 8])
+def test_embedding_partial_words_train_and_eval(bits: int) -> None:
+    embedding = torch.nn.Embedding(17, 19)
+    embedding.weight.data.copy_(torch.arange(17 * 19).reshape(17, 19) % (1 << bits))
+    module = TorchQuantEmbeddings(
+        bits=bits,
+        group_size=32,
+        sym=False,
+        desc_act=False,
+        in_features=17,
+        out_features=19,
+        format=FORMAT.GPTQ_V2,
+    )
+    module.pack_original(embedding, torch.ones((19, 1)), torch.zeros((19, 1)), module.g_idx)
+    input_ids = torch.tensor([[0, 8, 16]])
+    for training in (True, False):
+        module.train(training)
+        torch.testing.assert_close(module.dequantize_weight().float(), embedding.weight, rtol=0, atol=0)
+        torch.testing.assert_close(module(input_ids).float(), embedding(input_ids), rtol=0, atol=0)


### PR DESCRIPTION
## Summary

The Torch backend accepts arbitrary input/output widths, but partial words can crash packing or decode with padded dimensions. Handle these tails consistently through packing and Torch decoding.

## What Changed

- Bound the original 2/4/8-bit packing loops and trim logical input/output dimensions during decoding.
- Keep incomplete zero-point words on Torch decoding because the optional Triton decoder assumes complete group strides. Preserve aligned and input-only-tail eligibility.

## Tests

- [x] I added a new simple/fast unit test for this change.
- [x] I ran the new targeted test locally.
- [x] I ran other directly relevant local tests.

```bash
GPTQMODEL_DISABLE_PACK_EXT=1 TORCH_COMPILE_DISABLE=1 CUDA_VISIBLE_DEVICES='' \
PYTHONPATH=. python -m pytest -p no:cacheprovider -q \
  tests/test_pack_tails.py tests/test_torch_kernel_accuracy.py \
  tests/test_planar_format_gptq_p.py tests/test_planar_bits_567.py \
  tests/test_torch.py::test_torch_quant_embeddings_pack_original_handles_unaligned_vocab \
  tests/test_torch.py::test_cpu_cached_dequant_num_itr_matches_packable \
  -k 'not tiny_model'
```

220 passed, 5 model-lifecycle cases deselected. Includes actual pack/dequantize/forward and checkpoint round trips, embeddings, activation-order groups, smaller storage words, and existing 3-bit/planar controls. Eligibility tests use explicit device metadata stand-ins.

## Review Requirements

- [x] I personally reviewed every file in this diff.
- [x] I checked that the code matches existing project structure, APIs, and conventions.
- [x] I avoided unnecessary monkeypatching and used normal extension points where possible.

## Notes

Native Triton kernels and GPU packer alignment are unchanged. No new unaligned continuous-3-bit or planar support is claimed. Scoped Ruff and whitespace checks pass. GPU/native/compiled execution and full model lifecycle qualification were not run.

