### PR TITLE
Defer InternVL torchvision imports until image preprocessing

### DIFF
--- a/gptqmodel/models/definitions/internvl_chat.py
+++ b/gptqmodel/models/definitions/internvl_chat.py
@@ -9,9 +9,7 @@ from copy import deepcopy
 from typing import Any, Dict, Optional
 
 import torch
-import torchvision.transforms as T
 from PIL import Image
-from torchvision.transforms.functional import InterpolationMode
 from transformers import AutoModel, GenerationConfig
 
 from ...utils.calibration import batched_conversations
@@ -78,6 +76,17 @@ class InternVLChatQModel(BaseQModel):
 
     @staticmethod
     def _build_transform(input_size: int):
+        try:
+            import torchvision.transforms as T
+            from torchvision.transforms.functional import InterpolationMode
+        except ModuleNotFoundError as exc:
+            if exc.name != "torchvision":
+                raise
+            raise ImportError(
+                "InternVL image preprocessing requires torchvision. Install a "
+                "torchvision version compatible with your PyTorch installation."
+            ) from exc
+
         return T.Compose(
             [
                 T.Lambda(lambda img: img.convert("RGB") if img.mode != "RGB" else img),

--- a/tests/test_internvl_optional_vision.py
+++ b/tests/test_internvl_optional_vision.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2026 ModelCloud.ai
+# SPDX-License-Identifier: Apache-2.0
+
+import builtins
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import torch
+from PIL import Image
+
+
+def test_package_import_without_torchvision() -> None:
+    script = textwrap.dedent("""
+        import importlib.util
+        from importlib.machinery import PathFinder
+        from pathlib import Path
+
+        original_find_spec = PathFinder.find_spec
+
+        def find_spec_without_torchvision(fullname, *args, **kwargs):
+            if fullname == "torchvision" or fullname.startswith("torchvision."):
+                return None
+            return original_find_spec(fullname, *args, **kwargs)
+
+        PathFinder.find_spec = staticmethod(find_spec_without_torchvision)
+        assert importlib.util.find_spec("torchvision") is None
+
+        import gptqmodel
+        from gptqmodel.models.definitions.internvl_chat import InternVLChatQModel
+
+        assert Path(gptqmodel.__file__).resolve().parent == Path.cwd() / "gptqmodel"
+        try:
+            InternVLChatQModel._build_transform(8)
+        except ImportError as exc:
+            assert "InternVL image preprocessing requires torchvision" in str(exc)
+            assert isinstance(exc.__cause__, ModuleNotFoundError)
+            assert exc.__cause__.name == "torchvision"
+        else:
+            raise AssertionError("Image preprocessing should require torchvision")
+    """)
+    env = os.environ.copy()
+    env.update(CUDA_VISIBLE_DEVICES="", HIP_VISIBLE_DEVICES="")
+    command = [sys.executable]
+    if sys.flags.no_site:
+        command.append("-S")
+    result = subprocess.run(
+        [*command, "-c", script],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("mode", ["L", "RGB", "RGBA"])
+@pytest.mark.parametrize("input_size", [1, 8])
+def test_image_transform_preserves_preprocessing(mode: str, input_size: int) -> None:
+    transforms = pytest.importorskip("torchvision.transforms")
+    from torchvision.transforms.functional import InterpolationMode
+
+    from gptqmodel.models.definitions.internvl_chat import (
+        IMAGENET_MEAN,
+        IMAGENET_STD,
+        InternVLChatQModel,
+    )
+
+    channels = len(mode)
+    pixels = bytes(index % 256 for index in range(7 * 5 * channels))
+    image = Image.frombytes(mode, (7, 5), pixels)
+    expected = transforms.Compose(
+        [
+            transforms.Lambda(lambda img: img.convert("RGB") if img.mode != "RGB" else img),
+            transforms.Resize((input_size, input_size), interpolation=InterpolationMode.BICUBIC),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=IMAGENET_MEAN, std=IMAGENET_STD),
+        ]
+    )(image)
+
+    actual = InternVLChatQModel._build_transform(input_size)(image)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert actual.shape == (3, input_size, input_size)
+
+
+def test_image_transform_preserves_unrelated_import_errors(monkeypatch) -> None:
+    from gptqmodel.models.definitions.internvl_chat import InternVLChatQModel
+
+    original_import = builtins.__import__
+    missing_dependency = ModuleNotFoundError("Missing dependency", name="numpy")
+
+    def fail_transitive_import(name, *args, **kwargs):
+        if name == "torchvision.transforms":
+            raise missing_dependency
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_transitive_import)
+
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        InternVLChatQModel._build_transform(8)
+
+    assert exc_info.value is missing_dependency


### PR DESCRIPTION
## Summary

Importing GPTQModel currently requires torchvision through InternVL even for text-only use, although the base dependency graph does not require it. Import the vision helpers when constructing the image transform.

## What Changed

- Move the two torchvision imports into the existing transform builder without changing preprocessing order.
- Report a missing top-level torchvision dependency at image preprocessing and preserve other import errors.

## Tests

- [x] I added a new simple/fast unit test for this change.
- [x] I ran the new targeted test locally.
- [x] I ran other directly relevant local tests.

```bash
PYTHONPATH=. python -m pytest -p no:cacheprovider -q \
  tests/test_internvl_optional_vision.py
```

With torchvision: 8 passed. Without torchvision: 2 passed, 6 transform-only skips. Checks cover fresh-process package import, deferred errors, and exact RGB/grayscale/RGBA transform parity. Scoped Ruff and whitespace checks pass.

## Review Requirements

- [x] I personally reviewed every file in this diff.
- [x] I checked that the code matches existing project structure, APIs, and conventions.
- [x] I avoided unnecessary monkeypatching and used normal extension points where possible.

## Notes

No mandatory dependency or other model-import behavior is changed. Genuine dependency-presence/absence controls also passed. Full model, GPU and full-suite qualification were not run.

