### PR TITLE
fix(looper): import Sequence used in paroquant_processor annotations

### DIFF
--- a/gptqmodel/looper/paroquant_processor.py
+++ b/gptqmodel/looper/paroquant_processor.py
@@ -25,7 +25,7 @@ import threading
 import time
 from contextlib import nullcontext
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Set, Tuple
 
 import torch
 import torch.nn.functional as F


### PR DESCRIPTION
### Problem

`gptqmodel/looper/paroquant_processor.py` uses `Sequence` in a type
annotation on `_layer_train_shard_batches`:

```python
def _layer_train_shard_batches(
    self,
    layer: torch.nn.Module,
    *,
    param_groups: Sequence[dict[str, object]],
    ...
```

but `Sequence` is not imported. The `from typing import ...` line only
brings in `Any, Callable, Dict, Iterator, List, Optional, Set, Tuple`.

Because the module has `from __future__ import annotations`, the
annotation is stored as a string and the missing name stays latent at
normal runtime — but it is a genuine undefined name: `typing.get_type_hints()`
on this method, and strict static type checkers, both fail on it.

### Fix

Add `Sequence` to the existing `typing` import. One line, no behavior
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
