### PR TITLE
Validate required qweight tensors in GPTQ safetensors checkpoints

### DIFF
--- a/gptqmodel/models/loader.py
+++ b/gptqmodel/models/loader.py
@@ -82,6 +82,7 @@ from ..utils.model import (
     make_quant,
     no_placement_module_names,
     simple_dispatch_model,
+    validate_checkpoint_qweights,
 )
 from ._const import DEVICE, HAS_NPU, normalize_device
 
@@ -1470,6 +1471,8 @@ def ModelLoader(cls):
                     dtype=dtype,
                     is_sharded=is_sharded,
                 )
+
+        validate_checkpoint_qweights(model, model_save_name, format_code)
 
         if isinstance(requested_device_map, str) and requested_device_map not in [
                 "auto",

--- a/gptqmodel/utils/model.py
+++ b/gptqmodel/utils/model.py
@@ -1937,7 +1937,9 @@ def get_state_dict_for_save(model: nn.Module, offload_root: Optional[str] = None
     return state_dict
 
 
-def _checkpoint_tensor_keys(checkpoint: str | os.PathLike) -> Optional[set[str]]:
+def _checkpoint_tensor_keys(
+    checkpoint: str | os.PathLike, *, verify_shards: bool = False,
+) -> Optional[set[str]]:
     # accelerate.load_checkpoint_in_model() does not return the checkpoint key
     # set. Read only metadata/index keys here so tie_weights() can distinguish
     # tensors that were truly absent from tensors that were loaded separately.
@@ -1949,6 +1951,16 @@ def _checkpoint_tensor_keys(checkpoint: str | os.PathLike) -> Optional[set[str]]
                 index = json.load(f)
             weight_map = index.get("weight_map", index)
             if isinstance(weight_map, dict):
+                if verify_shards:
+                    keys = set()
+                    for shard in set(weight_map.values()):
+                        shard_keys = _checkpoint_tensor_keys(
+                            os.path.join(os.path.dirname(checkpoint), shard),
+                        )
+                        if shard_keys is None:
+                            return None
+                        keys.update(shard_keys)
+                    return keys
                 return set(weight_map)
             return None
 
@@ -1970,12 +1982,34 @@ def _checkpoint_tensor_keys(checkpoint: str | os.PathLike) -> Optional[set[str]]
     if len(index_files) != 1:
         return None
 
-    with open(os.path.join(checkpoint, index_files[0]), encoding="utf-8") as f:
-        index = json.load(f)
-    weight_map = index.get("weight_map", index)
-    if isinstance(weight_map, dict):
-        return set(weight_map)
-    return None
+    return _checkpoint_tensor_keys(
+        os.path.join(checkpoint, index_files[0]), verify_shards=verify_shards,
+    )
+
+
+def validate_checkpoint_qweights(
+    model: nn.Module, checkpoint: str | os.PathLike, format: FORMAT,
+) -> None:
+    if format not in (FORMAT.GPTQ, FORMAT.GPTQ_V2):
+        return
+
+    checkpoint_keys = _checkpoint_tensor_keys(checkpoint, verify_shards=True)
+    if checkpoint_keys is None:
+        return
+
+    # A shared quantized module can be saved under any one of its aliases.
+    module_keys = collections.defaultdict(set)
+    for name, module in model.named_modules(remove_duplicate=False):
+        if isinstance(module, GPTQQuantLinear):
+            module_keys[id(module)].add(f"{name}.qweight" if name else "qweight")
+    missing = sorted(
+        min(keys) for keys in module_keys.values() if not keys & checkpoint_keys
+    )
+    if missing:
+        raise ValueError(
+            f"Missing required quantized weights in checkpoint {os.fspath(checkpoint)!r}: "
+            + ", ".join(missing)
+        )
 
 
 def _tie_weights_after_checkpoint_load(model, checkpoint: str | os.PathLike | None) -> None:

--- a/tests/test_required_qweight.py
+++ b/tests/test_required_qweight.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import accelerate
+import pytest
+import torch
+from safetensors.torch import save_file
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from transformers import LlamaConfig, LlamaForCausalLM, PreTrainedTokenizerFast
+
+from gptqmodel import BACKEND, GPTQModel, QuantizeConfig
+from gptqmodel.nn_modules.qlinear.torch import TorchLinear
+from gptqmodel.quantization import FORMAT
+from gptqmodel.utils.model import (
+    _checkpoint_tensor_keys,
+    convert_gptq_v2_to_v1_format,
+    validate_checkpoint_qweights,
+)
+
+
+QWEIGHT_KEY = "model.layers.0.self_attn.q_proj.qweight"
+
+
+def _save_checkpoint(path, format, sharded, missing=None, tied=False, stale_index=False):
+    config = LlamaConfig(
+        vocab_size=32,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=32,
+        tie_word_embeddings=tied,
+        bos_token_id=1,
+        eos_token_id=2,
+    )
+    qcfg = QuantizeConfig(
+        bits=4,
+        group_size=32,
+        desc_act=False,
+        sym=True,
+        format=format,
+    )
+    with torch.random.fork_rng(devices=[]):
+        torch.manual_seed(0)
+        model = LlamaForCausalLM(config).half()
+    for name, linear in list(model.named_modules()):
+        if not isinstance(linear, torch.nn.Linear) or name == "lm_head":
+            continue
+        quant = TorchLinear(
+            bits=4,
+            group_size=32,
+            desc_act=False,
+            sym=True,
+            in_features=linear.in_features,
+            out_features=linear.out_features,
+            bias=False,
+            format=FORMAT.GPTQ_V2,
+        )
+        scales = torch.full((linear.out_features, linear.in_features // 32), 0.01)
+        quant.pack_original(linear, scales, torch.full_like(scales, 8))
+        model.set_submodule(name, quant)
+    if format == FORMAT.GPTQ:
+        convert_gptq_v2_to_v1_format(model, qcfg, TorchLinear)
+    state = {name: value.clone() for name, value in model.state_dict().items()}
+    keys = list(state)
+    if missing is not None:
+        del state[missing]
+    if sharded:
+        weight_map = {
+            name: f"model-{1 + index % 2:05d}-of-00002.safetensors"
+            for index, name in enumerate(keys if stale_index else state)
+        }
+        for shard in set(weight_map.values()):
+            save_file(
+                {name: value for name, value in state.items() if weight_map[name] == shard},
+                str(path / shard),
+                metadata={"format": "pt"},
+            )
+        (path / "model.safetensors.index.json").write_text(
+            json.dumps({"weight_map": weight_map}),
+            encoding="utf-8",
+        )
+    else:
+        save_file(state, str(path / "model.safetensors"), metadata={"format": "pt"})
+    config.architectures = ["LlamaForCausalLM"]
+    config.save_pretrained(path)
+    qcfg.save_pretrained(str(path))
+    tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=Tokenizer(WordLevel({"[UNK]": 0, "[BOS]": 1, "[EOS]": 2}, unk_token="[UNK]")),
+        unk_token="[UNK]",
+        bos_token="[BOS]",
+        eos_token="[EOS]",
+    )
+    tokenizer.save_pretrained(path)
+    return state
+
+
+def _load_checkpoint(path):
+    return GPTQModel.load(
+        str(path),
+        backend=BACKEND.GPTQ_TORCH,
+        device="cpu",
+        dtype=torch.float16,
+        attn_implementation="eager",
+        local_files_only=True,
+    ).model
+
+
+@pytest.mark.parametrize("format", [FORMAT.GPTQ, FORMAT.GPTQ_V2])
+@pytest.mark.parametrize("sharded", [False, True])
+@pytest.mark.parametrize("missing", [None, "lm_head.weight", QWEIGHT_KEY.replace("qweight", "g_idx")])
+def test_complete_or_derived_checkpoint_weights_load(tmp_path, format, sharded, missing):
+    state = _save_checkpoint(tmp_path, format, sharded, missing, tied=missing == "lm_head.weight")
+
+    model = _load_checkpoint(tmp_path)
+
+    torch.testing.assert_close(model.state_dict()[QWEIGHT_KEY], state[QWEIGHT_KEY])
+    if missing == "lm_head.weight":
+        assert model.lm_head.weight is model.model.embed_tokens.weight
+    with torch.inference_mode():
+        logits = model(input_ids=torch.tensor([[1, 3, 4]]), use_cache=False).logits
+    assert torch.isfinite(logits).all()
+
+
+@pytest.mark.parametrize("format", [FORMAT.GPTQ, FORMAT.GPTQ_V2])
+@pytest.mark.parametrize("sharded,stale_index", [(False, False), (True, False), (True, True)])
+def test_missing_qweight_is_rejected(tmp_path, format, sharded, stale_index):
+    _save_checkpoint(tmp_path, format, sharded, QWEIGHT_KEY, stale_index=stale_index)
+
+    with pytest.raises(ValueError, match="Missing required quantized weights") as exc:
+        _load_checkpoint(tmp_path)
+
+    assert QWEIGHT_KEY in str(exc.value)
+
+
+def test_shared_quantized_module_loads_through_saved_alias(tmp_path):
+    model = torch.nn.Module()
+    model.first = TorchLinear(
+        bits=4,
+        group_size=32,
+        sym=True,
+        desc_act=False,
+        in_features=32,
+        out_features=32,
+        bias=False,
+        format=FORMAT.GPTQ_V2,
+    )
+    model.second = model.first
+    state = {name: torch.ones_like(value) for name, value in model.state_dict().items() if name.startswith("second.")}
+    checkpoint = tmp_path / "model.safetensors"
+    save_file(state, str(checkpoint), metadata={"format": "pt"})
+
+    validate_checkpoint_qweights(model, checkpoint, FORMAT.GPTQ_V2)
+    accelerate.load_checkpoint_in_model(model, str(checkpoint), device_map={"": "cpu"})
+
+    assert model.first is model.second
+    torch.testing.assert_close(model.first.qweight, state["second.qweight"])
+
+
+@pytest.mark.parametrize("format", [value for value in FORMAT if value not in (FORMAT.GPTQ, FORMAT.GPTQ_V2)])
+def test_other_storage_formats_do_not_require_gptq_qweights(tmp_path, format):
+    model = TorchLinear(
+        bits=4,
+        group_size=32,
+        sym=True,
+        desc_act=False,
+        in_features=32,
+        out_features=32,
+        bias=False,
+        format=FORMAT.GPTQ_V2,
+    )
+
+    validate_checkpoint_qweights(model, tmp_path / "not-a-gptq-checkpoint", format)
+
+
+@pytest.mark.parametrize("directory", [False, True])
+def test_shard_verification_preserves_default_index_key_semantics(tmp_path, directory):
+    shard = "model-00001-of-00001.safetensors"
+    save_file({"present": torch.ones(1)}, str(tmp_path / shard))
+    index = tmp_path / "model.safetensors.index.json"
+    index.write_text(json.dumps({"weight_map": {"missing": shard}}), encoding="utf-8")
+    checkpoint = tmp_path if directory else index
+
+    assert _checkpoint_tensor_keys(checkpoint) == {"missing"}
+    assert _checkpoint_tensor_keys(checkpoint, verify_shards=True) == {"present"}
+
+
+def test_checkpoint_metadata_does_not_deserialize_pickle_weights(tmp_path):
+    checkpoint = tmp_path / "pytorch_model.bin"
+    checkpoint.write_bytes(b"not a pickle checkpoint")
+
+    assert _checkpoint_tensor_keys(checkpoint, verify_shards=True) is None


### PR DESCRIPTION
## Summary

A GPTQ/GPTQ_V2 checkpoint missing a selected quantized layer's `qweight` can load and run with zero-initialized packed weights. Validate required storage before loading single-file and entirely safetensors-sharded checkpoints.

## What Changed

- Read actual shard headers so a stale index cannot conceal missing qweight in these inventories.
- Preserve tied dense heads, shared quantized module aliases, derived g_idx omissions and other stored formats; retain existing tying-helper defaults.

## Tests

- [x] I added a new simple/fast unit test for this change.
- [x] I ran the new targeted test locally.
- [x] I ran other directly relevant local tests.

```bash
PYTHONPATH=. python -m pytest -p no:cacheprovider -q \
  tests/test_required_qweight.py tests/test_loader.py \
  tests/test_embedding_save_lifecycle.py
```

43 passed. Real local Llama GPTQ/GPTQ_V2 load-and-forward controls pass; six missing-storage cases expose the unpatched defect. Scoped Ruff and whitespace checks pass.

## Review Requirements

- [x] I personally reviewed every file in this diff.
- [x] I checked that the code matches existing project structure, APIs, and conventions.
- [x] I avoided unnecessary monkeypatching and used normal extension points where possible.

## Notes

Only qweight presence is checked. Opaque or mixed inventories containing `.bin` shards retain existing behavior without this check; payloads are not deserialized for validation. This is not blanket strict state-dict loading. GPU backend conversions and the full suite were not exercised.

