### PR TITLE
Validate offload metadata before saving meta tensors

### DIFF
--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -1760,6 +1760,15 @@ def _resolve_offload_entry(
     else:
         shape = shape_hint
 
+    if resolved_dtype != dtype or shape != shape_hint:
+        name = f"{module_path}.{leaf}" if module_path else leaf
+        index_path = os.path.join(module_dir, "index.json")
+        raise ValueError(
+            f"Offload metadata mismatch for tensor '{name}' in '{index_path}': "
+            f"expected dtype {dtype} and shape {shape_hint}, "
+            f"found dtype {resolved_dtype} and shape {shape}."
+        )
+
     safetensors_file = entry.get("safetensors_file")
     if safetensors_file:
         path = safetensors_file
@@ -1784,7 +1793,7 @@ def _resolve_offload_entry(
         end = start + (_torch_dtype_num_bytes(resolved_dtype) * math.prod(shape or (1,)))
         return OffloadTensorRef(
             path=os.path.abspath(path),
-            dtype=resolved_dtype,
+            torch_dtype=resolved_dtype,
             shape=shape,
             format="dat",
             weight_name=None,

--- a/tests/test_offload_files.py
+++ b/tests/test_offload_files.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from accelerate import disk_offload
 from safetensors import safe_open
 from safetensors.torch import save_file
 from torch import nn
@@ -387,6 +388,121 @@ def test_offload_to_disk_writes_single_dat_file(tmp_path):
     undo_offload_to_disk(model.linear, delete_offload_folders=False)
     for name, tensor in model.linear.state_dict().items():
         torch.testing.assert_close(tensor, original_state[name])
+
+
+def _offloaded_save_model(
+    tmp_path: Path, offload_format: str, dtype: torch.dtype = torch.float32
+) -> tuple[nn.Module, Path, dict[str, torch.Tensor]]:
+    model = nn.Module()
+    model.block = nn.Module()
+    tensor = torch.arange(24, dtype=dtype).reshape(4, 6) / 8
+    model.block.weight = nn.Parameter(tensor.clone())
+    model.block.register_buffer("scale", tensor.clone())
+    original_state = _clone_state_dict(model)
+    offload_root = tmp_path / "offload_root"
+
+    if offload_format == "safetensors":
+        offload_to_disk(
+            module=model.block, model=model, disk_path=str(offload_root), force=True
+        )
+    else:
+        module_dir = offload_root / "block"
+        disk_offload(
+            model.block,
+            offload_dir=str(module_dir),
+            offload_buffers=True,
+            execution_device=torch.device("cpu"),
+        )
+        if offload_format == "dat-filename":
+            index_path = module_dir / "index.json"
+            index = json.loads(index_path.read_text())
+            for name, entry in index.items():
+                entry["filename"] = f"{name}.dat"
+            index_path.write_text(json.dumps(index))
+
+    return model, offload_root, original_state
+
+
+@pytest.mark.parametrize("offload_format", ["safetensors", "dat", "dat-filename"])
+@pytest.mark.parametrize("leaf", ["weight", "scale"])
+@pytest.mark.parametrize(
+    "stored_dtype, shell_dtype",
+    [(torch.float32, torch.float16), (torch.float16, torch.bfloat16)],
+)
+def test_offload_save_rejects_dtype_mismatch(
+    tmp_path: Path,
+    offload_format: str,
+    leaf: str,
+    stored_dtype: torch.dtype,
+    shell_dtype: torch.dtype,
+) -> None:
+    model, offload_root, _ = _offloaded_save_model(
+        tmp_path, offload_format, dtype=stored_dtype
+    )
+    tensor = getattr(model.block, leaf).to(shell_dtype)
+    if leaf == "weight":
+        tensor = nn.Parameter(tensor)
+    setattr(model.block, leaf, tensor)
+
+    with pytest.raises(ValueError, match="Offload metadata mismatch") as exc:
+        get_state_dict_for_save(model, offload_root=str(offload_root))
+
+    message = str(exc.value)
+    assert f"block.{leaf}" in message
+    assert str(offload_root / "block" / "index.json") in message
+    assert f"expected dtype {shell_dtype}" in message
+    assert f"found dtype {stored_dtype}" in message
+
+
+@pytest.mark.parametrize("offload_format", ["safetensors", "dat", "dat-filename"])
+@pytest.mark.parametrize("leaf", ["weight", "scale"])
+def test_offload_save_rejects_shape_mismatch(
+    tmp_path: Path, offload_format: str, leaf: str
+) -> None:
+    model, offload_root, _ = _offloaded_save_model(tmp_path, offload_format)
+    tensor = getattr(model.block, leaf).reshape(6, 4)
+    if leaf == "weight":
+        tensor = nn.Parameter(tensor)
+    setattr(model.block, leaf, tensor)
+
+    with pytest.raises(ValueError, match="Offload metadata mismatch") as exc:
+        get_state_dict_for_save(model, offload_root=str(offload_root))
+
+    message = str(exc.value)
+    assert f"block.{leaf}" in message
+    assert str(offload_root / "block" / "index.json") in message
+    assert "shape (6, 4)" in message
+    assert "shape (4, 6)" in message
+
+
+@pytest.mark.parametrize("offload_format", ["safetensors", "dat", "dat-filename"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_offload_save_preserves_matching_metadata(
+    tmp_path: Path, offload_format: str, dtype: torch.dtype
+) -> None:
+    model, offload_root, original_state = _offloaded_save_model(
+        tmp_path, offload_format, dtype=dtype
+    )
+    model.output = nn.Module()
+    model.output.weight = model.block.weight
+
+    state_dict = get_state_dict_for_save(model, offload_root=str(offload_root))
+    assert set(state_dict) == set(original_state)
+    assert model.output.weight is model.block.weight
+    save_dir = tmp_path / "saved"
+    save_dir.mkdir()
+    expected_files, _, _ = streaming_state_dict_to_shards(
+        state_dict,
+        save_dir=str(save_dir),
+        model_base_name="model",
+        single_file_name="model.safetensors",
+        metadata={},
+        max_shard_size=None,
+    )
+
+    with safe_open(str(save_dir / expected_files[0]), framework="pt") as handler:
+        for name, tensor in original_state.items():
+            torch.testing.assert_close(handler.get_tensor(name), tensor)
 
 
 def test_alias_all_from_turtle_restores_direct_meta_tensors_with_offloaded_children(tmp_path):


### PR DESCRIPTION
## Summary

Saving a meta tensor whose dtype or shape differs from its offload entry can write an unreadable checkpoint or silently reinterpret values. Reject the mismatch before collecting tensors for save.

## What Changed

- Compare resolved offload dtype and shape with the model tensor and report the key, index and metadata on mismatch.
- Preserve matching safetensors and legacy `.dat` saves; correct the adjacent explicit-filename `OffloadTensorRef` dtype keyword.

## Tests

- [x] I added a new simple/fast unit test for this change.
- [x] I ran the new targeted test locally.
- [x] I ran other directly relevant local tests.

```bash
PYTHONPATH=. python -m pytest -p no:cacheprovider -q tests/test_offload_files.py
```

55 passed, 1 GPU-only skip. New tests use actual offload and save/reload paths, cover parameters/buffers and tied aliases, and expose 21 base errors with 6 matching controls passing.

## Review Requirements

- [x] I personally reviewed every file in this diff.
- [x] I checked that the code matches existing project structure, APIs, and conventions.
- [x] I avoided unnecessary monkeypatching and used normal extension points where possible.

## Notes

Known index metadata is validated; payload checksums, stale values with identical metadata, and offload-run isolation are outside this change. Scoped Ruff and whitespace checks pass. GPU and full-suite validation were not run.

